### PR TITLE
Fix FP in 921120 (mv PR from old repo)

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -63,7 +63,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx [\n\r]+(?:get|post|head|options|connect|put|
 # [ References ]
 # http://projects.webappsec.org/HTTP-Response-Splitting
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx [\r\n]\W*?(?:content-(?:type|length)|set-cookie|location):" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx [\r\n]\W*?(?:content-(?:type|length)|set-cookie|location):\s*\w" \
     "id:921120,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921120.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921120.yaml
@@ -1,6 +1,6 @@
 ---
   meta:
-    author: csanders-git
+    author: csanders-git, Franziska Bühler
     description: None
     enabled: true
     name: 921120.yaml
@@ -49,3 +49,22 @@
           version: HTTP/1.1
         output:
           log_contains: id "921120"
+  -
+    test_title: 921120-3
+    desc: "Fix FP issue 1615. Header followed by word chars."
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Proxy-Connection: keep-alive
+            Referer: http
+            User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)
+          method: GET
+          port: 80
+          uri: "/file.jsp?somevar=%0A%0Dlocation:%0A%0D"
+          version: HTTP/1.1
+        output:
+          no_log_contains: id "921120"


### PR DESCRIPTION
This is a PR I copied from the old repo. See https://github.com/SpiderLabs/owasp-modsecurity-crs/pull/1746 for history.

This PR solves issue #1615.
The request headers must now be followed by optional space characters and at least one word character.
In reality, other request header values than word chars are allowed, but we don't want to match the whole request header in this rule. We just want to be sure that at least one word char follows the request header. I thought this is enough.
