### PR TITLE
Decrease processing time of rules, fixes #1665 #1708

### DIFF
--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -96,7 +96,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
 # -=[ XSS Filters - Category 2 ]=-
 # XSS vectors making use of event handlers like onerror, onload etc, e.g., <body onload="alert(1)">
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\"'`;\/0-9=\x0B\x09\x0C\x3B\x2C\x28\x3B]+on[a-zA-Z]+[\s\x0B\x09\x0C\x3B\x2C\x28\x3B]*?=" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\"'`;\/0-9=\x0B\x09\x0C\x3B\x2C\x28\x3B]on[a-zA-Z]+[\s\x0B\x09\x0C\x3B\x2C\x28\x3B]*?=" \
     "id:941120,\
     phase:2,\
     block,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -762,7 +762,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # to the Regexp::Assemble output:
 #   (?i:ASSEMBLE_OUTPUT)
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:(?:n(?:and|ot)|(?:x?x)?or|between|\|\||like|and|div|&&)[\s(]+\w+[\s)]*?[!=+]+[\s\d]*?[\"'`=()]|\/\w+;?\s+(?:between|having|select|like|x?or|and|div)\W|\d+\s*?(?:between|like|x?or|and|div)\s*?\d+\s*?[\-+]|--\s*?(?:(?:insert|update)\s*?\w{2,}|alter|drop)|#\s*?(?:(?:insert|update)\s*?\w{2,}|alter|drop)|;\s*?(?:(?:insert|update)\s*?\w{2,}|alter|drop)|\@.+=\s*?\(\s*?select|\d\s+group\s+by.+\(|[^\w]SET\s*?\@\w+))" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:(?:n(?:and|ot)|(?:x?x)?or|between|\|\||like|and|div|&&)[\s(]+\w+[\s)]*?[!=+]+[\s\d]*?[\"'`=()]|\d(?:\s*?(?:between|like|x?or|and|div)\s*?\d+\s*?[\-+]|\s+group\s+by.+\()|\/\w+;?\s+(?:between|having|select|like|x?or|and|div)\W|--\s*?(?:(?:insert|update)\s*?\w{2,}|alter|drop)|#\s*?(?:(?:insert|update)\s*?\w{2,}|alter|drop)|;\s*?(?:(?:insert|update)\s*?\w{2,}|alter|drop)|\@.+=\s*?\(\s*?select|[^\w]SET\s*?\@\w+))" \
     "id:942210,\
     phase:2,\
     block,\
@@ -794,7 +794,8 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # to the Regexp::Assemble output:
 #    ASSEMBLE_OUTPUT | s/^(?:/(?i:/
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:[\"'`]\s*?(?:(?:n(?:and|ot)|(?:x?x)?or|between|\|\||and|div|&&)\s+[\s\w]+=\s*?\w+\s*?having\s+|like(?:\s+[\s\w]+=\s*?\w+\s*?having\s+|\W*?[\"'`\d])|[^?\w\s=.,;)(]++\s*?[(@\"'`]*?\s*?\w+\W+\w|\*\s*?\w+\W+[\"'`])|(?:union\s*?(?:distinct|[(!@]*?|all)?\s*?[([]*?\s*?select|select\s+?[\[\]()\s\w\.,\"'`-]+from)\s+|\w+\s+like\s+[\"'`]|find_in_set\s*?\(|like\s*?[\"'`]%)" \
+# original:
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:[\"'`]\s*?(?:(?:n(?:and|ot)|(?:x?x)?or|between|\|\||and|div|&&)\s+[\s\w]+=\s*?\w+\s*?having\s+|like(?:\s+[\s\w]+=\s*?\w+\s*?having\s+|\W*?[\"'`\d])|[^?\w\s=.,;)(]++\s*?[(@\"'`]*?\s*?\w+\W+\w|\*\s*?\w+\W+[\"'`])|(?:union\s*?(?:distinct|[(!@]*?|all)?\s*?[([]*?\s*?select|select\s+?[\[\]()\s\w\.,\"'`-]+from)\s+|\w\s+like\s+[\"'`]|find_in_set\s*?\(|like\s*?[\"'`]%)" \
     "id:942260,\
     phase:2,\
     block,\

--- a/util/regexp-assemble/regexp-942210.data
+++ b/util/regexp-assemble/regexp-942210.data
@@ -1,10 +1,10 @@
 @.+=\s*?\(\s*?select
-\d+\s*?or\s*?\d+\s*?[\-+]
-\d+\s*?xor\s*?\d+\s*?[\-+]
-\d+\s*?div\s*?\d+\s*?[\-+]
-\d+\s*?like\s*?\d+\s*?[\-+]
-\d+\s*?between\s*?\d+\s*?[\-+]
-\d+\s*?and\s*?\d+\s*?[\-+]
+\d\s*?or\s*?\d+\s*?[\-+]
+\d\s*?xor\s*?\d+\s*?[\-+]
+\d\s*?div\s*?\d+\s*?[\-+]
+\d\s*?like\s*?\d+\s*?[\-+]
+\d\s*?between\s*?\d+\s*?[\-+]
+\d\s*?and\s*?\d+\s*?[\-+]
 \/\w+;?\s+having\W
 \/\w+;?\s+and\W
 \/\w+;?\s+or\W

--- a/util/regexp-assemble/regexp-942260.data
+++ b/util/regexp-assemble/regexp-942260.data
@@ -2,7 +2,7 @@ union\s*?\s*?[([]*?\s*?select\s+
 union\s*?all\s*?[([]*?\s*?select\s+
 union\s*?distinct\s*?[([]*?\s*?select\s+
 union\s*?[(!@]*?\s*?[([]*?\s*?select\s+
-\w+\s+like\s+[\"'`]
+\w\s+like\s+[\"'`]
 like\s*?[\"'`]\%
 [\"'`]\s*?like\W*?[\"'`\d]
 [\"'`]\s*?and\s+[\s\w]+=\s*?\w+\s*?having\s+


### PR DESCRIPTION
This PR fixes the #1665, which created in old [repository](https://github.com/SpiderLabs/owasp-modsecurity-crs/issues/1665), and the migration bot copied [here](https://github.com/coreruleset/coreruleset/issues/1665). Later @fzipi created a [reminder](https://github.com/coreruleset/coreruleset/issues/1708).

In the old repo, there was a [fix](https://github.com/SpiderLabs/owasp-modsecurity-crs/pull/1708) with so many comments. @allanrbo and @mirkodziadzka-avi found two similar solutions. I made a [tool](https://github.com/airween/msc_pcretest/) to make some comparisons for performance. I [found](https://github.com/SpiderLabs/owasp-modsecurity-crs/pull/1708#issuecomment-619618272) that the first solution from Allan gives better performance, but we stayed in we keep the more clear solutions.

The diff is a bit different than the [original pull request](https://github.com/SpiderLabs/owasp-modsecurity-crs/pull/1708/files). I assume Allan assembled the regexes (from the data files) with [regex-assemble.pl](https://github.com/coreruleset/coreruleset/blob/v3.3/dev/util/regexp-assemble/regexp-assemble.pl), not the regexp-assemble-v2.pl, and we didn't realized that some regression [tests were failed](https://travis-ci.org/github/SpiderLabs/owasp-modsecurity-crs/builds/658123205#L421-L437).

Now I assembled the data files with regex-assemble-v2.pl, and appended the `(?i:` modifier. Not all regression test were passed.

Hope we can merge this PR before the release of v3.3.

Credits are for @allanrbo and @mirkodziadzka-avi. Thanks for all participants.