### PR TITLE
Move 932200 to PL2

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,7 @@ Important changes:
 New functionality:
  * Block backup files ending with ~ in filename (Andrea Menin)
  * Detect ffuf vuln scanner (Will Woodson)
+ * Detect Nuclei vuln scanner (azurit)
  * Detect SemrushBot crawler (Christian Folini)
  * Detect WFuzz vuln scanner (azurit)
  * New LDAP injection rule (Christian Folini)

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -589,6 +589,13 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:932013,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:932014,phase:2,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+#
+# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
+#
+
+
 #
 # -=[ Rule 932200 ]=-
 #
@@ -617,7 +624,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-rce',\
-    tag:'paranoia-level/1',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
@@ -627,15 +634,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     SecRule MATCHED_VAR "@rx /" "t:none,t:urlDecodeUni,chain"
     SecRule MATCHED_VAR "@rx \s" "t:none,t:urlDecodeUni,\
         setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
-
-
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:932013,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:932014,phase:2,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
-#
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
-#
-
+        setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:932015,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"


### PR DESCRIPTION
In #1818, Taiki-San reported large FPs on new rule 932200. In #1820, we tightened the rule to be more specific. I tried out the rule and didn't find any FPs myself, although I'm starting to think my setup uses so many exclusions that I can't effectively test for FPs. So, I'm still feeling a bit scared about enabling the rule in PL1 at this point.

I discussed this with my co-leads, and we decided that it's best to put this rule in PL2 for this release, and move it to PL1 for the next release, based on reports from the field. In this way, professional users can already use the rule, while novice/wholesale users will not have potential trouble. We can gain more experience and see how FP-prone it is in a real life scenario.

I'll create an issue for 3.4 so it isn't forgotten.