### PR TITLE
Migrate PR: RE2 compatibility for 920120

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -90,12 +90,12 @@ SecRule REQUEST_LINE "!@rx ^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+
 #                ['\";=] : ' " ; = meta-characters
 #
 # -=[ References ]=-
-# https://www.owasp.org/index.php/ModSecurity_CRS_RuleID-960000
+# https://www.owasp.org/index.php/ModSecurity_CRS_RuleID-96000
 # http://www.ietf.org/rfc/rfc2183.txt
 #
-# The regular expression in the rule 920120 is not RE2 compatible.
-# If you are using a non-PCRE engine, replace the regex in the rule with this regex.
-# Remove line breaks and backslashes:
+# The regular expression in the active rule 920120 demands a PCRE-compatible
+# regular expression engine. If you are using a non-PCRE engine, replace the regex
+# in the rule with the following regex (remove line breaks and backslashes):
 #
 # (?:(?:^|[^lceps])|(?:^|[^mi])l|(?:^|[^r])c|(?:^|[^tvd])e|(?:^|[^m])p|(?:^|[^o])s|\
 # (?:^|[^u])ml|(?:^|[^i])rc|(?:^|[^u])te|(?:^|[^a])ve|(?:^|[^d])il|(?:^|[^l])de|\
@@ -107,19 +107,27 @@ SecRule REQUEST_LINE "!@rx ^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+
 # (?:^|[^aAnNoO])tilde|(?:^|[^&])[eEiIoOuUyY]acute|(?:^|[^&])[aAeEiIoOuU]grave|\
 # (?:^|[^&])[cC]cedil|(?:^|[^&])[aAnNoO]tilde);|['\"=]
 #
-# To be compatible with non-PCRE regex engines, negative lookbehinds are
-# avoided. Instead the script in util/regexp-negativelookbehind was used to
+# In this regex, negative lookbehinds are avoided to be compatible with non-PCRE
+# regex engines. Instead the script in util/regexp-negativelookbehind was used to
 # generate an alternative equivalent regex:
-# To rebuild the regexp:
+# To rebuild the alternative regexp:
 #   cd util/regexp-negativelookbehind
 #     ./negativelookbehind.py negativelookbehind-920120.data
 #
 # Note that an ;|['\"=] is added at the end of the output of the script:
 #   "@rx SCRIPT_OUTPUT;|['\"=]"
 #
-# Caution: Large files can potentially lead to a DoS with this RE2 compatible regex. 
+# This alternative regex is not the default one, since it comes with a severe
+# performance impact, namely for larger files.
 #
-# As mentioned above, the following regex in the rule is not supported by RE2 (?<!re).
+# Caution: The performance impact of the alternative regex can lead to
+# a DoS for larger files.
+#
+# Please see https://coreruleset.org/20210106/introducing-msc_retest/ for
+# a thorough discussion and detailed performance data.
+#
+# The regex in the following enabled rule is not supported by non-PCRE
+# regular expression engines (?<!re).
 #
  SecRule FILES_NAMES|FILES "@rx (?<!&(?:[aAoOuUyY]uml)|&(?:[aAeEiIoOuU]circ)|&(?:[eEiIoOuUyY]acute)|&(?:[aAeEiIoOuU]grave)|&(?:[cC]cedil)|&(?:[aAnNoO]tilde)|&(?:amp)|&(?:apos));|['\"=]" \
     "id:920120,\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -77,7 +77,7 @@ SecRule REQUEST_LINE "!@rx ^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+
 # These rules check for the existence of the ' " ; = meta-characters in
 # either the file or file name variables.
 # HTML entities may lead to false positives, why they are allowed on PL1.
-# Negative look behind assertions allow frequently used entities &_;
+# Frequently used HTML entities such as &auml; are allowed.
 #
 # -=[ Targets, characters and html entities ]=-
 #
@@ -89,13 +89,21 @@ SecRule REQUEST_LINE "!@rx ^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+
 # 920121: PL2 : FILES_NAMES, FILES
 #                ['\";=] : ' " ; = meta-characters
 #
-# Not supported by re2 (?<!re).
-#
 # -=[ References ]=-
 # https://www.owasp.org/index.php/ModSecurity_CRS_RuleID-960000
 # http://www.ietf.org/rfc/rfc2183.txt
 #
