### PR TITLE
 Eliminate FPs in 941120 by applying character limit to regex

### DIFF
--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -92,7 +92,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
 # The shortest known event is "onget". The longest known event is "onmozorientationchange"
 # with 23 chars after the prefix. 25 chars adds a little bit of safety.
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Refer er|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\"'`;\/0-9=\x0B\x09\x0C\x3B\x2C\x28\x3B]on[a-zA-Z]{3,25}[\s\x0B\x09\x0C\x3B\x2C\x2 8\x3B]*?=" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\"'`;\/0-9=\x0B\x09\x0C\x3B\x2C\x28\x3B]on[a-zA-Z]{3,25}[\s\x0B\x09\x0C\x3B\x2C\x28\x3B]*?=" \
     "id:941120,\
     phase:2,\
     block,\

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -86,7 +86,13 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
 # -=[ XSS Filters - Category 2 ]=-
 # XSS vectors making use of event handlers like onerror, onload etc, e.g., <body onload="alert(1)">
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\"'`;/0-9=\x0B\x09\x0C\x3B\x2C\x28\x3B]on[a-zA-Z]+[\s\x0B\x09\x0C\x3B\x2C\x28\x3B]*?=" \
+# We are not listing all the known event handlers like rule 941160, but we
+# limit the alerts to keywords of 3-25 characters after the prefix ("on").
+#
+# The shortest known event is "onget". The longest known event is "onmozorientationchange"
+# with 23 chars after the prefix. 25 chars adds a little bit of safety.
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Refer er|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\"'`;\/0-9=\x0B\x09\x0C\x3B\x2C\x28\x3B]on[a-zA-Z]{3,25}[\s\x0B\x09\x0C\x3B\x2C\x2 8\x3B]*?=" \    
     "id:941120,\
     phase:2,\
     block,\

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -92,7 +92,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
 # The shortest known event is "onget". The longest known event is "onmozorientationchange"
 # with 23 chars after the prefix. 25 chars adds a little bit of safety.
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Refer er|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\"'`;\/0-9=\x0B\x09\x0C\x3B\x2C\x28\x3B]on[a-zA-Z]{3,25}[\s\x0B\x09\x0C\x3B\x2C\x2 8\x3B]*?=" \    
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Refer er|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\"'`;\/0-9=\x0B\x09\x0C\x3B\x2C\x28\x3B]on[a-zA-Z]{3,25}[\s\x0B\x09\x0C\x3B\x2C\x2 8\x3B]*?=" \
     "id:941120,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941120.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941120.yaml
@@ -18,7 +18,54 @@
           method: POST
           port: 80
           uri: "/?%20%20onload%3d%20=vardata"
-          #data: "%20%20onload%3d%20=vardata"
           version: HTTP/1.0
         output:
           log_contains: id "941120"
+  -
+    test_title: 941120-2
+    desc: "XSS Filter - Category 2: Event Handler Vector"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: POST
+          port: 80
+          uri: "/?%20%20onabcdefgh%3d%20=vardata"
+          version: HTTP/1.0
+        output:
+          log_contains: id "941120"
+  -
+    test_title: 941120-3
+    desc: "XSS Filter - Category 2: Event Handler Vector"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: POST
+          port: 80
+          uri: "/?%20%20onab%3d%20=vardata"
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "941120"
+  -
+    test_title: 941120-4
+    desc: "XSS Filter - Category 2: Event Handler Vector"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: POST
+          port: 80
+          uri: "/?%20%20onabcdefghijklmnopqrstuvwxyz%3d%20=vardata"
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "941120"


### PR DESCRIPTION
This solves a part of the problem of #1828 by adding a character limit to the regex.

Before:
[a-zA-Z]+

After
[a-zA-Z]{3,25}

Also adding 3 tests.