### PR TITLE
932200: RCE bypass techniques

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -613,6 +613,45 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
+#
+# -=[ Rule 932200 ]=-
+#
+# Block RCE Bypass using different techniques:
+# - uninitialized variables (https://www.secjuice.com/web-application-firewall-waf-evasion/)
+# - string concatenations (https://medium.com/secjuice/web-application-firewall-waf-evasion-techniques-2-125995f3e7b0)
+# - globbing patterns (https://medium.com/secjuice/waf-evasion-techniques-718026d693d8)
+#
+# Examples:
+# - foo;cat$u+/etc$u/passwd
+# - bar;cd+/etc;/bin$u/ca*+passwd
+# - foo;ca\t+/et\c/pa\s\swd
+# - foo;c'at'+/etc/pa's'swd
+#
+# Regex notes: https://regex101.com/r/JgZFRi/7
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx ([*?`\\'][^/\n]+/|\$[({\[#a-zA-Z0-9]|/[^/]+?[*?`\\'])" \
+    "id:932200,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:lowercase,t:urlDecodeUni,\
+    msg:'RCE Bypass Technique',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
+    tag:'OWASP_CRS',\
+    tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
+    tag:'WASCTC/WASC-31',\
+    tag:'OWASP_TOP_10/A1',\
+    tag:'PCI/6.5.2',\
+    ver:'OWASP_CRS/3.2.0',\
+    severity:'CRITICAL',\
+    setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:932013,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:932014,phase:2,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 #


### PR DESCRIPTION
This rule is a more stable and less prone to FPs version of the #1602 
unlike the previous version, this regex tries to match the following techniques:
- uninitialized variables (https://www.secjuice.com/web-application-firewall-waf-evasion/)
- string concatenations (https://medium.com/secjuice/web-application-firewall-waf-evasion-techniques-2-125995f3e7b0)
- globbing patterns (https://medium.com/secjuice/waf-evasion-techniques-718026d693d8)

If you can review the regex, I'll test it on my production