-SecRule FILES_NAMES|FILES "@rx (?<!&(?:[aAoOuUyY]uml)|&(?:[aAeEiIoOuU]circ)|&(?:[eEiIoOuUyY]acute)|&(?:[aAeEiIoOuU]grave)|&(?:[cC]cedil)|&(?:[aAnNoO]tilde)|&(?:amp)|&(?:apos));|['\"=]" \
+# To be compatible with non-PCRE regex engines, negative lookbehinds are
+# avoided. Instead the script in util/regexp-negativelookbehind was used to
+# generate an alternative equivalent regex:
+# To rebuild the regexp:
+#   cd util/regexp-negativelookbehind
+#     ./negativelookbehind.py negativelookbehind-920120.data
+#
+# Note that an ;|['\"=] is added at the end of the output of the script:
+#   "@rx SCRIPT_OUTPUT;|['\"=]"
+#
+ SecRule FILES_NAMES|FILES "@rx (?:(?:^|[^lceps])|(?:^|[^mi])l|(?:^|[^r])c|(?:^|[^tvd])e|(?:^|[^m])p|(?:^|[^o])s|(?:^|[^u])ml|(?:^|[^i])rc|(?:^|[^u])te|(?:^|[^a])ve|(?:^|[^d])il|(?:^|[^l])de|(?:^|[^a])mp|(?:^|[^p])os|(?:^|[^aAoOuUyY])uml|(?:^|[^c])irc|(?:^|[^c])ute|(?:^|[^r])ave|(?:^|[^e])dil|(?:^|[^i])lde|(?:^|[^&])amp|(?:^|[^a])pos|(?:^|[^&])[aAoOuUyY]uml|(?:^|[^aAeEiIoOuU])circ|(?:^|[^a])cute|(?:^|[^g])rave|(?:^|[^c])edil|(?:^|[^t])ilde|(?:^|[^&])apos|(?:^|[^&])[aAeEiIoOuU]circ|(?:^|[^eEiIoOuUyY])acute|(?:^|[^aAeEiIoOuU])grave|(?:^|[^cC])cedil|(?:^|[^aAnNoO])tilde|(?:^|[^&])[eEiIoOuUyY]acute|(?:^|[^&])[aAeEiIoOuU]grave|(?:^|[^&])[cC]cedil|(?:^|[^&])[aAnNoO]tilde);|['\"=]" \
     "id:920120,\
     phase:2,\
     block,\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -93,6 +93,20 @@ SecRule REQUEST_LINE "!@rx ^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+
 # https://www.owasp.org/index.php/ModSecurity_CRS_RuleID-960000
 # http://www.ietf.org/rfc/rfc2183.txt
 #
+# The regular expression in the rule 920120 is not RE2 compatible.
+# If you are using a non-PCRE engine, replace the regex in the rule with this regex.
+# Remove line breaks and backslashes:
+#
+# (?:(?:^|[^lceps])|(?:^|[^mi])l|(?:^|[^r])c|(?:^|[^tvd])e|(?:^|[^m])p|(?:^|[^o])s|\
+# (?:^|[^u])ml|(?:^|[^i])rc|(?:^|[^u])te|(?:^|[^a])ve|(?:^|[^d])il|(?:^|[^l])de|\
+# (?:^|[^a])mp|(?:^|[^p])os|(?:^|[^aAoOuUyY])uml|(?:^|[^c])irc|(?:^|[^c])ute|\
+# (?:^|[^r])ave|(?:^|[^e])dil|(?:^|[^i])lde|(?:^|[^&])amp|(?:^|[^a])pos|\
+# (?:^|[^&])[aAoOuUyY]uml|(?:^|[^aAeEiIoOuU])circ|(?:^|[^a])cute|(?:^|[^g])rave|\
+# (?:^|[^c])edil|(?:^|[^t])ilde|(?:^|[^&])apos|(?:^|[^&])[aAeEiIoOuU]circ|\
+# (?:^|[^eEiIoOuUyY])acute|(?:^|[^aAeEiIoOuU])grave|(?:^|[^cC])cedil|\
+# (?:^|[^aAnNoO])tilde|(?:^|[^&])[eEiIoOuUyY]acute|(?:^|[^&])[aAeEiIoOuU]grave|\
+# (?:^|[^&])[cC]cedil|(?:^|[^&])[aAnNoO]tilde);|['\"=]
+#
 # To be compatible with non-PCRE regex engines, negative lookbehinds are
 # avoided. Instead the script in util/regexp-negativelookbehind was used to
 # generate an alternative equivalent regex:
@@ -103,7 +117,11 @@ SecRule REQUEST_LINE "!@rx ^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+
 # Note that an ;|['\"=] is added at the end of the output of the script:
 #   "@rx SCRIPT_OUTPUT;|['\"=]"
 #
