### PR TITLE
Permit "version" string in content-type header, rebased to 3.4 + test

### DIFF
--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -471,6 +471,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
             ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:data[wp_autosave][post_title],\
+            ctl:ruleRemoveTargetByTag=attack-xss;ARGS:data[wp_autosave][post_title],\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:data[wp_autosave][content],\
             ctl:ruleRemoveTargetById=942431;ARGS_NAMES:data[wp-refresh-post-lock][post_id],\
             ctl:ruleRemoveTargetById=942431;ARGS_NAMES:data[wp-refresh-post-lock][lock],\
@@ -601,7 +602,8 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
         chain"
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
-            ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:new_title"
+            ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:new_title,\
+            ctl:ruleRemoveTargetByTag=attack-xss;ARGS:new_title"
 
 # Add external link to menu
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -913,7 +913,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
 # - multipart/form-data; boundary=----WebKitFormBoundary12345
 # - application/soap+xml; charset=utf-8; action="urn:localhost-hwh#getQuestions"
 #
-SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+-]+(?:\s?;\s?(?:action|boundary|charset|type|start(?:-info)?)\s?=\s?['\"\w.()+,/:=?<>@#-]+)*$" \
+SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+-]+(?:\s?;\s?(?:action|boundary|charset|start(?:-info)?|type|version)\s?=\s?['\"\w.()+,/:=?<>@#-]+)*$" \
     "id:920470,\
     phase:1,\
     block,\

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920470.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920470.yaml
@@ -211,3 +211,17 @@
                   Content-Length: 0
             output:
               no_log_contains: "id \"920470\""
+    - test_title: 920470-16
+      stages:
+        - stage:
+            input:
+              dest_addr: 127.0.0.1
+              port: 80
+              method: POST
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: 'ext/vcard;version=4.0'
+                  Content-Length: 0
+            output:
+              no_log_contains: "id \"920470\""


### PR DESCRIPTION
PR #1848 by @sempervictus rebased to 3.4.