### PR TITLE
Fix FPs on 932200

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -616,15 +616,19 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
     tag:'WASCTC/WASC-31',\
     tag:'OWASP_TOP_10/A1',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.2.0',\
+    ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
-    setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    chain"
+    SecRule MATCHED_VAR "@rx /" "t:none,t:urlDecodeUni,chain"
+    SecRule MATCHED_VAR "@rx \s" "t:none,t:urlDecodeUni,\
+        setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
+        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:932013,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"


### PR DESCRIPTION
Referring to #1818 and from our slack channel
> Ok, I was panicking too much when updated CRS to 3.3.0 RC2 and saw LOTS (I mean really lot) of blocked requests. I had sites which operate normally with argument values like '$randomstring' or 'random$tring' and rule 932200 blocked them. I made specific exceptions and sites are working normally again :) But I would suggest to update it a bit, because every value which contain dollar sign, gets blocked. For example value "pa$sword": https://regex101.com/r/JgZFRi/8 . And this rule needs version updated to OWASP_CRS/3.3.0 (now it's OWASP_CRS/3.2.0). Or this: https://regex101.com/r/JgZFRi/9

this PR adds 2 chains in the rule checking for a whitespace character and a forward slash to complete the match of 932200 regex. This should prevent FPs when the following strings are sent as ARG values:

- `pa$word`
- `Price: $24.99`
- `rando$mstr.in/g`

also, it adds PL1 tag and fixes OWASP_CRS version