### PR TITLE
Fix FP while creating/editing a post in vanilla WordPress

### DIFF
--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -470,6 +470,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
         chain"
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
+            ctl:ruleRemoveTargetByTag=attack-xss;ARGS:data[wp_autosave][post_title],\
             ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:data[wp_autosave][post_title],\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:data[wp_autosave][content],\
             ctl:ruleRemoveTargetById=942431;ARGS_NAMES:data[wp-refresh-post-lock][post_id],\
@@ -601,6 +602,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
         chain"
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
+            ctl:ruleRemoveTargetByTag=attack-xss;ARGS:new_title,\
             ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:new_title"
 
 # Add external link to menu

--- a/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------
 # OWASP ModSecurity Core Rule Set ver.3.4.0
-# Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
+# Copyright (c) 2006-2020 Trustwave and contributors. (not) All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
 # Apache Software License (ASL) version 2
@@ -30,6 +30,28 @@ SecRule &TX:crs_exclusions_phpbb|TX:crs_exclusions_phpbb "@eq 0" \
     skipAfter:END-PHPBB"
 
 # Login, registration and password change
+#SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
+#    "id:9007100,\
+#    phase:2,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    ver:'OWASP_CRS/3.4.0',\
+#    chain"
+#    SecRule ARGS:mode "@rx ^(?:login|register|reg_details)$" \
+#        "t:none,\
+#        chain"
+#        SecRule &ARGS:mode "@eq 1" \
+#            "t:none,\
+#            ctl:ruleRemoveTargetById=941100;ARGS:redirect,\
+#            ctl:ruleRemoveTargetById=930100;ARGS:redirect,\
+#            ctl:ruleRemoveTargetById=930110;ARGS:redirect,\
+#            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:new_password,\
+#            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:cur_password,\
+#            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password_confirm,\
+#            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password"
+
+# Login
 SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
     "id:9007100,\
     phase:2,\
@@ -38,22 +60,72 @@ SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
     nolog,\
     ver:'OWASP_CRS/3.4.0',\
     chain"
-    SecRule ARGS:mode "@rx ^(?:login|register|reg_details)$" \
+    SecRule ARGS:mode "@streq login" \
         "t:none,\
         chain"
         SecRule &ARGS:mode "@eq 1" \
             "t:none,\
-            ctl:ruleRemoveTargetById=941100;ARGS:redirect,\
-            ctl:ruleRemoveTargetById=930100;ARGS:redirect,\
-            ctl:ruleRemoveTargetById=930110;ARGS:redirect,\
-            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:new_password,\
-            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:cur_password,\
-            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password_confirm,\
-            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password"
+            chain"
+            SecRule ARGS:password "@validateUtf8Encoding" \
+                "t:none,\
+                ctl:ruleRemoveTargetById=941100;ARGS:redirect,\
+                ctl:ruleRemoveTargetById=930100;ARGS:redirect,\
+                ctl:ruleRemoveTargetById=930110;ARGS:redirect,\
+                ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password"
+
+# Registration
+SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
+    "id:9007110,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.4.0',\
+    chain"
+    SecRule ARGS:mode "@streq register" \
+        "t:none,\
+        chain"
+        SecRule &ARGS:mode "@eq 1" \
+            "t:none,\
+            chain"
+            SecRule ARGS:new_password "@validateUtf8Encoding" \
+                "t:none,\
+                chain"
+                SecRule ARGS:password_confirm "@validateUtf8Encoding" \
+                    "t:none,\
+                    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:new_password,\
+                    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password_confirm"
+
+# Password change
+SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
+    "id:9007120,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.4.0',\
+    chain"
+    SecRule ARGS:mode "@streq reg_details" \
+        "t:none,\
+        chain"
+        SecRule &ARGS:mode "@eq 1" \
+            "t:none,\
+            chain"
+            SecRule ARGS:new_password "@validateUtf8Encoding" \
+                "t:none,\
+                chain"
+                SecRule ARGS:cur_password "@validateUtf8Encoding" \
+                    "t:none,\
+                    chain"
+                    SecRule ARGS:password_confirm "@validateUtf8Encoding" \
+                        "t:none,\
+                        ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:new_password,\
+                        ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:cur_password,\
+                        ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password_confirm"
 
 # Redirect after admin login
 SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
