### PR TITLE
Suppress rule 200002 when editing calendar events in Nextcloud

### DIFF
--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -304,6 +304,7 @@ SecRule REQUEST_METHOD "@streq PUT" \
         "t:none,\
         ctl:ruleRemoveById=200002"
 
+
 # [ Calendar ]
 #
 # Allow the data type 'text/calendar'
@@ -316,6 +317,18 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/calendars/" \
     nolog,\
     ver:'OWASP_CRS/3.3.0',\
     setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/calendar|'"
+
+# Allow modifying calendar events via the web interface
+SecRule REQUEST_METHOD "@streq PUT" \
+    "id:9003331,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule REQUEST_FILENAME "@contains /remote.php/dav/calendars/" \
+        "t:none,\
+        ctl:ruleRemoveById=200002"
 
 
 # [ Notes ]


### PR DESCRIPTION
## Issue

Modifying calendar events triggers an XML parsing error (rule 200002 in `modsecurity.conf`) which can be whitelisted in `REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf`.

This is essentially the same as [this issue](https://github.com/SpiderLabs/owasp-modsecurity-crs/pull/1742), but for calendar events.

## Reproduction

* Click on some calendar event
* Click the "More button" in the dialog
    * The event details open to the right of the window
* Modify event details, e.g. location & categories
* Click "Update" at the bottom

## Fix

This PR disables 200002 with `PUT` requests into `calendars`.