### PR TITLE
Fix FP in Postgres SQL Information Leakage Rule 951240

### DIFF
--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -388,7 +388,7 @@ SecRule TX:sql_error_match "@eq 1" \
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
-    SecRule RESPONSE_BODY "@rx (?i:PostgreSQL query failed:|pg_query\(\) \[:|pg_exec\(\) \[:|PostgreSQL.*ERROR|Warning.*pg_.*|valid PostgreSQL result|Npgsql\.|PG::[a-zA-Z]*Error|Supplied argument is not a valid PostgreSQL .*? resource|Unable to connect to PostgreSQL server)" \
+    SecRule RESPONSE_BODY "@rx (?i:PostgreSQL query failed:|pg_query\(\) \[:|pg_exec\(\) \[:|PostgreSQL.*ERROR|Warning.*\bpg_.*|valid PostgreSQL result|Npgsql\.|PG::[a-zA-Z]*Error|Supplied argument is not a valid PostgreSQL .*? resource|Unable to connect to PostgreSQL server)" \
         "capture,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\


### PR DESCRIPTION
This PR (probably) resolves the FP reported in #1468 by adding a word boundary in front of `pg_`

Old regex: `|Warning.*pg_.*|`
New regex: `|Warning.*\bpg_.*|`