-    "id:9007110,\
+    "id:9007130,\
     phase:2,\
     pass,\
     t:none,\
@@ -70,7 +142,7 @@ SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
 
 # Creating and editing posts
 SecRule REQUEST_FILENAME "@endsWith /posting.php" \
-    "id:9007120,\
+    "id:9007140,\
     phase:2,\
     pass,\
     t:none,\
@@ -85,6 +157,7 @@ SecRule REQUEST_FILENAME "@endsWith /posting.php" \
             ctl:ruleRemoveTargetByTag=attack-xss;ARGS:message,\
             ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:message,\
             ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:message,\
+            ctl:ruleRemoveTargetByTag=attack-rce;ARGS:message,\
             ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:subject,\
             ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:subject,\
             ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:subject_checked,\
@@ -92,7 +165,7 @@ SecRule REQUEST_FILENAME "@endsWith /posting.php" \
 
 # Private messages
 SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
-    "id:9007130,\
+    "id:9007150,\
     phase:2,\
     pass,\
     t:none,\
@@ -107,13 +180,14 @@ SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
             ctl:ruleRemoveTargetByTag=attack-xss;ARGS:message,\
             ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:message,\
             ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:message,\
+            ctl:ruleRemoveTargetByTag=attack-rce;ARGS:message,\
             ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:subject,\
             ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:subject"
 
 # Saving draft of a private message
-# In this case, phpBB is sending both GET and POST 'mode' parameter
+# In this case, phpBB is sending both GET and POST 'mode' parameters togather (maybe a bug in phpBB?)
 SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
-    "id:9007140,\
+    "id:9007160,\
     phase:2,\
     pass,\
     t:none,\
@@ -131,12 +205,13 @@ SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
                 ctl:ruleRemoveTargetByTag=attack-xss;ARGS:message,\
                 ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:message,\
                 ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:message,\
+                ctl:ruleRemoveTargetByTag=attack-rce;ARGS:message,\
                 ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:subject,\
                 ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:subject"
 
 # Profile - setting signature
 SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
-    "id:9007150,\
+    "id:9007170,\
     phase:2,\
     pass,\
     t:none,\

--- a/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
@@ -29,7 +29,7 @@ SecRule &TX:crs_exclusions_phpbb|TX:crs_exclusions_phpbb "@eq 0" \
     ver:'OWASP_CRS/3.4.0',\
     skipAfter:END-PHPBB"
 
-# User login and registration
+# Login, registration and password change
 SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
     "id:9007100,\
     phase:2,\
@@ -38,7 +38,7 @@ SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
     nolog,\
     ver:'OWASP_CRS/3.4.0',\
     chain"
-    SecRule ARGS:mode "@rx ^(?:login|register)$" \
+    SecRule ARGS:mode "@rx ^(?:login|register|reg_details)$" \
         "t:none,\
         chain"
         SecRule &ARGS:mode "@eq 1" \
@@ -47,6 +47,7 @@ SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
             ctl:ruleRemoveTargetById=930100;ARGS:redirect,\
             ctl:ruleRemoveTargetById=930110;ARGS:redirect,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:new_password,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:cur_password,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password_confirm,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password"
 

--- a/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
@@ -29,7 +29,6 @@ SecRule &TX:crs_exclusions_phpbb|TX:crs_exclusions_phpbb "@eq 0" \
     ver:'OWASP_CRS/3.4.0',\
     skipAfter:END-PHPBB"
 
-
 # User login and registration
 SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
     "id:9007100,\
@@ -45,13 +44,32 @@ SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
         SecRule &ARGS:mode "@eq 1" \
             "t:none,\
             ctl:ruleRemoveTargetById=941100;ARGS:redirect,\
+            ctl:ruleRemoveTargetById=930100;ARGS:redirect,\
+            ctl:ruleRemoveTargetById=930110;ARGS:redirect,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:new_password,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password_confirm,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password"
 
