### PR TITLE
move 920510 to PL3 to address protocol ossification concerns

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1102,55 +1102,6 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
     SecRule TX:/^header_name_/ "@within %{tx.restricted_headers}" \
         "setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
-#
-# Cache-Control Request Header whitelist
-#
-# -=[ Rule Logic ]=-
-# This rule aims to strictly whitelist the Cache-Control request header
-# values and to blocks all violations. This should be useful to intercept
-# "bad bot" and tools that impersonate a real browser but with wrong request
-# header setup.
-#
-# The regular expression used on this rule tries to match multiple directives
-# in a single value, for example: "max-stale=1, max-age=2". This leads us to
-# use a regular expression that accepts a trailing comma to keep compatibility
-# with all regex engines and not PCRE only. For example: "max-stale=1, max-age=2, "
-#
-# Moreover, this regular expression allows duplicate directives sequence like:
-# "max-stale, max-stale=1, no-cache, no-cache".
-#
-# Standard Cache-Control directives that can be used by the client:
-#   - max-age=<seconds>
-#   - max-stale[=<seconds>]
-#   - min-fresh=<seconds>
-#   - no-cache
-#   - no-store
-#   - no-transform
-#   - only-if-cached
-#
-# References:
-# - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
-# - https://regex101.com/r/CZ0Hxu/22
-#
-SecRule &REQUEST_HEADERS:Cache-Control "@gt 0" "id:920510,\
-    phase:1,\
-    block,\
-    t:none,\
-    msg:'Invalid Cache-Control request header',\
-    logdata:'Invalid Cache-Control value in request found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-multi',\
-    tag:'attack-protocol',\
-    tag:'header-whitelist',\
-    tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.3.0',\
-    severity:'CRITICAL',\
-    chain"
-    SecRule REQUEST_HEADERS:Cache-Control "!@rx ^(?:(?:max-age=[0-9]+|min-fresh=[0-9]+|no-cache|no-store|no-transform|only-if-cached|max-stale(?:=[0-9]+)?)(\s*\,\s*|$)){1,7}$" \
-        "setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
-
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:920013,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:920014,phase:2,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 #
@@ -1433,6 +1384,57 @@ SecRule &REQUEST_HEADERS:x-up-devcap-post-charset "@ge 1" \
     SecRule REQUEST_HEADERS:User-Agent "@rx ^(?i)up" \
         "t:none,\
         setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+
+
+#
+# Cache-Control Request Header whitelist
+#
+# -=[ Rule Logic ]=-
+# This rule aims to strictly whitelist the Cache-Control request header
+# values and to blocks all violations. This should be useful to intercept
+# "bad bot" and tools that impersonate a real browser but with wrong request
+# header setup.
+#
+# The regular expression used on this rule tries to match multiple directives
+# in a single value, for example: "max-stale=1, max-age=2". This leads us to
+# use a regular expression that accepts a trailing comma to keep compatibility
+# with all regex engines and not PCRE only. For example: "max-stale=1, max-age=2, "
+#
+# Moreover, this regular expression allows duplicate directives sequence like:
+# "max-stale, max-stale=1, no-cache, no-cache".
+#
+# Standard Cache-Control directives that can be used by the client:
+#   - max-age=<seconds>
+#   - max-stale[=<seconds>]
+#   - min-fresh=<seconds>
+#   - no-cache
+#   - no-store
+#   - no-transform
+#   - only-if-cached
+#
+# References:
+# - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
+# - https://regex101.com/r/CZ0Hxu/22
+#
+SecRule &REQUEST_HEADERS:Cache-Control "@gt 0" \
+    "id:920510,\
+    phase:1,\
+    block,\
+    t:none,\
+    msg:'Invalid Cache-Control request header',\
+    logdata:'Invalid Cache-Control value in request found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    tag:'header-whitelist',\
+    tag:'paranoia-level/3',\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'CRITICAL',\
+    chain"
+    SecRule REQUEST_HEADERS:Cache-Control "!@rx ^(?:(?:max-age=[0-9]+|min-fresh=[0-9]+|no-cache|no-store|no-transform|only-if-cached|max-stale(?:=[0-9]+)?)(\s*\,\s*|$)){1,7}$" \
+        "setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:920017,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"


### PR DESCRIPTION
Fixes the protocol ossification problems in rule 920510.

For discussion, see the issue #1821.
For more discussion, see the comments on the original feature in #1777.