### PR TITLE
Prevent bypass of rule 921130

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -85,7 +85,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:\bhttp\/(?:0\.9|1\.[01])|<(?:html|meta)\b)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:\bhttp\/\d|<(?:html|meta)\b)" \
     "id:921130,\
     phase:2,\
     block,\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -85,7 +85,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:\bhttp\/\d|<(?:html|meta)\b)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:\bhttp/\d|<(?:html|meta)\b)" \
     "id:921130,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921130.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921130.yaml
@@ -1,6 +1,6 @@
 ---
   meta:
-    author: csanders-git
+    author: "csanders-git, Franziska Bühler"
     description: None
     enabled: true
     name: 921130.yaml
@@ -45,5 +45,39 @@
           method: GET
           port: 80
           uri: "/"
+        output:
+          log_contains: id "921130"
+  -
+    test_title: 921130-3
+    desc: HTTP Request Smuggling with not supported HTTP versions such as HTTP/1.2
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Accept: "*/*"
+            User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)
+          method: GET
+          port: 80
+          uri: /?arg1=GET%20http%3A%2F%2Fwww.foo.bar%20HTTP%2F1.2
+        output:
+          log_contains: id "921130"
+  -
+    test_title: 921130-4
+    desc: HTTP Request Smuggling with not supported HTTP versions such as HTTP/3
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Accept: "*/*"
+            User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)
+          method: GET
+          port: 80
+          uri: /?arg1=GET%20http%3A%2F%2Fwww.foo.bar%20HTTP%2F3.2
         output:
           log_contains: id "921130"


### PR DESCRIPTION
Security researcher Amit Klein found two CRS bypasses. 
The first one is a possible bypass in rule 921130 with not supported HTTP versions, if the server accepts any protocol versions.
This PR enhances rule 921130 so that it also detects not supported HTTP version such as HTTP/3 for example.