+# Redirect after admin login
+SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
+    "id:9007110,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.4.0',\
+    chain"
+    SecRule &ARGS:mode "@eq 0" \
+        "t:none,\
+        chain"
+        SecRule &ARGS:username "@eq 1" \
+            "t:none,\
+            ctl:ruleRemoveTargetById=930100;ARGS:redirect,\
+            ctl:ruleRemoveTargetById=930110;ARGS:redirect"
+
 # Creating and editing posts
 SecRule REQUEST_FILENAME "@endsWith /posting.php" \
-    "id:9007110,\
+    "id:9007120,\
     phase:2,\
     pass,\
     t:none,\
@@ -71,25 +89,8 @@ SecRule REQUEST_FILENAME "@endsWith /posting.php" \
             ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:subject_checked,\
             ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:subject_checked"
 
-# Settings - adding Google AdSense code
-SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
-    "id:9007120,\
-    phase:2,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'OWASP_CRS/3.4.0',\
-    chain"
-    SecRule ARGS:mode "@streq settings" \
-        "t:none,\
-        chain"
-        SecRule &ARGS:mode "@eq 1" \
-            "t:none,\
-            ctl:ruleRemoveTargetByTag=attack-xss;ARGS:config[google_adsense_html],\
-            ctl:ruleRemoveTargetByTag=attack-rce;ARGS:config[google_adsense_html]"
-
-# Redirect after admin login
-SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
+# Private messages
+SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
     "id:9007130,\
     phase:2,\
     pass,\
@@ -97,13 +98,76 @@ SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
     nolog,\
     ver:'OWASP_CRS/3.4.0',\
     chain"
-    SecRule &ARGS:mode "@eq 0" \
+    SecRule ARGS:mode "@rx ^(?:compose|drafts)$" \
         "t:none,\
         chain"
-        SecRule &ARGS:username "@eq 1" \
+        SecRule &ARGS:mode "@eq 1" \
             "t:none,\
-            ctl:ruleRemoveTargetById=930100;ARGS:redirect,\
-            ctl:ruleRemoveTargetById=930110;ARGS:redirect"
+            ctl:ruleRemoveTargetByTag=attack-xss;ARGS:message,\
+            ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:message,\
+            ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:message,\
+            ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:subject,\
+            ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:subject"
+
+# Saving draft of a private messages
+# In this case, phpBB is sending both GET and POST 'mode' parameter
+SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
+    "id:9007140,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.4.0',\
+    chain"
+    SecRule ARGS_GET:mode "@streq compose" \
+        "t:none,\
+        chain"
+        SecRule ARGS_POST:mode "@streq compose" \
+            "t:none,\
+            chain"
+            SecRule &ARGS:mode "@eq 2" \
+                "t:none,\
+                ctl:ruleRemoveTargetByTag=attack-xss;ARGS:message,\
+                ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:message,\
+                ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:message,\
+                ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:subject,\
+                ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:subject"
+
+# Profile - setting signature
+SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
+    "id:9007150,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.4.0',\
+    chain"
+    SecRule ARGS:mode "@streq signature" \
+        "t:none,\
+        chain"
+        SecRule &ARGS:mode "@eq 1" \
+            "t:none,\
+            ctl:ruleRemoveTargetByTag=attack-xss;ARGS:signature,\
+            ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:signature,\
+            ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:signature"
+
+# Settings - adding Google AdSense code
+# Unknown but seen in the wild - maybe custom modification? Temporarily disabled.
+#SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
+#    "id:9007200,\
+#    phase:2,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    ver:'OWASP_CRS/3.4.0',\
+#    chain"
+#    SecRule ARGS:mode "@streq settings" \
+#        "t:none,\
+#        chain"
+#        SecRule &ARGS:mode "@eq 1" \
+#            "t:none,\
+#            ctl:ruleRemoveTargetByTag=attack-xss;ARGS:config[google_adsense_html],\
+#            ctl:ruleRemoveTargetByTag=attack-rce;ARGS:config[google_adsense_html]"
 
 
 SecMarker "END-PHPBB"