- SecRule FILES_NAMES|FILES "@rx (?:(?:^|[^lceps])|(?:^|[^mi])l|(?:^|[^r])c|(?:^|[^tvd])e|(?:^|[^m])p|(?:^|[^o])s|(?:^|[^u])ml|(?:^|[^i])rc|(?:^|[^u])te|(?:^|[^a])ve|(?:^|[^d])il|(?:^|[^l])de|(?:^|[^a])mp|(?:^|[^p])os|(?:^|[^aAoOuUyY])uml|(?:^|[^c])irc|(?:^|[^c])ute|(?:^|[^r])ave|(?:^|[^e])dil|(?:^|[^i])lde|(?:^|[^&])amp|(?:^|[^a])pos|(?:^|[^&])[aAoOuUyY]uml|(?:^|[^aAeEiIoOuU])circ|(?:^|[^a])cute|(?:^|[^g])rave|(?:^|[^c])edil|(?:^|[^t])ilde|(?:^|[^&])apos|(?:^|[^&])[aAeEiIoOuU]circ|(?:^|[^eEiIoOuUyY])acute|(?:^|[^aAeEiIoOuU])grave|(?:^|[^cC])cedil|(?:^|[^aAnNoO])tilde|(?:^|[^&])[eEiIoOuUyY]acute|(?:^|[^&])[aAeEiIoOuU]grave|(?:^|[^&])[cC]cedil|(?:^|[^&])[aAnNoO]tilde);|['\"=]" \
+# Caution: Large files can potentially lead to a DoS with this RE2 compatible regex. 
+#
+# As mentioned above, the following regex in the rule is not supported by RE2 (?<!re).
+#
+ SecRule FILES_NAMES|FILES "@rx (?<!&(?:[aAoOuUyY]uml)|&(?:[aAeEiIoOuU]circ)|&(?:[eEiIoOuUyY]acute)|&(?:[aAeEiIoOuU]grave)|&(?:[cC]cedil)|&(?:[aAnNoO]tilde)|&(?:amp)|&(?:apos));|['\"=]" \
     "id:920120,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920120.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920120.yaml
@@ -109,3 +109,435 @@
             - '-----------------------------265001916915724--'
           output:
             log_contains: id "920120"
+    -
+      test_title: 920120-4
+      desc: Attempted multipart/form-data bypass (920120). Negative test.
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="file"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            no_log_contains: id "920120"
+    -
+      test_title: 920120-5
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name=";zzzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-6
+      desc: Attempted multipart/form-data bypass (920120). Negative test.
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="zzz&amp;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            no_log_contains: id "920120"
+    -
+      test_title: 920120-7
+      desc: Attempted multipart/form-data bypass (920120). Negative test.
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="zzz&Auml;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            no_log_contains: id "920120"
+    -
+      test_title: 920120-8
+      desc: Attempted multipart/form-data bypass (920120). Negative test.
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="zzz&auml;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            no_log_contains: id "920120"
+    -
+      test_title: 920120-9
+      desc: Attempted multipart/form-data bypass (920120). Negative test.
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="&amp;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            no_log_contains: id "920120"
+    -
+      test_title: 920120-10
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="amp;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-11
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="mp;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-12
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="p;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-13
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="Zamp;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-14
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="Zmp;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-15
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="Zp;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-16
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="Z;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-17
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="ZZZamp;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-18
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="ZZZmp;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-19
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="ZZZp;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-20
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="ZZZ;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"
+    -
+      test_title: 920120-21
+      desc: Attempted multipart/form-data bypass (920120).
+      stages:
+      -
+        stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Host: "localhost"
+              Content-Type: multipart/form-data; boundary=---------------------------265001916915724
+            method: POST
+            port: 80
+            uri: /
+            data:
+            - '-----------------------------265001916915724'
+            - 'Content-Disposition: form-data; name="mZ;zzz"; filename="test"'
+            - 'Content-Type: application/octet-stream'
+            - ''
+            - 'helloworld'
+            - '-----------------------------265001916915724--'
+          output:
+            log_contains: id "920120"

--- a/util/regexp-negativelookbehind/negativelookbehind-920120.data
+++ b/util/regexp-negativelookbehind/negativelookbehind-920120.data
@@ -1,0 +1,8 @@
+&[aAoOuUyY]uml
+&[aAeEiIoOuU]circ
+&[eEiIoOuUyY]acute
+&[aAeEiIoOuU]grave
+&[cC]cedil
+&[aAnNoO]tilde
+&amp
+&apos

