### PR TITLE
XenForo: exclude login field

### DIFF
--- a/rules/REQUEST-903.9006-XENFORO-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9006-XENFORO-EXCLUSION-RULES.conf
@@ -252,6 +252,7 @@ SecRule REQUEST_FILENAME "@endsWith /login/login" \
     pass,\
     t:none,\
     nolog,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:login,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password,\
     ver:'OWASP_CRS/3.3.0'"
 


### PR DESCRIPTION
People use complex login names, which is acceptable to XenForo but not yet to us.