--- a/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
@@ -88,22 +88,24 @@ SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
             ctl:ruleRemoveTargetByTag=attack-xss;ARGS:config[google_adsense_html],\
             ctl:ruleRemoveTargetByTag=attack-rce;ARGS:config[google_adsense_html]"
 
-# Unknown but seen in the wild, temporarily disabled
-#SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
-#    "id:9007130,\
-#    phase:2,\
-#    pass,\
-#    t:none,\
-#    nolog,\
-#    ver:'OWASP_CRS/3.4.0',\
-#    chain"
-#    SecRule &ARGS:mode "@eq 0" \
-#        "t:none,\
-#        chain"
-#        SecRule &ARGS:username "@eq 1" \
-#            "t:none,\
-#            ctl:ruleRemoveTargetById=930100;REQUEST_BODY,\
-#            ctl:ruleRemoveTargetById=930110;REQUEST_BODY"
+# Redirect after admin login
+# Problem is only with POST parameter 'redirect' (redirect=./../adm/index.php?sid=bb684831bb228a8fc3736a8ea91a8033)
+# but rules 930100 and 930110 are matching against REQUEST_BODY :-(
+SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
+    "id:9007130,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.4.0',\
+    chain"
+    SecRule &ARGS:mode "@eq 0" \
+        "t:none,\
+        chain"
+        SecRule &ARGS:username "@eq 1" \
+            "t:none,\
+            ctl:ruleRemoveTargetById=930100;REQUEST_BODY,\
+            ctl:ruleRemoveTargetById=930110;REQUEST_BODY"
 
 
 SecMarker "END-PHPBB"

--- a/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
@@ -30,7 +30,8 @@ SecRule &TX:crs_exclusions_phpbb|TX:crs_exclusions_phpbb "@eq 0" \
     skipAfter:END-PHPBB"
 
 
-SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
+# User login and registration
+SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
     "id:9007100,\
     phase:2,\
     pass,\
@@ -38,34 +39,19 @@ SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
     nolog,\
     ver:'OWASP_CRS/3.4.0',\
     chain"
-    SecRule &ARGS:mode "@eq 0" \
-        "t:none,\
-        chain"
-        SecRule &ARGS:username "@eq 1" \
-            "t:none,\
-            ctl:ruleRemoveTargetById=930100;REQUEST_BODY,\
-            ctl:ruleRemoveTargetById=930110;REQUEST_BODY"
-
-# Settings - adding Google AdSense code
-SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
-    "id:9007110,\
-    phase:2,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'OWASP_CRS/3.4.0',\
-    chain"
-    SecRule ARGS:mode "@streq settings" \
+    SecRule ARGS:mode "@rx ^(?:login|register)$" \
         "t:none,\
         chain"
         SecRule &ARGS:mode "@eq 1" \
             "t:none,\
-            ctl:ruleRemoveTargetByTag=attack-xss;ARGS:config[google_adsense_html],\
-            ctl:ruleRemoveTargetByTag=attack-rce;ARGS:config[google_adsense_html]"
+            ctl:ruleRemoveTargetById=941100;ARGS:redirect,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:new_password,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password_confirm,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password"
 
 # Creating and editing posts
 SecRule REQUEST_FILENAME "@endsWith /posting.php" \
-    "id:9007120,\
+    "id:9007110,\
     phase:2,\
     pass,\
     t:none,\
@@ -85,24 +71,39 @@ SecRule REQUEST_FILENAME "@endsWith /posting.php" \
             ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:subject_checked,\
             ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:subject_checked"
 
-# User login and registration
-SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
-    "id:9007130,\
+# Settings - adding Google AdSense code
+SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
+    "id:9007120,\
     phase:2,\
     pass,\
     t:none,\
     nolog,\
     ver:'OWASP_CRS/3.4.0',\
     chain"
