### PR TITLE
Prevent bypass of rule 921110

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -23,14 +23,14 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:921012,phase:2,pass,nolog,skipAf
 # -=[ HTTP Request Smuggling ]=-
 #
 # [ Rule Logic ]
-# This rule looks for a CR/LF character in combination with a HTTP / WEBDAV method name.
+# This rule looks for a HTTP / WEBDAV method name in combination with the word http/\d or a CR/LF character.
 # This would point to an attempt to inject a 2nd request into the request, thus bypassing
 # tests carried out on the primary request.
 #
 # [ References ]
 # http://projects.webappsec.org/HTTP-Request-Smuggling
 #
-SecRule ARGS_NAMES|ARGS|XML:/* "@rx [\n\r]+(?:get|post|head|options|connect|put|delete|trace|track|patch|propfind|propatch|mkcol|copy|move|lock|unlock)\s+[^\s]+(?:\s+http|[\r\n])" \
+SecRule ARGS_NAMES|ARGS|REQUEST_BODY|XML:/* "@rx (?:get|post|head|options|connect|put|delete|trace|track|patch|propfind|propatch|mkcol|copy|move|lock|unlock)\s+[^\s]+(?:\s+http\/\d|[\r\n])" \
     "id:921110,\
     phase:2,\
     block,\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -30,7 +30,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:921012,phase:2,pass,nolog,skipAf
 # [ References ]
 # http://projects.webappsec.org/HTTP-Request-Smuggling
 #
-SecRule ARGS_NAMES|ARGS|REQUEST_BODY|XML:/* "@rx (?:get|post|head|options|connect|put|delete|trace|track|patch|propfind|propatch|mkcol|copy|move|lock|unlock)\s+\/[^\s]+(?:\s+http\/\d|[\r\n])" \
+SecRule ARGS_NAMES|ARGS|REQUEST_BODY|XML:/* "@rx (?:get|post|head|options|connect|put|delete|trace|track|patch|propfind|propatch|mkcol|copy|move|lock|unlock)\s+[^\s]+(?:\s+http\/\d|[\r\n])" \
     "id:921110,\
     phase:2,\
     block,\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -30,7 +30,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:921012,phase:2,pass,nolog,skipAf
 # [ References ]
 # http://projects.webappsec.org/HTTP-Request-Smuggling
 #
-SecRule ARGS_NAMES|ARGS|REQUEST_BODY|XML:/* "@rx (?:get|post|head|options|connect|put|delete|trace|track|patch|propfind|propatch|mkcol|copy|move|lock|unlock)\s+[^\s]+(?:\s+http\/\d|[\r\n])" \
+SecRule ARGS_NAMES|ARGS|REQUEST_BODY|XML:/* "@rx (?:get|post|head|options|connect|put|delete|trace|track|patch|propfind|propatch|mkcol|copy|move|lock|unlock)\s+\/[^\s]+(?:\s+http\/\d|[\r\n])" \
     "id:921110,\
     phase:2,\
     block,\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -30,7 +30,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:921012,phase:2,pass,nolog,skipAf
 # [ References ]
 # http://projects.webappsec.org/HTTP-Request-Smuggling
 #
-SecRule ARGS_NAMES|ARGS|REQUEST_BODY|XML:/* "@rx (?:get|post|head|options|connect|put|delete|trace|track|patch|propfind|propatch|mkcol|copy|move|lock|unlock)\s+[^\s]+(?:\s+http\/\d|[\r\n])" \
+SecRule ARGS_NAMES|ARGS|REQUEST_BODY|XML:/* "@rx (?:get|post|head|options|connect|put|delete|trace|track|patch|propfind|propatch|mkcol|copy|move|lock|unlock)\s+(?:\/|\w)[^\s]*(?:\s+http\/\d|[\r\n])" \
     "id:921110,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921110.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921110.yaml
@@ -1,6 +1,6 @@
 ---
   meta:
-    author: "Christian S.J. Peron"
+    author: "Christian S.J. Peron, Franziska Bühler"
     description: None
     enabled: true
     name: 921110.yaml
@@ -90,3 +90,58 @@
           version: HTTP/1.0
         output:
           no_log_contains: id "921110"
+  -
+    test_title: 921110-6
+    desc: HTTP Request Smuggling bypass with Content-Type text/plain
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Accept: "*/*"
+            User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)
+            Content-Type: text/plain
+            Content-Length: 36
+          method: POST
+          port: 80
+          uri: /
+          data: "barGET /a.html HTTP/1.1\r\nSomething: GET /b.html HTTP/1.1\r\nHost: foo.com\r\nUser-Agent: foo\r\nAccept: */*"
+        output:
+          log_contains: id "921110"
+  -
+    test_title: 921110-7
+    desc: HTTP Request Smuggling with not supported HTTP versions such as HTTP/1.2
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Accept: "*/*"
+            User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)
+          method: GET
+          port: 80
+          uri: /?arg1=GET%20http%3A%2F%2Fwww.foo.bar%20HTTP%2F1.2
+        output:
+          log_contains: id "921110"
+  -
+    test_title: 921110-8
+    desc: HTTP Request Smuggling with not supported HTTP versions such as HTTP/3
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Accept: "*/*"
+            User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)
+          method: GET
+          port: 80
+          uri: /?arg1=GET%20http%3A%2F%2Fwww.foo.bar%20HTTP%2F3.2
+        output:
+          log_contains: id "921110"
+

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921110.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921110.yaml
@@ -144,4 +144,3 @@
           uri: /?arg1=GET%20http%3A%2F%2Fwww.foo.bar%20HTTP%2F3.2
         output:
           log_contains: id "921110"
-

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921110.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921110.yaml
@@ -107,7 +107,7 @@
           method: POST
           port: 80
           uri: /
-          data: "barGET /a.html HTTP/1.1\r\nSomething: GET /b.html HTTP/1.1\r\nHost: foo.com\r\nUser-Agent: foo\r\nAccept: */*"
+          data: "barGET /a.html HTTP/1.1\r\nSomething: GET /b.html HTTP/1.1\r\nHost: foo.com\r\nUser-Agent: foo\r\nAccept: */*\r\n\r\n"
         output:
           log_contains: id "921110"
   -


### PR DESCRIPTION
Security researcher Amit Klein found two CRS bypasses. 
The second one is a possible bypass in rule in 921110.
This PR enhances rule 921110:
* `REQUEST_BODY` is also checked, not only `ARGS_NAMES|ARGS|XML:/*`
* The leading CR/LF character is removed
* The regex after `http` is enhanced with `\/\d`

The first two changes may lead to new false positives.
The third change is made to reduce these FP again.