### PR TITLE
Fill in missing CAPEC tags and also OWASP_CRS along the way

### DIFF
--- a/rules/REQUEST-910-IP-REPUTATION.conf
+++ b/rules/REQUEST-910-IP-REPUTATION.conf
@@ -39,6 +39,7 @@ SecRule TX:DO_REPUT_BLOCK "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain,\
@@ -68,6 +69,7 @@ SecRule TX:HIGH_RISK_COUNTRY_CODES "!@rx ^$" \
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
@@ -122,6 +124,7 @@ SecRule IP:PREVIOUS_RBL_CHECK "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     skipAfter:END-RBL-LOOKUP"
 
@@ -145,6 +148,7 @@ SecRule &TX:block_suspicious_ip "@eq 0" \
     t:none,\
     nolog,\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     chain,\
     skipAfter:END-RBL-CHECK"
@@ -166,6 +170,7 @@ SecRule TX:REAL_IP "@rbl dnsbl.httpbl.org" \
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     setvar:'tx.httpbl_msg=%{tx.0}',\
     chain"
@@ -186,6 +191,7 @@ SecRule TX:block_search_ip "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain,\
@@ -209,6 +215,7 @@ SecRule TX:block_spammer_ip "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain,\
@@ -232,6 +239,7 @@ SecRule TX:block_suspicious_ip "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain,\
@@ -255,6 +263,7 @@ SecRule TX:block_harvester_ip "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain,\

--- a/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
+++ b/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
@@ -36,6 +36,7 @@ SecRule REQUEST_METHOD "!@within %{tx.allowed_methods}" \
     tag:'attack-generic',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
+    tag:'capec/1000/210/272/220/274',\
     tag:'PCI/12.1',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -260,6 +260,8 @@ SecRule &REQUEST_HEADERS:Transfer-Encoding "!@eq 0" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/210/272',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
     chain"
@@ -453,6 +455,8 @@ SecRule REQUEST_URI|REQUEST_BODY "@rx \%u[fF]{2}[0-9a-fA-F]{2}" \
     tag:'platform-windows',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/255/153/267/72',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
@@ -691,6 +695,8 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/210/272',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'NOTICE',\
     chain"
@@ -1094,7 +1100,6 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'PCI/12.1',\
-    tag:'PCI/12.1',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     setvar:'tx.header_name_%{tx.0}=/%{tx.0}/',\
@@ -1316,6 +1321,8 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/2',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/210/272',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
@@ -1430,6 +1437,7 @@ SecRule &REQUEST_HEADERS:Cache-Control "@gt 0" \
     tag:'header-whitelist',\
     tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
+    tag:'capec/1000/210/272',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
@@ -1576,6 +1584,8 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@rx (?:^|[^\\\\])\\\\[cdegh
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/4',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/153/267',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -112,7 +112,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # [ Rule Logic ]
 # These rules look for Carriage Return (CR) %0d and Linefeed (LF) %0a characters,
 # on their own or in combination with header field names.
-# These characters may cause problems if the data is returned in a respones header
+# These characters may cause problems if the data is returned in a response header
 # and interpreted by the client.
 # The rules are similar to rules defending against the HTTP Request Splitting and
 # Request Smuggling rules.
@@ -134,6 +134,7 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@rx [\n\r]" \
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
+    tag:'capec/1000/210/272/220/273',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -162,6 +163,7 @@ SecRule ARGS_NAMES "@rx [\n\r]" \
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
+    tag:'capec/1000/210/272/220/33',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -183,6 +185,7 @@ SecRule ARGS_GET_NAMES|ARGS_GET "@rx [\n\r]+(?:\s|location|refresh|(?:set-)?cook
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
+    tag:'capec/1000/210/272/220/33',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -240,6 +243,8 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'application-multi',\
     tag:'language-ldap',\
     tag:'platform-multi',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/248/136',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -273,6 +278,7 @@ SecRule ARGS_GET "@rx [\n\r]" \
     tag:'attack-protocol',\
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
+    tag:'capec/1000/210/272/220/33',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -315,6 +321,8 @@ SecRule ARGS_NAMES "@rx ." \
     tag:'platform-multi',\
     tag:'attack-protocol',\
     tag:'paranoia-level/3',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/137/15/460',\
     ver:'OWASP_CRS/3.3.0',\
     setvar:'TX.paramcounter_%{MATCHED_VAR_NAME}=+1'"
 

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -581,6 +581,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'attack-rce',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
+    tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -617,9 +618,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-rce',\
     tag:'OWASP_CRS',\
-    tag:'OWASP_CRS/WEB_ATTACK/COMMAND_INJECTION',\
-    tag:'WASCTC/WASC-31',\
-    tag:'OWASP_TOP_10/A1',\
+    tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.2.0',\
     severity:'CRITICAL',\

--- a/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -43,6 +43,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'platform-multi',\
     tag:'attack-rce',\
     tag:'OWASP_CRS',\
+    tag:'capec/1000/152/137/6',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/1',\
     ver:'OWASP_CRS/3.3.0',\
@@ -76,6 +77,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'platform-multi',\
     tag:'attack-rce',\
     tag:'OWASP_CRS',\
+    tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/1',\
     ver:'OWASP_CRS/3.3.0',\
@@ -101,6 +103,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'platform-multi',\
     tag:'attack-rce',\
     tag:'OWASP_CRS',\
+    tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/1',\
     ver:'OWASP_CRS/3.3.0',\
@@ -134,6 +137,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'platform-multi',\
     tag:'attack-rce',\
     tag:'OWASP_CRS',\
+    tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/1',\
     ver:'OWASP_CRS/3.3.0',\
@@ -172,6 +176,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'platform-multi',\
     tag:'attack-rce',\
     tag:'OWASP_CRS',\
+    tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -193,6 +198,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'platform-multi',\
     tag:'attack-rce',\
     tag:'OWASP_CRS',\
+    tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -214,6 +220,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'platform-multi',\
     tag:'attack-rce',\
     tag:'OWASP_CRS',\
+    tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -238,6 +245,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'platform-multi',\
     tag:'attack-rce',\
     tag:'OWASP_CRS',\
+    tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.3.0',\
@@ -273,6 +281,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'platform-multi',\
     tag:'attack-rce',\
     tag:'OWASP_CRS',\
+    tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.3.0',\

--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -107,6 +107,8 @@ SecRule RESPONSE_STATUS "@rx ^5\d{2}$" \
     tag:'attack-disclosure',\
     tag:'PCI/6.5.6',\
     tag:'paranoia-level/2',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\


### PR DESCRIPTION
This closes gaps with the CAPEC tagging and I also found rules without the OWASP_CRS tag along the way. Plus a typo in a comment.