### PR TITLE
Fixed Nextcloud desktop client sync and IOS Calendar sync

### DIFF
--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -94,6 +94,32 @@ SecRule REQUEST_METHOD "@streq PUT" \
         ctl:ruleRemoveById=930110,\
         ctl:ruleRemoveById=930120"
 
+# Fix for Nextcloud Desktop Client
+SecRule REQUEST_METHOD "@streq PROPFIND" \
+    "id:9003106,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.3.0',\
+    chain"
+    SecRule REQUEST_FILENAME "@contains /remote.php/webdav" \
+        "t:none,\
+        ctl:ruleRemoveById=921110"
+
+# Fix for Nextcloud Desktop Client
+SecRule REQUEST_METHOD "@streq PROPFIND" \
+    "id:9003107,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.3.0',\
+    chain"
+    SecRule REQUEST_FILENAME "@contains /remote.php/dav/files" \
+        "t:none,\
+        ctl:ruleRemoveById=921110"
+
 # Allow the data type 'text/vcard'
 
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
@@ -329,6 +355,31 @@ SecRule REQUEST_METHOD "@streq PUT" \
     SecRule REQUEST_FILENAME "@contains /remote.php/dav/calendars/" \
         "t:none,\
         ctl:ruleRemoveById=200002"
+
+# Fix for iOS Calender not syncing
+SecRule REQUEST_METHOD "@streq PROPFIND" \
+    "id:9003332,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.3.0',\
+    chain"
+    SecRule REQUEST_FILENAME "@contains /remote.php/dav/principals/users/" \
+        "t:none,\
+        ctl:ruleRemoveById=921110"
+
+SecRule REQUEST_METHOD "@streq PROPFIND" \
+    "id:9003333,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.3.0',\
+    chain"
+    SecRule REQUEST_FILENAME "@contains /remote.php/dav/calendars/" \
+        "t:none,\
+        ctl:ruleRemoveById=921110"
 
 
 # [ Notes ]

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942230.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942230.yaml
@@ -165,4 +165,3 @@
           version: HTTP/1.0
         output:
           log_contains: id "942230"
-


### PR DESCRIPTION
Added new rules to fix the Nextcloud Desktop client sync being blocked as well as the iOS calendar sync (when adding calendar using caldav).