### PR TITLE
Wordpress FP fixes

### DIFF
--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -411,6 +411,7 @@ SecAction \
     nolog,\
     ctl:ruleRemoveTargetById=920230;ARGS:_wp_http_referer,\
     ctl:ruleRemoveTargetById=931130;ARGS:_wp_http_referer,\
+    ctl:ruleRemoveTargetById=932200;ARGS:_wp_http_referer,\
     ctl:ruleRemoveTargetById=932150;ARGS:_wp_http_referer,\
     ctl:ruleRemoveTargetById=941100;ARGS:_wp_http_referer,\
     ctl:ruleRemoveTargetById=942130;ARGS:_wp_http_referer,\
@@ -420,6 +421,7 @@ SecAction \
     ctl:ruleRemoveTargetById=942440;ARGS:_wp_http_referer,\
     ctl:ruleRemoveTargetById=920230;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=931130;ARGS:wp_http_referer,\
+    ctl:ruleRemoveTargetById=932200;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=932150;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=941100;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=942130;ARGS:wp_http_referer,\

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -476,6 +476,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
             ctl:ruleRemoveTargetById=942431;ARGS_NAMES:data[wp-refresh-post-lock][post_id],\
             ctl:ruleRemoveTargetById=942431;ARGS_NAMES:data[wp-refresh-post-lock][lock],\
             ctl:ruleRemoveTargetById=942431;ARGS_NAMES:data[wp-check-locked-posts][],\
+            ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
             ctl:ruleRemoveById=921180,\
             ctl:ruleRemoveById=920272"
 

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -478,7 +478,6 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
             ctl:ruleRemoveTargetById=942431;ARGS_NAMES:data[wp-refresh-post-lock][post_id],\
             ctl:ruleRemoveTargetById=942431;ARGS_NAMES:data[wp-refresh-post-lock][lock],\
             ctl:ruleRemoveTargetById=942431;ARGS_NAMES:data[wp-check-locked-posts][],\
-            ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
             ctl:ruleRemoveById=921180,\
             ctl:ruleRemoveById=920272"
 

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -452,6 +452,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/post.php" \
             "t:none,\
             ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:post_title,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:content,\
+            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:excerpt,\
             ctl:ruleRemoveById=920272,\
             ctl:ruleRemoveById=921180"
 


### PR DESCRIPTION
Improvements to the WordPress exclusion profile.

- Fixes #1834 by excluding all rules on the excerpt parameter, and rule 921110, while making/editing a post.
- Fixes #1884 by excluding rule 932200 on wp_http_referer parameters. This parameter appears on many endpoints.