### PR TITLE
Remove unneeded transformation from MATCHED_VARS

### DIFF
--- a/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -110,8 +110,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VARS "@rx (?:runtime|processbuilder)" \
-        "t:none,t:lowercase,\
-        setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+        "setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # This rule is also triggered by the following exploit(s):


### PR DESCRIPTION
The outer rule had t:lowercase already.