-    SecRule ARGS:mode "@rx ^(?:login|register)$" \
+    SecRule ARGS:mode "@streq settings" \
         "t:none,\
         chain"
         SecRule &ARGS:mode "@eq 1" \
             "t:none,\
-            ctl:ruleRemoveTargetById=941100;ARGS:redirect,\
-            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:new_password,\
-            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password_confirm,\
-            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password"
+            ctl:ruleRemoveTargetByTag=attack-xss;ARGS:config[google_adsense_html],\
+            ctl:ruleRemoveTargetByTag=attack-rce;ARGS:config[google_adsense_html]"
+
+# Unknown but seen in the wild, temporarily disabled
+#SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
+#    "id:9007130,\
+#    phase:2,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    ver:'OWASP_CRS/3.4.0',\
+#    chain"
+#    SecRule &ARGS:mode "@eq 0" \
+#        "t:none,\
+#        chain"
+#        SecRule &ARGS:username "@eq 1" \
+#            "t:none,\
+#            ctl:ruleRemoveTargetById=930100;REQUEST_BODY,\
+#            ctl:ruleRemoveTargetById=930110;REQUEST_BODY"
 
 
 SecMarker "END-PHPBB"

--- a/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
@@ -109,7 +109,7 @@ SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
             ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:subject,\
             ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:subject"
 
-# Saving draft of a private messages
+# Saving draft of a private message
 # In this case, phpBB is sending both GET and POST 'mode' parameter
 SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
     "id:9007140,\

--- a/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
@@ -1,0 +1,115 @@
+# ------------------------------------------------------------------------
+# OWASP ModSecurity Core Rule Set ver.3.4.0
+# Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
+#
+# The OWASP ModSecurity Core Rule Set is distributed under
+# Apache Software License (ASL) version 2
+# Please see the enclosed LICENSE file for full details.
+# ------------------------------------------------------------------------
+
+# These exclusions remedy false positives in a default phpBB install.
+# The exclusions are only active if crs_exclusions_phpbb=1 is set.
+# See rule 900130 in crs-setup.conf.example for instructions.
+
+SecRule &TX:crs_exclusions_phpbb|TX:crs_exclusions_phpbb "@eq 0" \
+    "id:9007000,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.4.0',\
+    skipAfter:END-PHPBB"
+
+SecRule &TX:crs_exclusions_phpbb|TX:crs_exclusions_phpbb "@eq 0" \
+    "id:9007001,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.4.0',\
+    skipAfter:END-PHPBB"
+
+
+
+
+
+
+SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
+    "id:9007100,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.4.0',\
+    chain"
+    SecRule &ARGS_GET:mode "@eq 0" \
+        "t:none,\
+        chain"
+        SecRule &ARGS_POST:username "@eq 1" \
+            "t:none,\
+            ctl:ruleRemoveTargetById=930100;REQUEST_BODY,\
+            ctl:ruleRemoveTargetById=930110;REQUEST_BODY"
+
+SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
+    "id:9007110,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.4.0',\
+    chain"
+    SecRule ARGS_GET:mode "@streq settings" \
+        "t:none,\
+        chain"
+        SecRule &ARGS_GET:mode "@eq 1" \
+            "t:none,\
+            ctl:ruleRemoveTargetById=932130;ARGS:config[google_adsense_html],\
+            ctl:ruleRemoveTargetById=941100;ARGS:config[google_adsense_html],\
+            ctl:ruleRemoveTargetById=941110;ARGS:config[google_adsense_html],\
+            ctl:ruleRemoveTargetById=941180;ARGS:config[google_adsense_html]"
+
+SecRule REQUEST_FILENAME "@endsWith /posting.php" \
+    "id:9007120,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.4.0',\
+    chain"
+    SecRule ARGS_GET:mode "@rx ^(?:post|edit|quote|reply)$" \
+        "t:none,\
+        chain"
+        SecRule &ARGS_GET:mode "@eq 1" \
+            "t:none,\
+            ctl:ruleRemoveTargetById=941100;ARGS:message,\
+            ctl:ruleRemoveTargetById=941110;ARGS:message,\
+            ctl:ruleRemoveTargetById=933210;ARGS:message,\
+            ctl:ruleRemoveTargetById=942190;ARGS:message,\
+            ctl:ruleRemoveTargetById=942270;ARGS:message,\
+            ctl:ruleRemoveTargetById=942100;ARGS:subject,\
+            ctl:ruleRemoveTargetById=933210;ARGS:subject,\
+            ctl:ruleRemoveTargetById=942190;ARGS:subject,\
+            ctl:ruleRemoveTargetById=942100;ARGS:subject_checked,\
+            ctl:ruleRemoveTargetById=933210;ARGS:subject_checked"
+
+# User login and registration
+SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
+    "id:9007130,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.4.0',\
+    chain"
+    SecRule ARGS:mode "@rx ^(?:login|register)$" \
+        "t:none,\
+        chain"
+        SecRule &ARGS:mode "@eq 1" \
+            "t:none,\
+            ctl:ruleRemoveTargetById=941100;ARGS:redirect,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:new_password,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password_confirm,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password"
+
+
+SecMarker "END-PHPBB"

