### PR TITLE
fix: change msg values to not span multiple lines

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -429,8 +429,7 @@ SecRule TX:sampling_rnd100 "!@lt %{tx.sampling_percentage}" \
     pass,\
     log,\
     noauditlog,\
-    msg:'Sampling: Disable the rule engine based on sampling_percentage \
-%{TX.sampling_percentage} and random number %{TX.sampling_rnd100}',\
+    msg:'Sampling: Disable the rule engine based on sampling_percentage %{TX.sampling_percentage} and random number %{TX.sampling_rnd100}',\
     ctl:ruleEngine=Off,\
     ver:'OWASP_CRS/3.2.0'"
 


### PR DESCRIPTION
For `SecRule` `msg`, the value is some format string.  It may be
tempting to wrap it across multiple lines, but that does not seem to be
possible as trailing backslashes don't escape newlines.  For instance,
having

```
    msg:'Blah blah
blah',\
```

causes the message to appear in logs as

```
Blah blah\x0ablah
```

and having

```
    msg:'Blah blah\
blah',\
```

causes the message to appear in logs as

```
Blah blah\\x0ablah
```

Fix all instances of a `msg` value wrapping across newlines: just one in
`REQUEST-901-INITIALIZATION.conf`.