### PR TITLE
WordPress: add exclusion for site-health.php 'SQL server' response

### DIFF
--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -753,6 +753,17 @@ SecRule REQUEST_FILENAME "@rx /wp-admin/load-(?:scripts|styles)\.php$" \
     ver:'OWASP_CRS/3.3.0'"
 
 
+# Site health output can trigger database error rule.
+SecRule REQUEST_FILENAME "@endsWith /wp-admin/site-health.php" \
+    "id:9002910,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveById=951220,\
+    ver:'OWASP_CRS/3.3.0'"
+
+
 SecMarker "END-WORDPRESS-ADMIN"
 
 


### PR DESCRIPTION
The site-health.php response could lead to a false positive in the database error rule 951220.

Fixes #1862.
Code was contributed by @Fregf in that issue.