### PR TITLE
Permit "version" string in content-type header

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -911,8 +911,9 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
 # - text/plain
 # - text/plain; charset="UTF-8"
 # - multipart/form-data; boundary=----WebKitFormBoundary12345
+# - text/vcard;version=4.0
 #
-SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+-]+(?:\s?;\s?(?:action|boundary|charset|type|start(?:-info)?)\s?=\s?['\"\w.()+,/:=?<>@-]+)*$" \
+SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+-]+(?:\s?;\s?(?:action|boundary|charset|version|type|start(?:-info)?)\s?=\s?['\"\w.()+,/:=?<>@-]+)*$" \
     "id:920470,\
     phase:1,\
     block,\


### PR DESCRIPTION
Content such as ext/vcard;version=4.0 flags and is blocked by the
default CRS.
Permit version string in content-type header.

Tested on NextCloud 19 with modsecurity 2.9.x