### PR TITLE
fix typos found by fossies codespell

### DIFF
--- a/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -61,7 +61,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
 # [ Java deserialization vulnerability/Oracle Weblogic (CVE-2017-10271) ]
 # [ SAP CRM Java vulnerability CVE-2018-2380 - Exploit tested: https://www.exploit-db.com/exploits/44292 ]
 #
-# Generic rule to detect processbuilder or runtime calls, if any of thos is found and the same target contains
+# Generic rule to detect processbuilder or runtime calls, if any of those is found and the same target contains
 # java. unmarshaller or base64data to trigger a potential payload execution
 # tested with https://www.exploit-db.com/exploits/42627/ and https://www.exploit-db.com/exploits/43458/
 

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942120.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942120.yaml
@@ -340,7 +340,7 @@
           method: POST
           port: 80
           uri: "/"
-          data: "pay= in ( Aa,- Ab-, andd Ac)"
+          data: "pay= in ( Aa,- Ab-, and Ac)"
           version: HTTP/1.0
         output:
           log_contains: id "942120"

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942380.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942380.yaml
@@ -562,7 +562,7 @@
           method: POST
           port: 80
           uri: "/"
-          data: "execute syste"
+          data: "execute system"
           version: HTTP/1.0
         output:
           log_contains: id "942380"


### PR DESCRIPTION
Fixed 3 typos found by fossies Codespell Project in the 3.3/dev branch.
https://fossies.org/linux/test/coreruleset-3.3-dev.3b4a13b.200602.tar.gz/codespell.html

Those typos are also present in the 3.2 branch, however they are only in either comments or regression tests and I don't think we need to backport them. Otherwise let me know.