--- a/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
@@ -30,10 +30,6 @@ SecRule &TX:crs_exclusions_phpbb|TX:crs_exclusions_phpbb "@eq 0" \
     skipAfter:END-PHPBB"
 
 
-
-
-
-
 SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
     "id:9007100,\
     phase:2,\

--- a/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
@@ -11,14 +11,14 @@
 # The exclusions are only active if crs_exclusions_phpbb=1 is set.
 # See rule 900130 in crs-setup.conf.example for instructions.
 
-SecRule &TX:crs_exclusions_phpbb|TX:crs_exclusions_phpbb "@eq 0" \
-    "id:9007000,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'OWASP_CRS/3.4.0',\
-    skipAfter:END-PHPBB"
+#SecRule &TX:crs_exclusions_phpbb|TX:crs_exclusions_phpbb "@eq 0" \
+#    "id:9007000,\
+#    phase:1,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    ver:'OWASP_CRS/3.4.0',\
+#    skipAfter:END-PHPBB"
 
 SecRule &TX:crs_exclusions_phpbb|TX:crs_exclusions_phpbb "@eq 0" \
     "id:9007001,\

--- a/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
@@ -159,9 +159,9 @@ SecRule REQUEST_FILENAME "@endsWith /posting.php" \
             ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:message,\
             ctl:ruleRemoveTargetByTag=attack-rce;ARGS:message,\
             ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:subject,\
-            ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:subject,\
-            ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:subject_checked,\
-            ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:subject_checked"
+            ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:subject"
+#            ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:subject_checked
+#            ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:subject_checked
 
 # Private messages
 SecRule REQUEST_FILENAME "@endsWith /ucp.php" \

--- a/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
@@ -89,8 +89,6 @@ SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
             ctl:ruleRemoveTargetByTag=attack-rce;ARGS:config[google_adsense_html]"
 
 # Redirect after admin login
-# Problem is only with POST parameter 'redirect' (redirect=./../adm/index.php?sid=bb684831bb228a8fc3736a8ea91a8033)
-# but rules 930100 and 930110 are matching against REQUEST_BODY :-(
 SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
     "id:9007130,\
     phase:2,\
@@ -104,8 +102,8 @@ SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
         chain"
         SecRule &ARGS:username "@eq 1" \
             "t:none,\
-            ctl:ruleRemoveTargetById=930100;REQUEST_BODY,\
-            ctl:ruleRemoveTargetById=930110;REQUEST_BODY"
+            ctl:ruleRemoveTargetById=930100;ARGS:redirect,\
+            ctl:ruleRemoveTargetById=930110;ARGS:redirect"
 
 
 SecMarker "END-PHPBB"

--- a/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
@@ -38,10 +38,10 @@ SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
     nolog,\
     ver:'OWASP_CRS/3.4.0',\
     chain"
-    SecRule &ARGS_GET:mode "@eq 0" \
+    SecRule &ARGS:mode "@eq 0" \
         "t:none,\
         chain"
-        SecRule &ARGS_POST:username "@eq 1" \
+        SecRule &ARGS:username "@eq 1" \
             "t:none,\
             ctl:ruleRemoveTargetById=930100;REQUEST_BODY,\
             ctl:ruleRemoveTargetById=930110;REQUEST_BODY"
