### PR TITLE
Drop unneeded tags

### DIFF
--- a/rules/REQUEST-910-IP-REPUTATION.conf
+++ b/rules/REQUEST-910-IP-REPUTATION.conf
@@ -39,7 +39,6 @@ SecRule TX:DO_REPUT_BLOCK "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
-    tag:'IP_REPUTATION/MALICIOUS_CLIENT',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain,\

--- a/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
+++ b/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
@@ -35,11 +35,6 @@ SecRule REQUEST_METHOD "!@within %{tx.allowed_methods}" \
     tag:'platform-multi',\
     tag:'attack-generic',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/POLICY/METHOD_NOT_ALLOWED',\
-    tag:'WASCTC/WASC-15',\
-    tag:'OWASP_TOP_10/A6',\
-    tag:'OWASP_AppSensor/RE1',\
     tag:'PCI/12.1',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\

--- a/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
+++ b/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
@@ -35,6 +35,7 @@ SecRule REQUEST_METHOD "!@within %{tx.allowed_methods}" \
     tag:'platform-multi',\
     tag:'attack-generic',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/12.1',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\

--- a/rules/REQUEST-913-SCANNER-DETECTION.conf
+++ b/rules/REQUEST-913-SCANNER-DETECTION.conf
@@ -43,10 +43,6 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scanners-user-agents.data" \
     tag:'platform-multi',\
     tag:'attack-reputation-scanner',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/AUTOMATION/SECURITY_SCANNER',\
-    tag:'WASCTC/WASC-21',\
-    tag:'OWASP_TOP_10/A7',\
     tag:'PCI/6.5.10',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -68,10 +64,6 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@pmFromFile scanners-headers.data
     tag:'platform-multi',\
     tag:'attack-reputation-scanner',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/AUTOMATION/SECURITY_SCANNER',\
-    tag:'WASCTC/WASC-21',\
-    tag:'OWASP_TOP_10/A7',\
     tag:'PCI/6.5.10',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -95,10 +87,6 @@ SecRule REQUEST_FILENAME|ARGS "@pmFromFile scanners-urls.data" \
     tag:'platform-multi',\
     tag:'attack-reputation-scanner',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/AUTOMATION/SECURITY_SCANNER',\
-    tag:'WASCTC/WASC-21',\
-    tag:'OWASP_TOP_10/A7',\
     tag:'PCI/6.5.10',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -136,10 +124,6 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scripting-user-agents.data" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-reputation-scripting',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/AUTOMATION/SCRIPTING',\
-    tag:'WASCTC/WASC-21',\
-    tag:'OWASP_TOP_10/A7',\
     tag:'PCI/6.5.10',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -172,10 +156,6 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile crawlers-user-agents.data" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-reputation-crawler',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/AUTOMATION/CRAWLER',\
-    tag:'WASCTC/WASC-21',\
-    tag:'OWASP_TOP_10/A7',\
     tag:'PCI/6.5.10',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\

--- a/rules/REQUEST-913-SCANNER-DETECTION.conf
+++ b/rules/REQUEST-913-SCANNER-DETECTION.conf
@@ -43,6 +43,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scanners-user-agents.data" \
     tag:'platform-multi',\
     tag:'attack-reputation-scanner',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.10',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -64,6 +65,7 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@pmFromFile scanners-headers.data
     tag:'platform-multi',\
     tag:'attack-reputation-scanner',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.10',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -87,6 +89,7 @@ SecRule REQUEST_FILENAME|ARGS "@pmFromFile scanners-urls.data" \
     tag:'platform-multi',\
     tag:'attack-reputation-scanner',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.10',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -124,6 +127,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scripting-user-agents.data" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-reputation-scripting',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.10',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -156,6 +160,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile crawlers-user-agents.data" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-reputation-crawler',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.10',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -56,9 +56,6 @@ SecRule REQUEST_LINE "!@rx ^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_REQ',\
-    tag:'CAPEC-272',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
@@ -108,9 +105,6 @@ SecRule FILES_NAMES|FILES "@rx (?<!&(?:[aAoOuUyY]uml)|&(?:[aAeEiIoOuU]circ)|&(?:
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_REQ',\
-    tag:'CAPEC-272',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -138,9 +132,6 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^\d+$" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
-    tag:'CAPEC-272',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -173,9 +164,6 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
-    tag:'CAPEC-272',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
@@ -199,9 +187,6 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
-    tag:'CAPEC-272',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
@@ -236,9 +221,6 @@ SecRule REQUEST_PROTOCOL "!@within HTTP/2 HTTP/2.0" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
-    tag:'CAPEC-272',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
     chain"
@@ -266,8 +248,6 @@ SecRule &REQUEST_HEADERS:Transfer-Encoding "!@eq 0" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
-    tag:'CAPEC-272',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
     chain"
@@ -304,8 +284,6 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx (\d+)-(\d+)" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
     chain"
@@ -337,8 +315,6 @@ SecRule REQUEST_HEADERS:Connection "@rx \b(?:keep-alive|close),\s?(?:keep-alive|
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
@@ -370,8 +346,6 @@ SecRule REQUEST_URI "@rx \x25" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
     chain"
@@ -390,8 +364,6 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)application/x-www-form-urlencoded
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
     chain"
@@ -422,8 +394,6 @@ SecRule TX:CRS_VALIDATE_UTF8_ENCODING "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
     chain"
@@ -513,8 +483,6 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 1-255" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -544,10 +512,6 @@ SecRule &REQUEST_HEADERS:Host "@eq 0" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER_HOST',\
-    tag:'WASCTC/WASC-21',\
-    tag:'OWASP_TOP_10/A7',\
     tag:'PCI/6.5.10',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
@@ -566,8 +530,6 @@ SecRule REQUEST_HEADERS:Host "@rx ^$" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER_HOST',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
@@ -606,8 +568,6 @@ SecRule REQUEST_HEADERS:Accept "@rx ^$" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER_ACCEPT',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'NOTICE',\
     chain"
@@ -631,8 +591,6 @@ SecRule REQUEST_HEADERS:Accept "@rx ^$" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER_ACCEPT',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'NOTICE',\
     chain"
@@ -664,8 +622,6 @@ SecRule REQUEST_HEADERS:User-Agent "@rx ^$" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/EMPTY_HEADER_UA',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'NOTICE',\
     setvar:'tx.anomaly_score_pl1=+%{tx.notice_anomaly_score}'"
@@ -731,10 +687,6 @@ SecRule REQUEST_HEADERS:Host "@rx ^[\d.:]+$" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/IP_HOST',\
-    tag:'WASCTC/WASC-21',\
-    tag:'OWASP_TOP_10/A7',\
     tag:'PCI/6.5.10',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
