### PR TITLE
Suppress rule 200002 when Nextcloud mobile app accesses shares through API

### DIFF
--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -516,6 +516,19 @@ SecRule REQUEST_FILENAME "@contains /ocs/v2.php/apps/notifications/api/v2/notifi
     setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
 
 
+# [ API ]
+#
+# Allow access to the shares API URL from mobile app
+
+SecRule REQUEST_FILENAME "@contains /ocs/v2.php/apps/files_sharing/api/v1/shares" \
+    "id:9003600,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveById=200002"
+
+
 SecMarker "END-NEXTCLOUD-ADMIN"
 
 SecMarker "END-NEXTCLOUD"

--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -521,12 +521,15 @@ SecRule REQUEST_FILENAME "@contains /ocs/v2.php/apps/notifications/api/v2/notifi
 # Allow access to the shares API URL from mobile app
 
 SecRule REQUEST_FILENAME "@contains /ocs/v2.php/apps/files_sharing/api/v1/shares" \
-    "id:9003600,\
+    "id:9003800,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveById=200002"
+    chain"
+    SecRule REQUEST_METHOD "@streq GET" \
+        "t:none,\
+        ctl:ruleRemoveById=200002"
 
 
 SecMarker "END-NEXTCLOUD-ADMIN"


### PR DESCRIPTION
## Issue

When you open Nextcloud iOS app (v3.0.1) it sends the following request:

```
GET /ocs/v2.php/apps/files_sharing/api/v1/shares?reshares=false&subfiles=false HTTP/2.0
content-type: application/xml
```

Again this triggers rule ID 200002 ("XML parsing error: XML: Failed parsing document.") as there is no body in the `GET` request.

## Reproduction

Open the Nextcloud iOS mobile app and you can see the rejected request:

![IMG_9495](https://user-images.githubusercontent.com/1058704/87176967-63b1cb00-c2ca-11ea-91db-56f1bbc1328d.PNG)

## Fix

This PR disables 200002 for the aforementioned URL path.