### PR TITLE
Make Content-Type case insensitive 920420 (mv PR from old repo)

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -967,7 +967,8 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
     setvar:'tx.content_type=|%{tx.0}|',\
     chain"
     SecRule TX:content_type "!@within %{tx.allowed_request_content_type}" \
-        "setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        "t:lowercase,\
+        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920420.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920420.yaml
@@ -250,5 +250,36 @@
               data: "test"
             output:
               log_contains: "id \"920420\""
-
+    -
+      test_title: 920420-12
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              method: "HEAD"
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: "multipart/related"
+              data: "test"
+            output:
+              no_log_contains: "id \"920420\""
+    -
+      test_title: 920420-13
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              method: "HEAD"
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: "Multipart/Related"
+              data: "test"
+            output:
+              no_log_contains: "id \"920420\""
 


### PR DESCRIPTION
This is a copied PR from the old repo: https://github.com/SpiderLabs/owasp-modsecurity-crs/pull/1740
See old PR for a history.

The CRS Content-Type check is case sensitive. But request headers should be case insensitive.
This PR adds t:lowercase to the rule 920420 that compares the sent Content-Type request header with a list of Content-Types defined in an initialization rule 900220.

This PR also adds a regression test for the new allowed Content-Type multipart/related from a already merged PR https://github.com/SpiderLabs/owasp-modsecurity-crs/pull/1721 and a new regression test with a Content-Type starting with an uppercase letter.