### PR TITLE
Added new nextcloud excludes for the "Security & setup warnings" test and session tokens

### DIFF
--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -467,11 +467,26 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/settings/users" \
 
 # This removes checks on multiple settings pages
 
+# Personal: Security
+
+# Fixes deltion of auth tokens
+SecRule REQUEST_METHOD "@streq DELETE" \
+    "id:9003601,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.3.0',\
+    chain"
+    SecRule REQUEST_FILENAME "@contains /settings/personal/authtokens/" \
+        "t:none,\
+        ctl:ruleRemoveById=911100"
+
 # Administration: Overview
 
-# Fixes "Security & setup warnings" test
+# Fixed "Security & setup warnings" test
 SecRule REQUEST_METHOD "@streq PROPFIND" \
-    "id:9003601,\
+    "id:9003602,\
     phase:2,\
     pass,\
     t:none,\
@@ -483,7 +498,7 @@ SecRule REQUEST_METHOD "@streq PROPFIND" \
         ctl:ruleRemoveById=911100"
 
 SecRule REQUEST_METHOD "@streq PROPFIND" \
-    "id:9003602,\
+    "id:9003603,\
     phase:2,\
     pass,\
     t:none,\

--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -461,6 +461,40 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/settings/users" \
     ver:'OWASP_CRS/3.3.0'"
 
 
+#
+# [ Settings pages ]
+#
+
+# This removes checks on multiple settings pages
+
+# Administration: Overview
+
+# Fixes "Security & setup warnings" test
+SecRule REQUEST_METHOD "@streq PROPFIND" \
+    "id:9003601,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.3.0',\
+    chain"
+    SecRule REQUEST_FILENAME "@streq /.well-known/caldav" \
+        "t:none,\
+        ctl:ruleRemoveById=911100"
+
+SecRule REQUEST_METHOD "@streq PROPFIND" \
+    "id:9003602,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.3.0',\
+    chain"
+    SecRule REQUEST_FILENAME "@streq /.well-known/carddav" \
+        "t:none,\
+        ctl:ruleRemoveById=911100"
+
+
 SecMarker "END-NEXTCLOUD-ADMIN"
 
 SecMarker "END-NEXTCLOUD"

--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -510,6 +510,25 @@ SecRule REQUEST_METHOD "@streq PROPFIND" \
         ctl:ruleRemoveById=911100"
 
 
+#
+# [ Notifications ]
+#
+# NexCloud uses notifictions to inform the user of important new details.
+
+# Allows notifications to be deleted
+SecRule REQUEST_METHOD "@streq DELETE" \
+    "id:9003701,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.3.0',\
+    chain"
+    SecRule REQUEST_FILENAME "@contains /ocs/v2.php/apps/notifications/api/v2/notifications" \
+        "t:none,\
+        ctl:ruleRemoveById=911100"
+
+
 SecMarker "END-NEXTCLOUD-ADMIN"
 
 SecMarker "END-NEXTCLOUD"

--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -493,7 +493,7 @@ SecRule REQUEST_METHOD "@streq PROPFIND" \
     nolog,\
     ver:'OWASP_CRS/3.3.0',\
     chain"
-    SecRule REQUEST_FILENAME "@streq /.well-known/caldav" \
+    SecRule REQUEST_FILENAME "@contains /.well-known/caldav" \
         "t:none,\
         ctl:ruleRemoveById=911100"
 
@@ -505,7 +505,7 @@ SecRule REQUEST_METHOD "@streq PROPFIND" \
     nolog,\
     ver:'OWASP_CRS/3.3.0',\
     chain"
-    SecRule REQUEST_FILENAME "@streq /.well-known/carddav" \
+    SecRule REQUEST_FILENAME "@contains /.well-known/carddav" \
         "t:none,\
         ctl:ruleRemoveById=911100"
 


### PR DESCRIPTION
This fixes the "Security & setup warnings" test in the overview section of the nextcloud administrator settings. This also fixes the security session revocation being blocked. And the deletion of notifications.