### PR TITLE
Permit "version" string in content-type header, rebased to 3.4 + test, v2

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -914,7 +914,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
 # - multipart/form-data; boundary=----WebKitFormBoundary12345
 # - application/soap+xml; charset=utf-8; action="urn:localhost-hwh#getQuestions"
 #
-SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+-]+(?:\s?;\s?(?:action|boundary|charset|type|start(?:-info)?)\s?=\s?['\"\w.()+,/:=?<>@#-]+)*$" \
+SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+-]+(?:\s?;\s?(?:action|boundary|charset|type|start(?:-info)?|type|version)\s?=\s?['\"\w.()+,/:=?<>@#-]+)*$" \
     "id:920470,\
     phase:1,\
     block,\

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920470.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920470.yaml
@@ -211,3 +211,17 @@
                   Content-Length: 0
             output:
               no_log_contains: "id \"920470\""
+    - test_title: 920470-16
+      stages:
+        - stage:
+            input:
+              dest_addr: 127.0.0.1
+              port: 80
+              method: POST
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Type: 'ext/vcard;version=4.0'
+                  Content-Length: 0
+            output:
+              no_log_contains: "id \"920470\""


### PR DESCRIPTION
Replacement for PR #1877.