--- a/util/regexp-negativelookbehind/negativelookbehind.py
+++ b/util/regexp-negativelookbehind/negativelookbehind.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+
+import fileinput
+
+#
+# This script generates regular expressions that behave like negative lookbehinds without using negative lookbehinds.
+# For example an alternative to "(?<!a[bB]c|1234)" would be "(?:(?:^|[^c4])|(?:^|[^bB])c|(?:^|[^3])4|(?:^|[^a])[bB]c|(?:^|[^2])34|(?:^|[^1])234)".
+# More explanation here: http://allanrbo.blogspot.com/2020/01/alternative-to-negative-lookbehinds-in.html
+#
+# Input (stdin or arg): a file where each line corresponds to an alternative-group in a negative lookbehind.
+#   Example to generate a regex equivalent to "(?<!a[bB]c|1234)":
+#     a[bB]c
+#     1234
+# Output: A regular expression corresponding to the negative lookbehind.
+#
+
+
+# Process lines from input file, or if not specified, standard input
+negativePrefixes = []
+for line in fileinput.input():
+    line = line.rstrip()
+    if line != "":
+      negativePrefixes.append(line)
+
+def removeDuplicateChars(s):
+  return "".join([c for i,c in enumerate(s) if c not in s[:i]])
+
+def removeChars(s, charsToRemove):
+  return "".join([c for i,c in enumerate(s) if c not in charsToRemove])
+
+# Split into arrays of strings. Each string is either a single char, or a char class.
+negativePrefixesSplit = []
+for np in negativePrefixes:
+  npSplit = []
+  curCc = ""
+  inCc = False
+  for c in np:
+    if c == "[":
+      inCc = True
+    elif c == "]":
+      npSplit.append(removeDuplicateChars(curCc))
+      curCc = ""
+      inCc = False
+    else:
+      if inCc:  
+        if c in "-\\":
+          raise "Only really simply char classes are currently supported. No ranges or escapes, sorry."
+        curCc += c
+      else:
+        npSplit.append(c)
+  negativePrefixesSplit.append(npSplit)
+
+allexprs = []
+
+class Expr():
+  pass
+
+suffixLength = 0
+while True:
+  suffixes = []
+  for np in negativePrefixesSplit:
+    if suffixLength < len(np):
+      suffixes.append(np[len(np)-suffixLength-1:])
+
+  if len(suffixes) == 0:
+    break
+
+  exprs = []
+  for suffix in suffixes:
+    curChar = suffix[0]
+    remainder = suffix[1:]
+    expr = Expr()
+    expr.curChar = curChar
+    expr.remainder = remainder
+    exprs.append(expr)
+
+  # Is the remainder a subset of any other suffixes remainders?
+  for i in range(len(exprs)):
+    e1 = exprs[i]
+    for j in range(len(exprs)):
+      e2 = exprs[j]
+      isSubset = True
+      for k in range(len(e1.remainder)):
+        if not set(e1.remainder[k]).issubset(set(e2.remainder[k])):
+          isSubset = False
+          break
+      if isSubset:
+        if e1.curChar == e2.curChar:
+          e1.remainder = e2.remainder
+          continue
+
+        e1.curChar += e2.curChar
+        e1.curChar = removeDuplicateChars(e1.curChar)
+        for k in range(len(e1.remainder)):
+          if len(set(e2.remainder[k]) - set(e1.remainder[k])) > 0:
+            charsInCommon = "".join(set(e2.remainder[k]) & set(e1.remainder[k]))
+            e2.remainder[k] = removeChars(e2.remainder[k], charsInCommon)
+
+  # Remove duplicate expressions
+  exprsFiltered = []
+  for i in range(len(exprs)):
+    e1 = exprs[i]
+    alreadyExists = False
+    for j in range(len(exprs)):
+      if i == j:
+        break
+
+      e2 = exprs[j]
+
+      sameC = set(e1.curChar) == set(e2.curChar)
+      sameR = True
+      for k in range(len(e1.remainder)):
+        if set(e1.remainder[k]) != set(e2.remainder[k]):
+          sameR = False
+          break
+      if sameC and sameR:
+        alreadyExists = True
+        break
+
+    if not alreadyExists:
+      exprsFiltered.append(e1)
+
+  allexprs.extend(exprsFiltered)
+
+  suffixLength += 1
+  continue
+
+out = "(?:\n"
+for i in range(len(allexprs)):
+  e = allexprs[i]
+  out += ("(?:^|[^" + e.curChar + "])")
+  for c in e.remainder:
+    if len(c) > 1:
+      out += "[" + c + "]"
+    else:
+      out += c
+  if i != len(allexprs)-1:
+    out += "|"
+  out += "\n"
+out += ")"
+
+print("Human readable:")
+print(out)
+print()
+print("Single line:")
+print(out.replace("\n",""))


### PR DESCRIPTION
This PR migrates the PR https://github.com/SpiderLabs/owasp-modsecurity-crs/pull/1663 by @allanrbo to our new repo.
There was a lot of discussion in the old PR (see link above). Especially in terms of performance. @fgsch and @dune73 were involved.

Since this PR is an optimization in relation to the regex (negative looks are avoided), I think it makes sense to migrate this PR and pursue it further. And that is only possible if we also have the PR in this new repo.

Next steps would be, as also mentioned in the old PR:
* Testing the rule in prod: performance
* Testing the rule in prod: coverage 