@@ -54,10 +54,10 @@ SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
     nolog,\
     ver:'OWASP_CRS/3.4.0',\
     chain"
-    SecRule ARGS_GET:mode "@streq settings" \
+    SecRule ARGS:mode "@streq settings" \
         "t:none,\
         chain"
-        SecRule &ARGS_GET:mode "@eq 1" \
+        SecRule &ARGS:mode "@eq 1" \
             "t:none,\
             ctl:ruleRemoveTargetById=932130;ARGS:config[google_adsense_html],\
             ctl:ruleRemoveTargetById=941100;ARGS:config[google_adsense_html],\
@@ -72,10 +72,10 @@ SecRule REQUEST_FILENAME "@endsWith /posting.php" \
     nolog,\
     ver:'OWASP_CRS/3.4.0',\
     chain"
-    SecRule ARGS_GET:mode "@rx ^(?:post|edit|quote|reply)$" \
+    SecRule ARGS:mode "@rx ^(?:post|edit|quote|reply)$" \
         "t:none,\
         chain"
-        SecRule &ARGS_GET:mode "@eq 1" \
+        SecRule &ARGS:mode "@eq 1" \
             "t:none,\
             ctl:ruleRemoveTargetById=941100;ARGS:message,\
             ctl:ruleRemoveTargetById=941110;ARGS:message,\

--- a/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
@@ -46,6 +46,7 @@ SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
             ctl:ruleRemoveTargetById=930100;REQUEST_BODY,\
             ctl:ruleRemoveTargetById=930110;REQUEST_BODY"
 
+# Settings - adding Google AdSense code
 SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
     "id:9007110,\
     phase:2,\
@@ -59,11 +60,10 @@ SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
         chain"
         SecRule &ARGS:mode "@eq 1" \
             "t:none,\
-            ctl:ruleRemoveTargetById=932130;ARGS:config[google_adsense_html],\
-            ctl:ruleRemoveTargetById=941100;ARGS:config[google_adsense_html],\
-            ctl:ruleRemoveTargetById=941110;ARGS:config[google_adsense_html],\
-            ctl:ruleRemoveTargetById=941180;ARGS:config[google_adsense_html]"
+            ctl:ruleRemoveTargetByTag=attack-xss;ARGS:config[google_adsense_html],\
+            ctl:ruleRemoveTargetByTag=attack-rce;ARGS:config[google_adsense_html]"
 
+# Creating and editing posts
 SecRule REQUEST_FILENAME "@endsWith /posting.php" \
     "id:9007120,\
     phase:2,\
@@ -77,16 +77,13 @@ SecRule REQUEST_FILENAME "@endsWith /posting.php" \
         chain"
         SecRule &ARGS:mode "@eq 1" \
             "t:none,\
-            ctl:ruleRemoveTargetById=941100;ARGS:message,\
-            ctl:ruleRemoveTargetById=941110;ARGS:message,\
-            ctl:ruleRemoveTargetById=933210;ARGS:message,\
-            ctl:ruleRemoveTargetById=942190;ARGS:message,\
-            ctl:ruleRemoveTargetById=942270;ARGS:message,\
-            ctl:ruleRemoveTargetById=942100;ARGS:subject,\
-            ctl:ruleRemoveTargetById=933210;ARGS:subject,\
-            ctl:ruleRemoveTargetById=942190;ARGS:subject,\
-            ctl:ruleRemoveTargetById=942100;ARGS:subject_checked,\
-            ctl:ruleRemoveTargetById=933210;ARGS:subject_checked"
+            ctl:ruleRemoveTargetByTag=attack-xss;ARGS:message,\
+            ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:message,\
+            ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:message,\
+            ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:subject,\
+            ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:subject,\
+            ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:subject_checked,\
+            ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:subject_checked"
 
 # User login and registration
 SecRule REQUEST_FILENAME "@endsWith /ucp.php" \


### PR DESCRIPTION
Example of a post title which will trigger rules 941100, 941110 and 941160 in WordPress (for example in version 4.9.15):
Usage of <script> tag