### PR TITLE
Cache-Control: a strict whitelist of possible values

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1132,6 +1132,46 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
     SecRule TX:/^header_name_/ "@within %{tx.restricted_headers}" \
         "setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
+#
+# Cache-Control Request Header whitelist
+#
+# -=[ Rule Logic ]=-
+# This rule aims to strictly whitelist the Cache-Control request header
+# values and to blocks all violations. This should be useful to intercept
+# "bad bot" and tools that impersonate a real browser but with wrong request
+# header setup.
+#
+# Standard Cache-Control directives that can be used by the client:
+#   - max-age=<seconds>
+#   - max-stale[=<seconds>]
+#   - min-fresh=<seconds>
+#   - no-cache
+#   - no-store
+#   - no-transform
+#   - only-if-cached
+#
+# References:
+# - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
+# - https://regex101.com/r/CZ0Hxu/1
+#
+SecRule &REQUEST_HEADERS:Cache-Control "@gt 0" "id:920510,\
+    phase:1,\
+    block,\
+    t:none,\
+    msg:'Invalid Cache-Control request header',\
+    logdata:'Invalid Cache-Control value in request found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    tag:'header-whitelist',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/3.2.0',\
+    severity:'CRITICAL',\
+    chain"
+    SecRule REQUEST_HEADERS:Cache-Control "!@rx ^(?:max-age=[0-9]+|min-fresh=[0-9]+|no-cache|no-store|no-transform|only-if-cached|max-stale(?:[=][0-9]+|))$" \
+        "setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:920013,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:920014,phase:2,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920510.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920510.yaml
@@ -1,0 +1,37 @@
+---
+  meta:
+    author: "Andrea Menin"
+    enabled: true
+    name: "920510.yaml"
+    description: "Cache-Control directives whitelist"
+  tests:
+    - test_title: 920510-1
+      desc: "block request with a response cache-control directive in request"
+      stages:
+        - stage:
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              method: "GET"
+              uri: "/"
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Cache-Control: "private"
+            output:
+              log_contains: "id \"920510\""
+    - test_title: 920510-2
+      desc: "block request with an invalid cache-control directive in request"
+      stages:
+        - stage:
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              method: "GET"
+              uri: "/"
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Cache-Control: "foo=bar"
+            output:
+              log_contains: "id \"920510\""


### PR DESCRIPTION
TL;DR some "bad bot" tries to mimic a real browser but with wrong cache-control request header directive and it should be easily blocked with a cache-control directive whitelist rule.

Recently I received two DoS attacks from a widely distributed botnet (more than 5000 unique IPs that made more than 12 million HTTP requests in a few hours):

![image](https://user-images.githubusercontent.com/4454961/82818046-62ede280-9e9e-11ea-8db4-9a62c05c286c.png)

After the first attack (the green one on the screenshot) I've looked at the requests and I saw that all requests mimic a real browser but come with a wrong Cache-Control request header (`cache-control: private`). The RFC 7234 section 5.2.1 and 5.2.2 (https://tools.ietf.org/html/rfc7234#section-5.2.1) says that "private" is a cache-control directive that a server could send in an HTTP response and not in a request. So I've written a rule to whitelist all possible request's cache-control directives and I was able to intercept all botnet activities (the yellow area in the screenshot).

I've created the rule 920510 (a proposal) for the REQUEST-920-PROTOCOL-ENFORCEMENT.conf rule set that tries to strictly whitelist all possible directives of the cache-control request header.