@@ -766,8 +718,6 @@ SecRule &TX:MAX_NUM_ARGS "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/POLICY/SIZE_LIMIT',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
@@ -791,8 +741,6 @@ SecRule &TX:ARG_NAME_LENGTH "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/POLICY/SIZE_LIMIT',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
@@ -818,8 +766,6 @@ SecRule &TX:ARG_LENGTH "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/POLICY/SIZE_LIMIT',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
@@ -842,8 +788,6 @@ SecRule &TX:TOTAL_ARG_LENGTH "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/POLICY/SIZE_LIMIT',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
@@ -867,8 +811,6 @@ SecRule &TX:MAX_FILE_SIZE "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/POLICY/SIZE_LIMIT',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
@@ -893,8 +835,6 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/POLICY/SIZE_LIMIT',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
@@ -930,11 +870,6 @@ SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+-]+(?:\s?;\s?(?:action|boundar
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/CONTENT_TYPE',\
-    tag:'WASCTC/WASC-20',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/EE2',\
     tag:'PCI/12.1',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -956,11 +891,6 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/POLICY/CONTENT_TYPE_NOT_ALLOWED',\
-    tag:'WASCTC/WASC-20',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/EE2',\
     tag:'PCI/12.1',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -986,11 +916,6 @@ SecRule REQUEST_HEADERS:Content-Type "@rx charset\s*=\s*[\"']?([^;\"'\s]+)" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/CONTENT_TYPE_CHARSET',\
-    tag:'WASCTC/WASC-20',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/EE2',\
     tag:'PCI/12.1',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -1016,10 +941,6 @@ SecRule REQUEST_PROTOCOL "!@within %{tx.allowed_http_versions}" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/POLICY/PROTOCOL_NOT_ALLOWED',\
-    tag:'WASCTC/WASC-21',\
-    tag:'OWASP_TOP_10/A6',\
     tag:'PCI/6.5.10',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -1041,10 +962,6 @@ SecRule REQUEST_BASENAME "@rx \.([^.]+)$" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/POLICY/EXT_RESTRICTED',\
-    tag:'WASCTC/WASC-15',\
-    tag:'OWASP_TOP_10/A7',\
     tag:'PCI/6.5.10',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -1070,10 +987,6 @@ SecRule REQUEST_FILENAME "@rx \.[^.~]+~(?:/.*|)$" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/POLICY/EXT_RESTRICTED',\
-    tag:'WASCTC/WASC-15',\
-    tag:'OWASP_TOP_10/A7',\
     tag:'PCI/6.5.10',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -1117,13 +1030,7 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/POLICY/HEADER_RESTRICTED',\
-    tag:'WASCTC/WASC-21',\
-    tag:'OWASP_TOP_10/A7',\
     tag:'PCI/12.1',\
-    tag:'WASCTC/WASC-15',\
-    tag:'OWASP_TOP_10/A7',\
     tag:'PCI/12.1',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -1141,14 +1048,6 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
 # "bad bot" and tools that impersonate a real browser but with wrong request
 # header setup.
 #
-# The regular expression used on this rule tries to match multiple directives
-# in a single value, for example: "max-stale=1, max-age=2". This leads us to
-# use a regular expression that accepts a trailing comma to keep compatibility
-# with all regex engines and not PCRE only. For example: "max-stale=1, max-age=2, "
-#
-# Moreover, this regular expression allows duplicate directives sequence like:
-# "max-stale, max-stale=1, no-cache, no-cache".
-#
 # Standard Cache-Control directives that can be used by the client:
 #   - max-age=<seconds>
 #   - max-stale[=<seconds>]
@@ -1160,7 +1059,7 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
 #
 # References:
 # - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
-# - https://regex101.com/r/CZ0Hxu/22
+# - https://regex101.com/r/CZ0Hxu/1
 #
 SecRule &REQUEST_HEADERS:Cache-Control "@gt 0" "id:920510,\
     phase:1,\
@@ -1174,11 +1073,10 @@ SecRule &REQUEST_HEADERS:Cache-Control "@gt 0" "id:920510,\
     tag:'attack-protocol',\
     tag:'header-whitelist',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.2.0',\
     severity:'CRITICAL',\
     chain"
-    SecRule REQUEST_HEADERS:Cache-Control "!@rx ^(?:(?:max-age=[0-9]+|min-fresh=[0-9]+|no-cache|no-store|no-transform|only-if-cached|max-stale(?:=[0-9]+)?)(\s*\,\s*|$)){1,7}$" \
+    SecRule REQUEST_HEADERS:Cache-Control "!@rx ^(?:max-age=[0-9]+|min-fresh=[0-9]+|no-cache|no-store|no-transform|only-if-cached|max-stale(?:[=][0-9]+|))$" \
         "setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:920013,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
@@ -1218,8 +1116,6 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
@@ -1242,8 +1138,6 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
@@ -1263,8 +1157,6 @@ SecRule ARGS "@rx %[0-9a-fA-F]{2}" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
@@ -1293,10 +1185,6 @@ SecRule &REQUEST_HEADERS:Accept "@eq 0" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER_ACCEPT',\
-    tag:'WASCTC/WASC-21',\
-    tag:'OWASP_TOP_10/A7',\
     tag:'PCI/6.5.10',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1322,8 +1210,6 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 9,10,13,
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -1348,10 +1234,6 @@ SecRule &REQUEST_HEADERS:User-Agent "@eq 0" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER_UA',\
-    tag:'WASCTC/WASC-21',\
-    tag:'OWASP_TOP_10/A7',\
     tag:'PCI/6.5.10',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1373,9 +1255,6 @@ SecRule FILES_NAMES|FILES "@rx ['\";=]" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_REQ',\
-    tag:'CAPEC-272',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -1431,8 +1310,6 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteR
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -1459,8 +1336,6 @@ SecRule &REQUEST_HEADERS:x-up-devcap-post-charset "@ge 1" \
     tag:'language-aspnet',\
     tag:'platform-windows',\
     tag:'attack-protocol',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -1491,8 +1366,6 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/INVALID_HREQ',\
     tag:'paranoia-level/4',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
@@ -1518,8 +1391,6 @@ SecRule ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteRange 38,44-46,48-58,61,65-90
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
     tag:'paranoia-level/4',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -1539,8 +1410,6 @@ SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!RE
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
     tag:'paranoia-level/4',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -1563,8 +1432,6 @@ SecRule REQUEST_HEADERS:Sec-Fetch-User "@validateByteRange 32,34,38,42-59,61,63,
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
     tag:'paranoia-level/4',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1108,7 +1108,7 @@ SecRule &REQUEST_HEADERS:Cache-Control "@gt 0" "id:920510,\
     ver:'OWASP_CRS/3.2.0',\
     severity:'CRITICAL',\
     chain"
-    SecRule REQUEST_HEADERS:Cache-Control "!@rx ^(?:max-age=[0-9]+|min-fresh=[0-9]+|no-cache|no-store|no-transform|only-if-cached|max-stale(?:[=][0-9]+|))$" \
+    SecRule REQUEST_HEADERS:Cache-Control "!@rx ^(?:(?:max-age=[0-9]+|min-fresh=[0-9]+|no-cache|no-store|no-transform|only-if-cached|max-stale(?:=[0-9]+)?)(\s*\,\s*|$)){1,7}$" \
         "setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:920013,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1079,6 +1079,14 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
 # "bad bot" and tools that impersonate a real browser but with wrong request
 # header setup.
 #
+# The regular expression used on this rule tries to match multiple directives
+# in a single value, for example: "max-stale=1, max-age=2". This leads us to
+# use a regular expression that accepts a trailing comma to keep compatibility
+# with all regex engines and not PCRE only. For example: "max-stale=1, max-age=2, "
+#
+# Moreover, this regular expression allows duplicate directives sequence like:
+# "max-stale, max-stale=1, no-cache, no-cache".
+#
 # Standard Cache-Control directives that can be used by the client:
 #   - max-age=<seconds>
 #   - max-stale[=<seconds>]
@@ -1090,7 +1098,7 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
 #
 # References:
 # - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
-# - https://regex101.com/r/CZ0Hxu/1
+# - https://regex101.com/r/CZ0Hxu/22
 #
 SecRule &REQUEST_HEADERS:Cache-Control "@gt 0" "id:920510,\
     phase:1,\
@@ -1105,7 +1113,7 @@ SecRule &REQUEST_HEADERS:Cache-Control "@gt 0" "id:920510,\
     tag:'header-whitelist',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.2.0',\
+    ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
     SecRule REQUEST_HEADERS:Cache-Control "!@rx ^(?:(?:max-age=[0-9]+|min-fresh=[0-9]+|no-cache|no-store|no-transform|only-if-cached|max-stale(?:=[0-9]+)?)(\s*\,\s*|$)){1,7}$" \

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -56,6 +56,7 @@ SecRule REQUEST_LINE "!@rx ^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
@@ -105,6 +106,7 @@ SecRule FILES_NAMES|FILES "@rx (?<!&(?:[aAoOuUyY]uml)|&(?:[aAeEiIoOuU]circ)|&(?:
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -132,6 +134,7 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^\d+$" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -164,6 +167,7 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
@@ -187,6 +191,7 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
@@ -221,6 +226,7 @@ SecRule REQUEST_PROTOCOL "!@within HTTP/2 HTTP/2.0" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
     chain"
@@ -284,6 +290,7 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx (\d+)-(\d+)" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
     chain"
@@ -315,6 +322,7 @@ SecRule REQUEST_HEADERS:Connection "@rx \b(?:keep-alive|close),\s?(?:keep-alive|
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
@@ -346,6 +354,7 @@ SecRule REQUEST_URI "@rx \x25" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
     chain"
@@ -364,6 +373,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)application/x-www-form-urlencoded
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
     chain"
@@ -394,6 +404,7 @@ SecRule TX:CRS_VALIDATE_UTF8_ENCODING "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
     chain"
@@ -483,6 +494,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 1-255" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -512,6 +524,7 @@ SecRule &REQUEST_HEADERS:Host "@eq 0" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.10',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
@@ -530,6 +543,7 @@ SecRule REQUEST_HEADERS:Host "@rx ^$" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
@@ -568,6 +582,7 @@ SecRule REQUEST_HEADERS:Accept "@rx ^$" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'NOTICE',\
     chain"
@@ -591,6 +606,7 @@ SecRule REQUEST_HEADERS:Accept "@rx ^$" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'NOTICE',\
     chain"
@@ -622,6 +638,7 @@ SecRule REQUEST_HEADERS:User-Agent "@rx ^$" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'NOTICE',\
     setvar:'tx.anomaly_score_pl1=+%{tx.notice_anomaly_score}'"
@@ -687,6 +704,7 @@ SecRule REQUEST_HEADERS:Host "@rx ^[\d.:]+$" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.10',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
@@ -718,6 +736,7 @@ SecRule &TX:MAX_NUM_ARGS "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
@@ -741,6 +760,7 @@ SecRule &TX:ARG_NAME_LENGTH "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
@@ -766,6 +786,7 @@ SecRule &TX:ARG_LENGTH "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
@@ -788,6 +809,7 @@ SecRule &TX:TOTAL_ARG_LENGTH "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
@@ -811,6 +833,7 @@ SecRule &TX:MAX_FILE_SIZE "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
@@ -835,6 +858,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
@@ -870,6 +894,7 @@ SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+-]+(?:\s?;\s?(?:action|boundar
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/12.1',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -891,6 +916,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/12.1',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -916,6 +942,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx charset\s*=\s*[\"']?([^;\"'\s]+)" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/12.1',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -941,6 +968,7 @@ SecRule REQUEST_PROTOCOL "!@within %{tx.allowed_http_versions}" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.10',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -962,6 +990,7 @@ SecRule REQUEST_BASENAME "@rx \.([^.]+)$" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.10',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -987,6 +1016,7 @@ SecRule REQUEST_FILENAME "@rx \.[^.~]+~(?:/.*|)$" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.10',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -1030,6 +1060,7 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/12.1',\
     tag:'PCI/12.1',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1073,6 +1104,7 @@ SecRule &REQUEST_HEADERS:Cache-Control "@gt 0" "id:920510,\
     tag:'attack-protocol',\
     tag:'header-whitelist',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.2.0',\
     severity:'CRITICAL',\
     chain"
@@ -1116,6 +1148,7 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
@@ -1138,6 +1171,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
@@ -1157,6 +1191,7 @@ SecRule ARGS "@rx %[0-9a-fA-F]{2}" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
@@ -1185,6 +1220,7 @@ SecRule &REQUEST_HEADERS:Accept "@eq 0" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.10',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1210,6 +1246,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 9,10,13,
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -1234,6 +1271,7 @@ SecRule &REQUEST_HEADERS:User-Agent "@eq 0" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.10',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1255,6 +1293,7 @@ SecRule FILES_NAMES|FILES "@rx ['\";=]" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -1310,6 +1349,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteR
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -1336,6 +1376,7 @@ SecRule &REQUEST_HEADERS:x-up-devcap-post-charset "@ge 1" \
     tag:'language-aspnet',\
     tag:'platform-windows',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -1366,6 +1407,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'paranoia-level/4',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
@@ -1391,6 +1433,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteRange 38,44-46,48-58,61,65-90
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'paranoia-level/4',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -1410,6 +1453,7 @@ SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!RE
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'paranoia-level/4',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -1432,6 +1476,7 @@ SecRule REQUEST_HEADERS:Sec-Fetch-User "@validateByteRange 32,34,38,42-59,61,63,
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'paranoia-level/4',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -43,6 +43,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx [\n\r]+(?:get|post|head|options|connect|put|
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -74,6 +75,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -94,6 +96,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -127,6 +130,7 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@rx [\n\r]" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -154,6 +158,7 @@ SecRule ARGS_NAMES "@rx [\n\r]" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -174,6 +179,7 @@ SecRule ARGS_GET_NAMES|ARGS_GET "@rx [\n\r]+(?:\s|location|refresh|(?:set-)?cook
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -198,6 +204,7 @@ SecRule REQUEST_FILENAME "@rx [\n\r]" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -261,6 +268,7 @@ SecRule ARGS_GET "@rx [\n\r]" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/2',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -316,6 +324,7 @@ SecRule TX:/paramcounter_.*/ "@gt 1" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -43,8 +43,6 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx [\n\r]+(?:get|post|head|options|connect|put|
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/REQUEST_SMUGGLING',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -76,8 +74,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/RESPONSE_SPLITTING',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -98,8 +94,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/RESPONSE_SPLITTING',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -133,8 +127,6 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@rx [\n\r]" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/HEADER_INJECTION',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -162,8 +154,6 @@ SecRule ARGS_NAMES "@rx [\n\r]" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/HEADER_INJECTION',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -184,8 +174,6 @@ SecRule ARGS_GET_NAMES|ARGS_GET "@rx [\n\r]+(?:\s|location|refresh|(?:set-)?cook
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/HEADER_INJECTION',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -210,8 +198,6 @@ SecRule REQUEST_FILENAME "@rx [\n\r]" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/HTTP_SPLITTING',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -275,8 +261,6 @@ SecRule ARGS_GET "@rx [\n\r]" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/2',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/HEADER_INJECTION',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -319,7 +303,6 @@ SecRule ARGS_NAMES "@rx ." \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/3',\
-    tag:'CAPEC-460',\
     ver:'OWASP_CRS/3.3.0',\
     setvar:'TX.paramcounter_%{MATCHED_VAR_NAME}=+1'"
 
@@ -333,10 +316,7 @@ SecRule TX:/paramcounter_.*/ "@gt 1" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/HTTP_PARAMETER_POLLUTION',\
     tag:'paranoia-level/3',\
-    tag:'CAPEC-460',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -39,8 +39,6 @@ SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@r
     tag:'platform-multi',\
     tag:'attack-lfi',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/DIR_TRAVERSAL',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
@@ -62,8 +60,6 @@ SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@rx (?
     tag:'platform-multi',\
     tag:'attack-lfi',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/DIR_TRAVERSAL',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     multiMatch,\
@@ -88,10 +84,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-lfi',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/FILE_INJECTION',\
-    tag:'WASCTC/WASC-33',\
-    tag:'OWASP_TOP_10/A4',\
     tag:'PCI/6.5.4',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -117,10 +109,6 @@ SecRule REQUEST_FILENAME "@pmFromFile restricted-files.data" \
     tag:'platform-multi',\
     tag:'attack-lfi',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/FILE_INJECTION',\
-    tag:'WASCTC/WASC-33',\
-    tag:'OWASP_TOP_10/A4',\
     tag:'PCI/6.5.4',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -39,6 +39,7 @@ SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@r
     tag:'platform-multi',\
     tag:'attack-lfi',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
@@ -60,6 +61,7 @@ SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@rx (?
     tag:'platform-multi',\
     tag:'attack-lfi',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     multiMatch,\
@@ -84,6 +86,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-lfi',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.4',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -109,6 +112,7 @@ SecRule REQUEST_FILENAME "@pmFromFile restricted-files.data" \
     tag:'platform-multi',\
     tag:'attack-lfi',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.4',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\

--- a/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
+++ b/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
@@ -46,6 +46,7 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?):\/\/(?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1
     tag:'platform-multi',\
     tag:'attack-rfi',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -65,6 +66,7 @@ SecRule QUERY_STRING|REQUEST_BODY "@rx (?i)(?:\binclude\s*\([^)]*|mosConfig_abso
     tag:'platform-multi',\
     tag:'attack-rfi',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -84,6 +86,7 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?).*?\?+$" \
     tag:'platform-multi',\
     tag:'attack-rfi',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -110,6 +113,7 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?)://([^/]*).*$" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-rfi',\
+    tag:'OWASP_CRS',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\

--- a/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
+++ b/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
@@ -46,8 +46,6 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?):\/\/(?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1
     tag:'platform-multi',\
     tag:'attack-rfi',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/RFI',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -67,8 +65,6 @@ SecRule QUERY_STRING|REQUEST_BODY "@rx (?i)(?:\binclude\s*\([^)]*|mosConfig_abso
     tag:'platform-multi',\
     tag:'attack-rfi',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/RFI',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -88,8 +84,6 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?).*?\?+$" \
     tag:'platform-multi',\
     tag:'attack-rfi',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/RFI',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -116,8 +110,6 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?)://([^/]*).*$" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-rfi',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/RFI',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -112,10 +112,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-unix',\
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
-    tag:'WASCTC/WASC-31',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -150,10 +146,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-unix',\
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
-    tag:'WASCTC/WASC-31',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -249,10 +241,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-windows',\
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
-    tag:'WASCTC/WASC-31',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -290,10 +278,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-windows',\
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
-    tag:'WASCTC/WASC-31',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -327,10 +311,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-windows',\
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
-    tag:'WASCTC/WASC-31',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -366,10 +346,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-unix',\
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
-    tag:'WASCTC/WASC-31',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -414,10 +390,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-windows',\
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
-    tag:'WASCTC/WASC-31',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -467,10 +439,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-unix',\
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
-    tag:'WASCTC/WASC-31',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -506,10 +474,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-unix',\
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
-    tag:'WASCTC/WASC-31',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -540,10 +504,6 @@ SecRule REQUEST_HEADERS|REQUEST_LINE "@rx ^\(\s*\)\s+{" \
     tag:'platform-unix',\
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
-    tag:'WASCTC/WASC-31',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -564,10 +524,6 @@ SecRule ARGS_NAMES|ARGS|FILES_NAMES "@rx ^\(\s*\)\s+{" \
     tag:'platform-unix',\
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
-    tag:'WASCTC/WASC-31',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -602,10 +558,6 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'platform-multi',\
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
-    tag:'WASCTC/WASC-31',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -657,10 +609,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-shell',\
     tag:'platform-unix',\
     tag:'attack-rce',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
-    tag:'WASCTC/WASC-31',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\
@@ -691,10 +639,6 @@ SecRule ARGS "@rx (?:/|\\\\)(?:[\?\*]+[a-z/\\\\]+|[a-z/\\\\]+[\?\*]+)" \
     tag:'language-shell',\
     tag:'platform-unix',\
     tag:'attack-rce',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
-    tag:'WASCTC/WASC-31',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -112,6 +112,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-unix',\
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -146,6 +147,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-unix',\
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -241,6 +243,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-windows',\
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -278,6 +281,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-windows',\
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -311,6 +315,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-windows',\
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -346,6 +351,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-unix',\
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -390,6 +396,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-windows',\
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -439,6 +446,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-unix',\
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -474,6 +482,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-unix',\
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -504,6 +513,7 @@ SecRule REQUEST_HEADERS|REQUEST_LINE "@rx ^\(\s*\)\s+{" \
     tag:'platform-unix',\
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -524,6 +534,7 @@ SecRule ARGS_NAMES|ARGS|FILES_NAMES "@rx ^\(\s*\)\s+{" \
     tag:'platform-unix',\
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -558,6 +569,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'platform-multi',\
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -609,6 +621,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-shell',\
     tag:'platform-unix',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\
@@ -639,6 +652,7 @@ SecRule ARGS "@rx (?:/|\\\\)(?:[\?\*]+[a-z/\\\\]+|[a-z/\\\\]+[\?\*]+)" \
     tag:'language-shell',\
     tag:'platform-unix',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -56,6 +56,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-injection-php',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -96,6 +97,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'platform-multi',\
     tag:'attack-injection-php',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -119,6 +121,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-injection-php',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -145,6 +148,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-injection-php',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -180,6 +184,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-injection-php',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -207,6 +212,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-injection-php',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -273,6 +279,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'platform-multi',\
     tag:'attack-injection-php',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -325,6 +332,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'platform-multi',\
     tag:'attack-injection-php',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -379,6 +387,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'platform-multi',\
     tag:'attack-injection-php',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -433,6 +442,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'platform-multi',\
     tag:'attack-injection-php',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -473,6 +483,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'platform-multi',\
     tag:'attack-injection-php',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -514,6 +525,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'OWASP_CRS',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -566,6 +578,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'OWASP_CRS',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -610,6 +623,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'OWASP_CRS',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -651,6 +665,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'OWASP_CRS',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -679,6 +694,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'OWASP_CRS',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -56,9 +56,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-injection-php',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
-    tag:'OWASP_TOP_10/A1',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -99,9 +96,6 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'platform-multi',\
     tag:'attack-injection-php',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
-    tag:'OWASP_TOP_10/A1',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -125,9 +119,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-injection-php',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
-    tag:'OWASP_TOP_10/A1',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -154,9 +145,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-injection-php',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
-    tag:'OWASP_TOP_10/A1',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -192,9 +180,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-injection-php',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
-    tag:'OWASP_TOP_10/A1',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -222,9 +207,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-injection-php',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
-    tag:'OWASP_TOP_10/A1',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -291,9 +273,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'platform-multi',\
     tag:'attack-injection-php',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
-    tag:'OWASP_TOP_10/A1',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -346,9 +325,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'platform-multi',\
     tag:'attack-injection-php',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
-    tag:'OWASP_TOP_10/A1',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -403,9 +379,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'platform-multi',\
     tag:'attack-injection-php',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
-    tag:'OWASP_TOP_10/A1',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -460,9 +433,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'platform-multi',\
     tag:'attack-injection-php',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
-    tag:'OWASP_TOP_10/A1',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -503,9 +473,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'platform-multi',\
     tag:'attack-injection-php',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
-    tag:'OWASP_TOP_10/A1',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -547,9 +514,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -602,9 +566,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -649,9 +610,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -693,9 +651,6 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -724,9 +679,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\

--- a/rules/REQUEST-934-APPLICATION-ATTACK-NODEJS.conf
+++ b/rules/REQUEST-934-APPLICATION-ATTACK-NODEJS.conf
@@ -59,8 +59,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'attack-rce',\
     tag:'attack-injection-nodejs',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS/WEB_ATTACK/NODEJS_INJECTION',\
-    tag:'OWASP_TOP_10/A1',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -46,6 +46,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -71,6 +72,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -95,6 +97,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -123,6 +126,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -147,6 +151,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -180,6 +185,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -203,6 +209,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -227,6 +234,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -252,6 +260,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -272,6 +281,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -292,6 +302,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -312,6 +323,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -332,6 +344,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -352,6 +365,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -372,6 +386,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -392,6 +407,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -412,6 +428,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -432,6 +449,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -452,6 +470,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -472,6 +491,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -497,6 +517,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-tomcat',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -522,6 +543,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-internet-explorer',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -562,6 +584,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -588,6 +611,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS|XML:
     tag:'language-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -616,6 +640,7 @@ SecRule REQUEST_HEADERS:Referer "@detectXSS" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -640,6 +665,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -721,6 +747,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.1',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -740,6 +767,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.1',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -762,6 +790,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.1',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -793,6 +822,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'attack-xss',\
+    tag:'OWASP_CRS',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -84,7 +84,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
 # -=[ XSS Filters - Category 2 ]=-
 # XSS vectors making use of event handlers like onerror, onload etc, e.g., <body onload="alert(1)">
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\"'`;\/0-9=\x0B\x09\x0C\x3B\x2C\x28\x3B]+on[a-zA-Z]+[\s\x0B\x09\x0C\x3B\x2C\x28\x3B]*?=" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\"'`;\/0-9=\x0B\x09\x0C\x3B\x2C\x28\x3B]on[a-zA-Z]+[\s\x0B\x09\x0C\x3B\x2C\x28\x3B]*?=" \
     "id:941120,\
     phase:2,\
     block,\

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -46,13 +46,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A3',\
-    tag:'OWASP_AppSensor/IE1',\
-    tag:'CAPEC-242',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -78,13 +71,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A3',\
-    tag:'OWASP_AppSensor/IE1',\
-    tag:'CAPEC-242',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -96,7 +82,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
 # -=[ XSS Filters - Category 2 ]=-
 # XSS vectors making use of event handlers like onerror, onload etc, e.g., <body onload="alert(1)">
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\"'`;\/0-9=\x0B\x09\x0C\x3B\x2C\x28\x3B]on[a-zA-Z]+[\s\x0B\x09\x0C\x3B\x2C\x28\x3B]*?=" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\"'`;\/0-9=\x0B\x09\x0C\x3B\x2C\x28\x3B]+on[a-zA-Z]+[\s\x0B\x09\x0C\x3B\x2C\x28\x3B]*?=" \
     "id:941120,\
     phase:2,\
     block,\
@@ -109,13 +95,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A3',\
-    tag:'OWASP_AppSensor/IE1',\
-    tag:'CAPEC-242',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -144,13 +123,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A3',\
-    tag:'OWASP_AppSensor/IE1',\
-    tag:'CAPEC-242',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -175,13 +147,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A3',\
-    tag:'OWASP_AppSensor/IE1',\
-    tag:'CAPEC-242',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -215,13 +180,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A3',\
-    tag:'OWASP_AppSensor/IE1',\
-    tag:'CAPEC-242',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -245,13 +203,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A3',\
-    tag:'OWASP_AppSensor/IE1',\
-    tag:'CAPEC-242',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -276,13 +227,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A3',\
-    tag:'OWASP_AppSensor/IE1',\
-    tag:'CAPEC-242',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -308,13 +252,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A3',\
-    tag:'OWASP_AppSensor/IE1',\
-    tag:'CAPEC-242',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -335,13 +272,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A3',\
-    tag:'OWASP_AppSensor/IE1',\
-    tag:'CAPEC-242',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -362,13 +292,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A3',\
-    tag:'OWASP_AppSensor/IE1',\
-    tag:'CAPEC-242',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -389,13 +312,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A3',\
-    tag:'OWASP_AppSensor/IE1',\
-    tag:'CAPEC-242',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -416,13 +332,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A3',\
-    tag:'OWASP_AppSensor/IE1',\
-    tag:'CAPEC-242',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -443,13 +352,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A3',\
-    tag:'OWASP_AppSensor/IE1',\
-    tag:'CAPEC-242',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -470,13 +372,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A3',\
-    tag:'OWASP_AppSensor/IE1',\
-    tag:'CAPEC-242',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -497,13 +392,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A3',\
-    tag:'OWASP_AppSensor/IE1',\
-    tag:'CAPEC-242',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -524,13 +412,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A3',\
-    tag:'OWASP_AppSensor/IE1',\
-    tag:'CAPEC-242',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -551,13 +432,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A3',\
-    tag:'OWASP_AppSensor/IE1',\
-    tag:'CAPEC-242',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -578,13 +452,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A3',\
-    tag:'OWASP_AppSensor/IE1',\
-    tag:'CAPEC-242',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -605,13 +472,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A3',\
-    tag:'OWASP_AppSensor/IE1',\
-    tag:'CAPEC-242',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -637,13 +497,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-tomcat',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A3',\
-    tag:'OWASP_AppSensor/IE1',\
-    tag:'CAPEC-242',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -669,13 +522,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-internet-explorer',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A3',\
-    tag:'OWASP_AppSensor/IE1',\
-    tag:'CAPEC-242',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -716,10 +562,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'OWASP_TOP_10/A7',\
-    tag:'CAPEC-63',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -746,10 +588,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS|XML:
     tag:'language-multi',\
     tag:'attack-xss',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'OWASP_TOP_10/A7',\
-    tag:'CAPEC-63',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -778,13 +616,6 @@ SecRule REQUEST_HEADERS:Referer "@detectXSS" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A3',\
-    tag:'OWASP_AppSensor/IE1',\
-    tag:'CAPEC-242',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -809,13 +640,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A3',\
-    tag:'OWASP_AppSensor/IE1',\
-    tag:'CAPEC-242',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -897,12 +721,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A2',\
-    tag:'OWASP_AppSensor/IE1',\
     tag:'PCI/6.5.1',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -922,12 +740,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A2',\
-    tag:'OWASP_AppSensor/IE1',\
     tag:'PCI/6.5.1',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -950,12 +762,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'WASCTC/WASC-8',\
-    tag:'WASCTC/WASC-22',\
-    tag:'OWASP_TOP_10/A2',\
-    tag:'OWASP_AppSensor/IE1',\
     tag:'PCI/6.5.1',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -987,10 +793,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'attack-xss',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/XSS',\
-    tag:'OWASP_TOP_10/A7',\
-    tag:'CAPEC-63',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -55,11 +55,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -92,11 +87,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -123,8 +113,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -151,11 +139,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -183,11 +166,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -207,11 +185,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -231,11 +204,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -263,11 +231,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -287,11 +250,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -311,11 +269,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -343,11 +296,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -367,11 +315,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -399,11 +342,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -431,11 +369,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -474,11 +407,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -513,11 +441,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -553,11 +476,6 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?:^\s*[\"'`;]+|[\"'`]+\s*$)" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -592,11 +510,6 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:(?:^|\W)in[+\s]*\([\s\d\"]+[^()]*\)|\
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -630,11 +543,6 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i:[\s'\"`()]*?\b([\d\w]+)\b[\s'\"`()]*?(?:
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -671,11 +579,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
@@ -704,11 +607,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -739,11 +637,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -762,7 +655,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # to the Regexp::Assemble output:
 #   (?i:ASSEMBLE_OUTPUT)
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:(?:n(?:and|ot)|(?:x?x)?or|between|\|\||like|and|div|&&)[\s(]+\w+[\s)]*?[!=+]+[\s\d]*?[\"'`=()]|\d(?:\s*?(?:between|like|x?or|and|div)\s*?\d+\s*?[\-+]|\s+group\s+by.+\()|\/\w+;?\s+(?:between|having|select|like|x?or|and|div)\W|--\s*?(?:(?:insert|update)\s*?\w{2,}|alter|drop)|#\s*?(?:(?:insert|update)\s*?\w{2,}|alter|drop)|;\s*?(?:(?:insert|update)\s*?\w{2,}|alter|drop)|\@.+=\s*?\(\s*?select|[^\w]SET\s*?\@\w+))" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:(?:n(?:and|ot)|(?:x?x)?or|between|\|\||like|and|div|&&)[\s(]+\w+[\s)]*?[!=+]+[\s\d]*?[\"'`=()]|\/\w+;?\s+(?:between|having|select|like|x?or|and|div)\W|\d+\s*?(?:between|like|x?or|and|div)\s*?\d+\s*?[\-+]|--\s*?(?:(?:insert|update)\s*?\w{2,}|alter|drop)|#\s*?(?:(?:insert|update)\s*?\w{2,}|alter|drop)|;\s*?(?:(?:insert|update)\s*?\w{2,}|alter|drop)|\@.+=\s*?\(\s*?select|\d\s+group\s+by.+\(|[^\w]SET\s*?\@\w+))" \
     "id:942210,\
     phase:2,\
     block,\
@@ -774,11 +667,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -794,7 +682,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # to the Regexp::Assemble output:
 #    ASSEMBLE_OUTPUT | s/^(?:/(?i:/
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:[\"'`]\s*?(?:(?:n(?:and|ot)|(?:x?x)?or|between|\|\||and|div|&&)\s+[\s\w]+=\s*?\w+\s*?having\s+|like(?:\s+[\s\w]+=\s*?\w+\s*?having\s+|\W*?[\"'`\d])|[^?\w\s=.,;)(]++\s*?[(@\"'`]*?\s*?\w+\W+\w|\*\s*?\w+\W+[\"'`])|(?:union\s*?(?:distinct|[(!@]*?|all)?\s*?[([]*?\s*?select|select\s+?[\[\]()\s\w\.,\"'`-]+from)\s+|\w\s+like\s+[\"'`]|find_in_set\s*?\(|like\s*?[\"'`]%)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:[\"'`]\s*?(?:(?:n(?:and|ot)|(?:x?x)?or|between|\|\||and|div|&&)\s+[\s\w]+=\s*?\w+\s*?having\s+|like(?:\s+[\s\w]+=\s*?\w+\s*?having\s+|\W*?[\"'`\d])|[^?\w\s=.,;)(]++\s*?[(@\"'`]*?\s*?\w+\W+\w|\*\s*?\w+\W+[\"'`])|(?:union\s*?(?:distinct|[(!@]*?|all)?\s*?[([]*?\s*?select|select\s+?[\[\]()\s\w\.,\"'`-]+from)\s+|\w+\s+like\s+[\"'`]|find_in_set\s*?\(|like\s*?[\"'`]%)" \
     "id:942260,\
     phase:2,\
     block,\
@@ -806,11 +694,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -838,11 +721,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -870,11 +748,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -910,11 +783,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -944,11 +812,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -972,11 +835,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1009,11 +867,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1038,11 +891,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
@@ -1068,11 +916,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
@@ -1101,11 +944,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
@@ -1141,11 +979,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
@@ -1177,11 +1010,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
@@ -1213,11 +1041,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
@@ -1258,11 +1081,6 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1305,11 +1123,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1333,11 +1146,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1385,11 +1193,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1427,11 +1230,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1454,11 +1252,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1497,11 +1290,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1529,11 +1317,6 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1562,11 +1345,6 @@ SecRule ARGS "@rx \W{4}" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1599,11 +1377,6 @@ SecRule REQUEST_BASENAME "@detectSQLi" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1652,11 +1425,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1688,11 +1456,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/4',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1720,11 +1483,6 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SQL_INJECTION',\
-    tag:'WASCTC/WASC-19',\
-    tag:'OWASP_TOP_10/A1',\
-    tag:'OWASP_AppSensor/CIE1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/4',\
     ver:'OWASP_CRS/3.3.0',\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -677,7 +677,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # to the Regexp::Assemble output:
 #   (?i:ASSEMBLE_OUTPUT)
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:(?:n(?:and|ot)|(?:x?x)?or|between|\|\||like|and|div|&&)[\s(]+\w+[\s)]*?[!=+]+[\s\d]*?[\"'`=()]|\/\w+;?\s+(?:between|having|select|like|x?or|and|div)\W|\d+\s*?(?:between|like|x?or|and|div)\s*?\d+\s*?[\-+]|--\s*?(?:(?:insert|update)\s*?\w{2,}|alter|drop)|#\s*?(?:(?:insert|update)\s*?\w{2,}|alter|drop)|;\s*?(?:(?:insert|update)\s*?\w{2,}|alter|drop)|\@.+=\s*?\(\s*?select|\d\s+group\s+by.+\(|[^\w]SET\s*?\@\w+))" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:(?:n(?:and|ot)|(?:x?x)?or|between|\|\||like|and|div|&&)[\s(]+\w+[\s)]*?[!=+]+[\s\d]*?[\"'`=()]|\d(?:\s*?(?:between|like|x?or|and|div)\s*?\d+\s*?[\-+]|\s+group\s+by.+\()|\/\w+;?\s+(?:between|having|select|like|x?or|and|div)\W|--\s*?(?:(?:insert|update)\s*?\w{2,}|alter|drop)|#\s*?(?:(?:insert|update)\s*?\w{2,}|alter|drop)|;\s*?(?:(?:insert|update)\s*?\w{2,}|alter|drop)|\@.+=\s*?\(\s*?select|[^\w]SET\s*?\@\w+))" \
     "id:942210,\
     phase:2,\
     block,\
@@ -705,7 +705,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # to the Regexp::Assemble output:
 #    ASSEMBLE_OUTPUT | s/^(?:/(?i:/
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:[\"'`]\s*?(?:(?:n(?:and|ot)|(?:x?x)?or|between|\|\||and|div|&&)\s+[\s\w]+=\s*?\w+\s*?having\s+|like(?:\s+[\s\w]+=\s*?\w+\s*?having\s+|\W*?[\"'`\d])|[^?\w\s=.,;)(]++\s*?[(@\"'`]*?\s*?\w+\W+\w|\*\s*?\w+\W+[\"'`])|(?:union\s*?(?:distinct|[(!@]*?|all)?\s*?[([]*?\s*?select|select\s+?[\[\]()\s\w\.,\"'`-]+from)\s+|\w+\s+like\s+[\"'`]|find_in_set\s*?\(|like\s*?[\"'`]%)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:[\"'`]\s*?(?:(?:n(?:and|ot)|(?:x?x)?or|between|\|\||and|div|&&)\s+[\s\w]+=\s*?\w+\s*?having\s+|like(?:\s+[\s\w]+=\s*?\w+\s*?having\s+|\W*?[\"'`\d])|[^?\w\s=.,;)(]++\s*?[(@\"'`]*?\s*?\w+\W+\w|\*\s*?\w+\W+[\"'`])|(?:union\s*?(?:distinct|[(!@]*?|all)?\s*?[([]*?\s*?select|select\s+?[\[\]()\s\w\.,\"'`-]+from)\s+|\w\s+like\s+[\"'`]|find_in_set\s*?\(|like\s*?[\"'`]%)" \
     "id:942260,\
     phase:2,\
     block,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -55,6 +55,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -87,6 +88,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -113,6 +115,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -139,6 +142,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -166,6 +170,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -185,6 +190,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -204,6 +210,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -231,6 +238,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -250,6 +258,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -269,6 +278,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -296,6 +306,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -315,6 +326,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -342,6 +354,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -369,6 +382,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -407,6 +421,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -441,6 +456,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -476,6 +492,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?:^\s*[\"'`;]+|[\"'`]+\s*$)" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -510,6 +527,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:(?:^|\W)in[+\s]*\([\s\d\"]+[^()]*\)|\
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -543,6 +561,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i:[\s'\"`()]*?\b([\d\w]+)\b[\s'\"`()]*?(?:
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -579,6 +598,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
@@ -607,6 +627,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -637,6 +658,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -667,6 +689,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -694,6 +717,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -721,6 +745,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -748,6 +773,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -783,6 +809,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -812,6 +839,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -835,6 +863,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -867,6 +896,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -891,6 +921,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
@@ -916,6 +947,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
@@ -944,6 +976,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
@@ -979,6 +1012,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
@@ -1010,6 +1044,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
@@ -1041,6 +1076,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
@@ -1081,6 +1117,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1123,6 +1160,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1146,6 +1184,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1193,6 +1232,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1230,6 +1270,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1252,6 +1293,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1290,6 +1332,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1317,6 +1360,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1345,6 +1389,7 @@ SecRule ARGS "@rx \W{4}" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1377,6 +1422,7 @@ SecRule REQUEST_BASENAME "@detectSQLi" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1425,6 +1471,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1456,6 +1503,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/4',\
     ver:'OWASP_CRS/3.3.0',\
@@ -1483,6 +1531,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/4',\
     ver:'OWASP_CRS/3.3.0',\

--- a/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
+++ b/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
@@ -40,10 +40,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-fixation',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SESSION_FIXATION',\
-    tag:'WASCTC/WASC-37',\
-    tag:'CAPEC-61',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -64,10 +60,6 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
     tag:'platform-multi',\
     tag:'attack-fixation',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SESSION_FIXATION',\
-    tag:'WASCTC/WASC-37',\
-    tag:'CAPEC-61',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -93,10 +85,6 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
     tag:'platform-multi',\
     tag:'attack-fixation',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/SESSION_FIXATION',\
-    tag:'WASCTC/WASC-37',\
-    tag:'CAPEC-61',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\

--- a/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
+++ b/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
@@ -40,6 +40,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-fixation',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -60,6 +61,7 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
     tag:'platform-multi',\
     tag:'attack-fixation',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -85,6 +87,7 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
     tag:'platform-multi',\
     tag:'attack-fixation',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\

--- a/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -42,6 +42,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/1',\
     ver:'OWASP_CRS/3.3.0',\
@@ -74,6 +75,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/1',\
     ver:'OWASP_CRS/3.3.0',\
@@ -98,6 +100,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/1',\
     ver:'OWASP_CRS/3.3.0',\
@@ -130,6 +133,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/1',\
     ver:'OWASP_CRS/3.3.0',\
@@ -167,6 +171,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -187,6 +192,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -207,6 +213,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -230,6 +237,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -264,6 +272,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.3.0',\

--- a/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -42,10 +42,6 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/JAVA_INJECTION',\
-    tag:'WASCTC/WASC-31',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/1',\
     ver:'OWASP_CRS/3.3.0',\
@@ -78,10 +74,6 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/JAVA_INJECTION',\
-    tag:'WASCTC/WASC-31',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/1',\
     ver:'OWASP_CRS/3.3.0',\
@@ -106,10 +98,6 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/JAVA_INJECTION',\
-    tag:'WASCTC/WASC-31',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/1',\
     ver:'OWASP_CRS/3.3.0',\
@@ -142,10 +130,6 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/JAVA_INJECTION',\
-    tag:'WASCTC/WASC-31',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/1',\
     ver:'OWASP_CRS/3.3.0',\
@@ -183,10 +167,6 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/JAVA_INJECTION',\
-    tag:'WASCTC/WASC-31',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -207,10 +187,6 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/JAVA_INJECTION',\
-    tag:'WASCTC/WASC-31',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -231,10 +207,6 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/JAVA_INJECTION',\
-    tag:'WASCTC/WASC-31',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -258,10 +230,6 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/JAVA_INJECTION',\
-    tag:'WASCTC/WASC-31',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -296,10 +264,6 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/JAVA_INJECTION',\
-    tag:'WASCTC/WASC-31',\
-    tag:'OWASP_TOP_10/A1',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.3.0',\

--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -40,10 +40,6 @@ SecRule RESPONSE_BODY "@rx (?:<(?:TITLE>Index of.*?<H|title>Index of.*?<h)1>Inde
     tag:'platform-multi',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/INFO_DIRECTORY_LISTING',\
-    tag:'WASCTC/WASC-13',\
-    tag:'OWASP_TOP_10/A6',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -76,10 +72,6 @@ SecRule RESPONSE_BODY "@rx ^#\!\s?/" \
     tag:'platform-multi',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/SOURCE_CODE_CGI',\
-    tag:'WASCTC/WASC-13',\
-    tag:'OWASP_TOP_10/A6',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -109,8 +101,6 @@ SecRule RESPONSE_STATUS "@rx ^5\d{2}$" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-disclosure',\
-    tag:'WASCTC/WASC-13',\
-    tag:'OWASP_TOP_10/A6',\
     tag:'PCI/6.5.6',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\

--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -40,6 +40,7 @@ SecRule RESPONSE_BODY "@rx (?:<(?:TITLE>Index of.*?<H|title>Index of.*?<h)1>Inde
     tag:'platform-multi',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -72,6 +73,7 @@ SecRule RESPONSE_BODY "@rx ^#\!\s?/" \
     tag:'platform-multi',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -52,6 +52,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-msaccess',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -75,6 +76,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-oracle',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -98,6 +100,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-db2',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -121,6 +124,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-emc',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -144,6 +148,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-firebird',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -168,6 +173,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-frontbase',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -191,6 +197,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-hsqldb',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -214,6 +221,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-informix',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -238,6 +246,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-ingres',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -262,6 +271,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-interbase',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -285,6 +295,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-maxdb',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -308,6 +319,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-mssql',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -331,6 +343,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-mysql',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -354,6 +367,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-pgsql',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -377,6 +391,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-sqlite',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -400,6 +415,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-sybase',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -52,9 +52,6 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-msaccess',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
-    tag:'CWE-209',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -78,9 +75,6 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-oracle',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
-    tag:'CWE-209',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -104,9 +98,6 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-db2',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
-    tag:'CWE-209',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -130,9 +121,6 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-emc',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
-    tag:'CWE-209',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -156,9 +144,6 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-firebird',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
-    tag:'CWE-209',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -183,9 +168,6 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-frontbase',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
-    tag:'CWE-209',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -209,9 +191,6 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-hsqldb',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
-    tag:'CWE-209',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -235,9 +214,6 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-informix',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
-    tag:'CWE-209',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -262,9 +238,6 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-ingres',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
-    tag:'CWE-209',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -289,9 +262,6 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-interbase',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
-    tag:'CWE-209',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -315,9 +285,6 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-maxdb',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
-    tag:'CWE-209',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -341,9 +308,6 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-mssql',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
-    tag:'CWE-209',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -367,9 +331,6 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-mysql',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
-    tag:'CWE-209',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -393,9 +354,6 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-pgsql',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
-    tag:'CWE-209',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -419,9 +377,6 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-sqlite',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
-    tag:'CWE-209',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -445,9 +400,6 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'platform-sybase',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
-    tag:'CWE-209',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\

--- a/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
+++ b/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
@@ -35,6 +35,7 @@ SecRule RESPONSE_BODY "@pmFromFile java-code-leakages.data" \
     tag:'platform-multi',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -60,6 +61,7 @@ SecRule RESPONSE_BODY "@pmFromFile java-errors.data" \
     tag:'platform-multi',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\

--- a/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
+++ b/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
@@ -35,10 +35,6 @@ SecRule RESPONSE_BODY "@pmFromFile java-code-leakages.data" \
     tag:'platform-multi',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/SOURCE_CODE_JAVA',\
-    tag:'WASCTC/WASC-13',\
-    tag:'OWASP_TOP_10/A6',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -64,10 +60,6 @@ SecRule RESPONSE_BODY "@pmFromFile java-errors.data" \
     tag:'platform-multi',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/ERRORS_JAVA',\
-    tag:'WASCTC/WASC-13',\
-    tag:'OWASP_TOP_10/A6',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\

--- a/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -35,6 +35,7 @@ SecRule RESPONSE_BODY "@pmFromFile php-errors.data" \
     tag:'platform-multi',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -60,6 +61,7 @@ SecRule RESPONSE_BODY "@rx (?:\b(?:f(?:tp_(?:nb_)?f?(?:ge|pu)t|get(?:s?s|c)|scan
     tag:'platform-multi',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -89,6 +91,7 @@ SecRule RESPONSE_BODY "@rx <\?(?!xml)" \
     tag:'platform-multi',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\

--- a/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -35,10 +35,6 @@ SecRule RESPONSE_BODY "@pmFromFile php-errors.data" \
     tag:'platform-multi',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/ERRORS_PHP',\
-    tag:'WASCTC/WASC-13',\
-    tag:'OWASP_TOP_10/A6',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -64,10 +60,6 @@ SecRule RESPONSE_BODY "@rx (?:\b(?:f(?:tp_(?:nb_)?f?(?:ge|pu)t|get(?:s?s|c)|scan
     tag:'platform-multi',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/SOURCE_CODE_PHP',\
-    tag:'WASCTC/WASC-13',\
-    tag:'OWASP_TOP_10/A6',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -97,10 +89,6 @@ SecRule RESPONSE_BODY "@rx <\?(?!xml)" \
     tag:'platform-multi',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/SOURCE_CODE_PHP',\
-    tag:'WASCTC/WASC-13',\
-    tag:'OWASP_TOP_10/A6',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\

--- a/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+++ b/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
@@ -78,6 +78,7 @@ SecRule RESPONSE_BODY "@rx (?:\b(?:A(?:DODB\.Command\b.{0,100}?\b(?:Application 
     tag:'platform-windows',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -100,6 +101,7 @@ SecRule RESPONSE_STATUS "!@rx ^404$" \
     tag:'platform-windows',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\

--- a/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+++ b/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
@@ -54,8 +54,6 @@ SecRule RESPONSE_BODY "@rx (?:Microsoft OLE DB Provider for SQL Server(?:<\/font
     tag:'platform-windows',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'WASCTC/WASC-13',\
-    tag:'OWASP_TOP_10/A6',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -80,10 +78,6 @@ SecRule RESPONSE_BODY "@rx (?:\b(?:A(?:DODB\.Command\b.{0,100}?\b(?:Application 
     tag:'platform-windows',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/ERRORS_IIS',\
-    tag:'WASCTC/WASC-13',\
-    tag:'OWASP_TOP_10/A6',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
@@ -106,10 +100,6 @@ SecRule RESPONSE_STATUS "!@rx ^404$" \
     tag:'platform-windows',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/LEAKAGE/ERRORS_IIS',\
-    tag:'WASCTC/WASC-13',\
-    tag:'OWASP_TOP_10/A6',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\


### PR DESCRIPTION
This is based on the discussions on slack and the blog post at https://coreruleset.org/20200608/overhauling-the-crs-tags/

It is the 1st of 2 PRs. The 2nd PR will add the new CAPEC tags.