### PR TITLE
Update Nextcloud rules

### DIFF
--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -95,7 +95,7 @@ SecRule REQUEST_METHOD "@streq PUT" \
         ctl:ruleRemoveById=930120"
 
 # Fix for Nextcloud Desktop Client
-SecRule REQUEST_METHOD "@streq PROPFIND" \
+SecRule REQUEST_METHOD "@rx ^(?:PROPFIND|PUT)$" \
     "id:9003106,\
     phase:2,\
     pass,\
@@ -108,7 +108,7 @@ SecRule REQUEST_METHOD "@streq PROPFIND" \
         ctl:ruleRemoveById=921110"
 
 # Fix for Nextcloud Desktop Client
-SecRule REQUEST_METHOD "@streq PROPFIND" \
+SecRule REQUEST_METHOD "@rx ^(?:PROPFIND|PUT)$" \
     "id:9003107,\
     phase:2,\
     pass,\
@@ -191,7 +191,7 @@ SecRule REQUEST_METHOD "@streq REPORT" \
 
 # [ Searchengine ]
 #
-# NexCloud uses a search field for filename or content queries.
+# Nextcloud uses a search field for filename or content queries.
 
 SecRule REQUEST_FILENAME "@contains /index.php/core/search" \
     "id:9003125,\
@@ -503,10 +503,10 @@ SecRule REQUEST_FILENAME "@contains /.well-known/carddav" \
 #
 # [ Notifications ]
 #
-# NexCloud uses notifictions to inform the user of important new details.
+# Nextcloud uses notifictions to inform the user of important new details.
 
 # Allows notifications to be deleted
-SecRule REQUEST_FILENAME "@contains /ocs/v2.php/apps/notifications/api/v2/notifications" \
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/notifications/api/v2/notifications" \
     "id:9003701,\
     phase:2,\
     pass,\
@@ -515,12 +515,12 @@ SecRule REQUEST_FILENAME "@contains /ocs/v2.php/apps/notifications/api/v2/notifi
     ver:'OWASP_CRS/3.3.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
 
-
+#
 # [ API ]
 #
-# Allow access to the shares API URL from mobile app
 
-SecRule REQUEST_FILENAME "@contains /ocs/v2.php/apps/files_sharing/api/v1/shares" \
+# Allow access to the shares API URL from mobile app
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/files_sharing/api/v1/shares" \
     "id:9003800,\
     phase:1,\
     pass,\
@@ -531,6 +531,33 @@ SecRule REQUEST_FILENAME "@contains /ocs/v2.php/apps/files_sharing/api/v1/shares
         "t:none,\
         ctl:ruleRemoveById=200002"
 
+#
+# [ Users ]
+#
+
+# Allow users to be deleted
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/cloud/users/" \
+    "id:9003850,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.3.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
+
+#
+# [ Extensions ]
+#
+
+# Ransomware protection
+SecRule REQUEST_FILENAME "@contains /config/apps/ransomware_protection/extension_additions" \
+    "id:9003900,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetById=932130;ARGS:value,\
+    ver:'OWASP_CRS/3.3.0'"
 
 SecMarker "END-NEXTCLOUD-ADMIN"
 

--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -92,35 +92,22 @@ SecRule REQUEST_METHOD "@streq PUT" \
         ctl:ruleRemoveById=930110,\
         ctl:ruleRemoveById=930120"
 
-# Fix for Nextcloud Desktop Client
+# Fix for Nextcloud Desktop Client / Allow sending source code
 SecRule REQUEST_METHOD "@pm PROPFIND PUT" \
-    "id:9003106,\
+    "id:9003110,\
     phase:2,\
     pass,\
     t:none,\
     nolog,\
     ver:'OWASP_CRS/3.3.0',\
     chain"
-    SecRule REQUEST_FILENAME "@contains /remote.php/webdav" \
-        "t:none,\
-        ctl:ruleRemoveById=921110"
-
-# Fix for Nextcloud Desktop Client
-SecRule REQUEST_METHOD "@pm PROPFIND PUT" \
-    "id:9003107,\
-    phase:2,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'OWASP_CRS/3.3.0',\
-    chain"
-    SecRule REQUEST_FILENAME "@contains /remote.php/dav/files" \
+    SecRule REQUEST_FILENAME "@rx /remote\.php/(?:webdav|dav/files)" \
         "t:none,\
         ctl:ruleRemoveById=921110"
 
 # Allow the data type 'text/vcard'
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
-    "id:9003110,\
+    "id:9003115,\
     phase:2,\
     pass,\
     t:none,\
@@ -130,26 +117,26 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
 
 # Allow the data type 'application/octet-stream'
 SecRule REQUEST_METHOD "@pm PUT MOVE" \
-    "id:9003115,\
+    "id:9003120,\
     phase:2,\
     pass,\
     t:none,\
     nolog,\
     ver:'OWASP_CRS/3.3.0',\
     chain"
-    SecRule REQUEST_FILENAME "@pm /remote.php/dav/files/ /remote.php/dav/uploads/" \
+    SecRule REQUEST_FILENAME "@rx /remote\.php/dav/(?:files|uploads)/" \
         "setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |application/octet-stream|'"
 
 # Allow data types like video/mp4
 SecRule REQUEST_METHOD "@streq PUT" \
-    "id:9003116,\
+    "id:9003125,\
     phase:2,\
     pass,\
     t:none,\
     nolog,\
     ver:'OWASP_CRS/3.3.0',\
     chain"
-    SecRule REQUEST_FILENAME "@pm /public.php/webdav/ /remote.php/dav/uploads/" \
+    SecRule REQUEST_FILENAME "@rx /(?:public\.php/webdav|remote\.php/dav/uploads)/" \
         "ctl:ruleRemoveById=920340,\
         ctl:ruleRemoveById=920420"
 
@@ -158,7 +145,7 @@ SecRule REQUEST_METHOD "@streq PUT" \
 # Allow all kind of filetypes.
 # Allow source code.
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
-    "id:9003120,\
+    "id:9003130,\
     phase:2,\
     pass,\
     t:none,\
@@ -171,7 +158,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
 
 # Allow REPORT requests without Content-Type header (at least the iOS app does this)
 SecRule REQUEST_METHOD "@streq REPORT" \
-    "id:9003121,\
+    "id:9003135,\
     phase:2,\
     pass,\
     t:none,\
@@ -188,7 +175,7 @@ SecRule REQUEST_METHOD "@streq REPORT" \
 
 # Nextcloud uses a search field for filename or content queries.
 SecRule REQUEST_FILENAME "@contains /index.php/core/search" \
-    "id:9003125,\
+    "id:9003150,\
     phase:2,\
     pass,\
     t:none,\
@@ -203,7 +190,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/core/search" \
 # [ DAV ]
 #
 
-# NextCloud uses DAV methods with index.php and remote.php to do many things
+# Nextcloud uses DAV methods with index.php and remote.php to do many things
 # The default ones in ModSecurity are: GET HEAD POST OPTIONS
 #
 # Looking through the code, and via testing, I found these:
@@ -213,8 +200,8 @@ SecRule REQUEST_FILENAME "@contains /index.php/core/search" \
 # Others in the code or js files: PATCH MKCOL MOVE TRACE
 # Others that I added just in case, and they seem related:
 #   CHECKOUT COPY LOCK MERGE MKACTIVITY UNLOCK.
-SecRule REQUEST_FILENAME "@pm /remote.php/ /index.php/ /public.php/" \
-    "id:9003130,\
+SecRule REQUEST_FILENAME "@rx /(?:remote|index|public)\.php/" \
+    "id:9003200,\
     phase:2,\
     pass,\
     t:none,\
@@ -226,7 +213,7 @@ SecRule REQUEST_FILENAME "@pm /remote.php/ /index.php/ /public.php/" \
 # DELETE - when the share is removed
 # PUT - when setting a password / expiration time
 SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/files_sharing/" \
-    "id:9003140,\
+    "id:9003210,\
     phase:2,\
     pass,\
     t:none,\
@@ -241,7 +228,7 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/files_sharing/" \
 
 # Preview
 SecRule REQUEST_FILENAME "@contains /index.php/core/preview.png" \
-    "id:9003150,\
+    "id:9003250,\
     phase:2,\
     pass,\
     t:none,\
@@ -251,7 +238,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/core/preview.png" \
 
 # Filepreview for trashbin
 SecRule REQUEST_FILENAME "@contains /index.php/apps/files_trashbin/ajax/preview.php" \
-    "id:9003155,\
+    "id:9003255,\
     phase:2,\
     pass,\
     t:none,\
@@ -262,7 +249,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/files_trashbin/ajax/preview.
 
 # Thumbnails
 SecRule REQUEST_FILENAME "@contains /index.php/apps/gallery/thumbnails" \
-    "id:9003160,\
+    "id:9003260,\
     phase:2,\
     pass,\
     t:none,\
@@ -284,13 +271,14 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/ownnote/" \
     ctl:ruleRemoveById=941150,\
     ver:'OWASP_CRS/3.3.0'"
 
+
 #
 # [ Text Editor ]
 #
 
 # This file can save anything, and it's name could be lots of things.
 SecRule REQUEST_FILENAME "@contains /index.php/apps/files_texteditor/" \
-    "id:9003310,\
+    "id:9003350,\
     phase:2,\
     pass,\
     t:none,\
@@ -309,7 +297,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/files_texteditor/" \
 
 # Allow the data type 'text/vcard'
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/addressbooks/" \
-    "id:9003320,\
+    "id:9003400,\
     phase:2,\
     pass,\
     t:none,\
@@ -319,11 +307,12 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/addressbooks/" \
 
 # Allow modifying contacts via the web interface
 SecRule REQUEST_METHOD "@streq PUT" \
-    "id:9003321,\
+    "id:9003410,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.3.0',\
     chain"
     SecRule REQUEST_FILENAME "@contains /remote.php/dav/addressbooks/" \
         "t:none,\
@@ -336,7 +325,7 @@ SecRule REQUEST_METHOD "@streq PUT" \
 
 # Allow the data type 'text/calendar'
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/calendars/" \
-    "id:9003330,\
+    "id:9003450,\
     phase:2,\
     pass,\
     t:none,\
@@ -346,11 +335,12 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/calendars/" \
 
 # Allow modifying calendar events via the web interface
 SecRule REQUEST_METHOD "@streq PUT" \
-    "id:9003331,\
+    "id:9003460,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.3.0',\
     chain"
     SecRule REQUEST_FILENAME "@contains /remote.php/dav/calendars/" \
         "t:none,\
@@ -358,14 +348,14 @@ SecRule REQUEST_METHOD "@streq PUT" \
 
 # Fix for iOS Calender not syncing
 SecRule REQUEST_METHOD "@streq PROPFIND" \
-    "id:9003332,\
+    "id:9003470,\
     phase:2,\
     pass,\
     t:none,\
     nolog,\
     ver:'OWASP_CRS/3.3.0',\
     chain"
-    SecRule REQUEST_FILENAME "@pm /remote.php/dav/principals/users/ /remote.php/dav/calendars/" \
+    SecRule REQUEST_FILENAME "@rx /remote\.php/dav/(?:principals/users|calendars)/" \
         "t:none,\
         ctl:ruleRemoveById=921110"
 
@@ -377,7 +367,7 @@ SecRule REQUEST_METHOD "@streq PROPFIND" \
 # We want to allow a lot of things as the user is
 # allowed to note on anything.
 SecRule REQUEST_FILENAME "@contains /index.php/apps/notes/" \
-    "id:9003340,\
+    "id:9003500,\
     phase:2,\
     pass,\
     t:none,\
@@ -392,7 +382,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/notes/" \
 
 # Allow urls in data.
 SecRule REQUEST_FILENAME "@contains /index.php/apps/bookmarks/" \
-    "id:9003350,\
+    "id:9003550,\
     phase:2,\
     pass,\
     t:none,\
@@ -402,13 +392,13 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/bookmarks/" \
 
 
 #
-# [ Login forms & Logout ]
+# [ Login forms and Logout ]
 #
 # This removes checks on the 'password' and related fields:
 
 # User login password.
 SecRule REQUEST_FILENAME "@contains /index.php/login" \
-    "id:9003400,\
+    "id:9003600,\
     phase:2,\
     pass,\
     t:none,\
@@ -419,7 +409,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/login" \
 
 # Reset password.
 SecRule REQUEST_FILENAME "@endsWith /index.php/login" \
-    "id:9003410,\
+    "id:9003610,\
     phase:2,\
     pass,\
     t:none,\
@@ -435,9 +425,9 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/login" \
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1-text,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass2"
 
-# Logout
+# Logout token
 SecRule REQUEST_FILENAME "@endsWith /index.php/logout" \
-    "id:9003420,\
+    "id:9003620,\
     phase:2,\
     pass,\
     t:none,\
@@ -447,7 +437,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/logout" \
 
 # Change Password and Setting up a new user/password
 SecRule REQUEST_FILENAME "@endsWith /index.php/settings/users" \
-    "id:9003500,\
+    "id:9003630,\
     phase:2,\
     pass,\
     t:none,\
@@ -466,7 +456,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/settings/users" \
 
 # Fixes deletion of auth tokens
 SecRule REQUEST_FILENAME "@contains /settings/personal/authtokens/" \
-    "id:9003601,\
+    "id:9003650,\
     phase:2,\
     pass,\
     t:none,\
@@ -478,7 +468,7 @@ SecRule REQUEST_FILENAME "@contains /settings/personal/authtokens/" \
 
 # Fixed "Security & setup warnings" test
 SecRule REQUEST_FILENAME "@contains /.well-known/caldav" \
-    "id:9003602,\
+    "id:9003660,\
     phase:2,\
     pass,\
     t:none,\
@@ -487,7 +477,7 @@ SecRule REQUEST_FILENAME "@contains /.well-known/caldav" \
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PROPFIND'"
 
 SecRule REQUEST_FILENAME "@contains /.well-known/carddav" \
-    "id:9003603,\
+    "id:9003670,\
     phase:2,\
     pass,\
     t:none,\
@@ -503,7 +493,7 @@ SecRule REQUEST_FILENAME "@contains /.well-known/carddav" \
 
 # Allows notifications to be deleted
 SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/notifications/api/v2/notifications" \
-    "id:9003701,\
+    "id:9003700,\
     phase:2,\
     pass,\
     t:none,\
@@ -518,11 +508,12 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/notifications/api/v2/notifi
 
 # Allow access to the shares API URL from mobile app
 SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/files_sharing/api/v1/shares" \
-    "id:9003800,\
+    "id:9003750,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.3.0',\
     chain"
     SecRule REQUEST_METHOD "@streq GET" \
         "t:none,\
@@ -535,7 +526,7 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/files_sharing/api/v1/shares
 
 # Allow users to be deleted
 SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/cloud/users/" \
-    "id:9003850,\
+    "id:9003800,\
     phase:2,\
     pass,\
     t:none,\
@@ -552,13 +543,14 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/cloud/users/" \
 
 # Allow configure file extensions fields
 SecRule REQUEST_FILENAME "@contains /config/apps/ransomware_protection/extension_additions" \
-    "id:9003900,\
+    "id:9003850,\
     phase:2,\
     pass,\
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=932130;ARGS:value,\
     ver:'OWASP_CRS/3.3.0'"
+
 
 SecMarker "END-NEXTCLOUD-ADMIN"
 

--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -8,7 +8,7 @@
 #
 # ------------------------------------------------------------------------
 
-# These exclusions remedy false positives in a default NextCloud install.
+# These exclusions remedy false positives in a default Nextcloud install.
 # They will likely work with OwnCloud too, but you may have to modify them.
 # The exclusions are only active if crs_exclusions_nextcloud=1 is set.
 # See rule 900130 in crs-setup.conf.example for instructions.
@@ -59,9 +59,8 @@ SecRule &TX:crs_exclusions_nextcloud|TX:crs_exclusions_nextcloud "@eq 0" \
 #
 # [ File Manager ]
 #
-#
-# The web interface uploads files, and interacts with the user.
 
+# The web interface uploads files, and interacts with the user.
 SecRule REQUEST_FILENAME "@contains /remote.php/webdav" \
     "id:9003100,\
     phase:2,\
@@ -77,7 +76,6 @@ SecRule REQUEST_FILENAME "@contains /remote.php/webdav" \
     ver:'OWASP_CRS/3.3.0'"
 
 # Skip PUT parsing for invalid encoding / protocol violations in binary files.
-
 SecRule REQUEST_METHOD "@streq PUT" \
     "id:9003105,\
     phase:2,\
@@ -95,7 +93,7 @@ SecRule REQUEST_METHOD "@streq PUT" \
         ctl:ruleRemoveById=930120"
 
 # Fix for Nextcloud Desktop Client
-SecRule REQUEST_METHOD "@rx ^(?:PROPFIND|PUT)$" \
+SecRule REQUEST_METHOD "@pm PROPFIND PUT" \
     "id:9003106,\
     phase:2,\
     pass,\
@@ -108,7 +106,7 @@ SecRule REQUEST_METHOD "@rx ^(?:PROPFIND|PUT)$" \
         ctl:ruleRemoveById=921110"
 
 # Fix for Nextcloud Desktop Client
-SecRule REQUEST_METHOD "@rx ^(?:PROPFIND|PUT)$" \
+SecRule REQUEST_METHOD "@pm PROPFIND PUT" \
     "id:9003107,\
     phase:2,\
     pass,\
@@ -121,7 +119,6 @@ SecRule REQUEST_METHOD "@rx ^(?:PROPFIND|PUT)$" \
         ctl:ruleRemoveById=921110"
 
 # Allow the data type 'text/vcard'
-
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     "id:9003110,\
     phase:2,\
@@ -132,8 +129,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/vcard|'"
 
 # Allow the data type 'application/octet-stream'
-
-SecRule REQUEST_METHOD "@rx ^(?:PUT|MOVE)$" \
+SecRule REQUEST_METHOD "@pm PUT MOVE" \
     "id:9003115,\
     phase:2,\
     pass,\
@@ -141,11 +137,10 @@ SecRule REQUEST_METHOD "@rx ^(?:PUT|MOVE)$" \
     nolog,\
     ver:'OWASP_CRS/3.3.0',\
     chain"
-    SecRule REQUEST_FILENAME "@rx /remote\.php/dav/(?:files|uploads)/" \
+    SecRule REQUEST_FILENAME "@pm /remote.php/dav/files/ /remote.php/dav/uploads/" \
         "setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |application/octet-stream|'"
 
 # Allow data types like video/mp4
-
 SecRule REQUEST_METHOD "@streq PUT" \
     "id:9003116,\
     phase:2,\
@@ -154,7 +149,7 @@ SecRule REQUEST_METHOD "@streq PUT" \
     nolog,\
     ver:'OWASP_CRS/3.3.0',\
     chain"
-    SecRule REQUEST_FILENAME "@rx (?:/public\.php/webdav/|/remote\.php/dav/uploads/)" \
+    SecRule REQUEST_FILENAME "@pm /public.php/webdav/ /remote.php/dav/uploads/" \
         "ctl:ruleRemoveById=920340,\
         ctl:ruleRemoveById=920420"
 
@@ -162,7 +157,6 @@ SecRule REQUEST_METHOD "@streq PUT" \
 # Allow characters like /../ in files.
 # Allow all kind of filetypes.
 # Allow source code.
-
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     "id:9003120,\
     phase:2,\
@@ -176,7 +170,6 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     ver:'OWASP_CRS/3.3.0'"
 
 # Allow REPORT requests without Content-Type header (at least the iOS app does this)
-
 SecRule REQUEST_METHOD "@streq REPORT" \
     "id:9003121,\
     phase:2,\
@@ -189,10 +182,11 @@ SecRule REQUEST_METHOD "@streq REPORT" \
         ctl:ruleRemoveById=920340"
 
 
+#
 # [ Searchengine ]
 #
-# Nextcloud uses a search field for filename or content queries.
 
+# Nextcloud uses a search field for filename or content queries.
 SecRule REQUEST_FILENAME "@contains /index.php/core/search" \
     "id:9003125,\
     phase:2,\
@@ -205,8 +199,10 @@ SecRule REQUEST_FILENAME "@contains /index.php/core/search" \
     ver:'OWASP_CRS/3.3.0'"
 
 
+#
 # [ DAV ]
 #
+
 # NextCloud uses DAV methods with index.php and remote.php to do many things
 # The default ones in ModSecurity are: GET HEAD POST OPTIONS
 #
@@ -217,8 +213,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/core/search" \
 # Others in the code or js files: PATCH MKCOL MOVE TRACE
 # Others that I added just in case, and they seem related:
 #   CHECKOUT COPY LOCK MERGE MKACTIVITY UNLOCK.
-
-SecRule REQUEST_FILENAME "@rx /(?:remote|index|public)\.php/" \
+SecRule REQUEST_FILENAME "@pm /remote.php/ /index.php/ /public.php/" \
     "id:9003130,\
     phase:2,\
     pass,\
@@ -227,11 +222,9 @@ SecRule REQUEST_FILENAME "@rx /(?:remote|index|public)\.php/" \
     ver:'OWASP_CRS/3.3.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT PATCH CHECKOUT COPY DELETE LOCK MERGE MKACTIVITY MKCOL MOVE PROPFIND PROPPATCH SEARCH UNLOCK REPORT TRACE jsonp'"
 
-
 # We need to allow DAV methods for sharing files, and removing shares
 # DELETE - when the share is removed
 # PUT - when setting a password / expiration time
-
 SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/files_sharing/" \
     "id:9003140,\
     phase:2,\
@@ -242,8 +235,11 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/files_sharing/" \
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT DELETE'"
 
 
+#
 # [ Preview and Thumbnails ]
+#
 
+# Preview
 SecRule REQUEST_FILENAME "@contains /index.php/core/preview.png" \
     "id:9003150,\
     phase:2,\
@@ -254,7 +250,6 @@ SecRule REQUEST_FILENAME "@contains /index.php/core/preview.png" \
     ver:'OWASP_CRS/3.3.0'"
 
 # Filepreview for trashbin
-
 SecRule REQUEST_FILENAME "@contains /index.php/apps/files_trashbin/ajax/preview.php" \
     "id:9003155,\
     phase:2,\
@@ -265,7 +260,8 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/files_trashbin/ajax/preview.
     ctl:ruleRemoveTargetById=942190;ARGS:file,\
     ver:'OWASP_CRS/3.3.0'"
 
-SecRule REQUEST_FILENAME "@rx /index\.php/(?:apps/gallery/thumbnails|logout$)" \
+# Thumbnails
+SecRule REQUEST_FILENAME "@contains /index.php/apps/gallery/thumbnails" \
     "id:9003160,\
     phase:2,\
     pass,\
@@ -275,7 +271,9 @@ SecRule REQUEST_FILENAME "@rx /index\.php/(?:apps/gallery/thumbnails|logout$)" \
     ver:'OWASP_CRS/3.3.0'"
 
 
+#
 # [ Ownnote ]
+#
 
 SecRule REQUEST_FILENAME "@contains /index.php/apps/ownnote/" \
     "id:9003300,\
@@ -286,11 +284,11 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/ownnote/" \
     ctl:ruleRemoveById=941150,\
     ver:'OWASP_CRS/3.3.0'"
 
-
+#
 # [ Text Editor ]
 #
-# This file can save anything, and it's name could be lots of things.
 
+# This file can save anything, and it's name could be lots of things.
 SecRule REQUEST_FILENAME "@contains /index.php/apps/files_texteditor/" \
     "id:9003310,\
     phase:2,\
@@ -305,10 +303,11 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/files_texteditor/" \
     ver:'OWASP_CRS/3.3.0'"
 
 
+#
 # [ Address Book ]
 #
-# Allow the data type 'text/vcard'
 
+# Allow the data type 'text/vcard'
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/addressbooks/" \
     "id:9003320,\
     phase:2,\
@@ -331,10 +330,11 @@ SecRule REQUEST_METHOD "@streq PUT" \
         ctl:ruleRemoveById=200002"
 
 
+#
 # [ Calendar ]
 #
-# Allow the data type 'text/calendar'
 
+# Allow the data type 'text/calendar'
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/calendars/" \
     "id:9003330,\
     phase:2,\
@@ -365,28 +365,17 @@ SecRule REQUEST_METHOD "@streq PROPFIND" \
     nolog,\
     ver:'OWASP_CRS/3.3.0',\
     chain"
-    SecRule REQUEST_FILENAME "@contains /remote.php/dav/principals/users/" \
-        "t:none,\
-        ctl:ruleRemoveById=921110"
-
-SecRule REQUEST_METHOD "@streq PROPFIND" \
-    "id:9003333,\
-    phase:2,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'OWASP_CRS/3.3.0',\
-    chain"
-    SecRule REQUEST_FILENAME "@contains /remote.php/dav/calendars/" \
+    SecRule REQUEST_FILENAME "@pm /remote.php/dav/principals/users/ /remote.php/dav/calendars/" \
         "t:none,\
         ctl:ruleRemoveById=921110"
 
 
+#
 # [ Notes ]
 #
+
 # We want to allow a lot of things as the user is
 # allowed to note on anything.
-
 SecRule REQUEST_FILENAME "@contains /index.php/apps/notes/" \
     "id:9003340,\
     phase:2,\
@@ -397,10 +386,11 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/notes/" \
     ver:'OWASP_CRS/3.3.0'"
 
 
+#
 # [ Bookmarks ]
 #
-# Allow urls in data.
 
+# Allow urls in data.
 SecRule REQUEST_FILENAME "@contains /index.php/apps/bookmarks/" \
     "id:9003350,\
     phase:2,\
@@ -412,13 +402,11 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/bookmarks/" \
 
 
 #
-# [ Login forms ]
+# [ Login forms & Logout ]
 #
-
 # This removes checks on the 'password' and related fields:
 
 # User login password.
-
 SecRule REQUEST_FILENAME "@contains /index.php/login" \
     "id:9003400,\
     phase:2,\
@@ -430,7 +418,6 @@ SecRule REQUEST_FILENAME "@contains /index.php/login" \
     ver:'OWASP_CRS/3.3.0'"
 
 # Reset password.
-
 SecRule REQUEST_FILENAME "@endsWith /index.php/login" \
     "id:9003410,\
     phase:2,\
@@ -448,8 +435,17 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/login" \
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1-text,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass2"
 
-# Change Password and Setting up a new user/password
+# Logout
+SecRule REQUEST_FILENAME "@endsWith /index.php/logout" \
+    "id:9003420,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetById=941120;ARGS:requesttoken,\
+    ver:'OWASP_CRS/3.3.0'"
 
+# Change Password and Setting up a new user/password
 SecRule REQUEST_FILENAME "@endsWith /index.php/settings/users" \
     "id:9003500,\
     phase:2,\
@@ -464,7 +460,6 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/settings/users" \
 #
 # [ Settings pages ]
 #
-
 # This removes checks on multiple settings pages
 
 # Personal: Security
@@ -500,6 +495,7 @@ SecRule REQUEST_FILENAME "@contains /.well-known/carddav" \
     ver:'OWASP_CRS/3.3.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PROPFIND'"
 
+
 #
 # [ Notifications ]
 #
@@ -514,6 +510,7 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/notifications/api/v2/notifi
     nolog,\
     ver:'OWASP_CRS/3.3.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
+
 
 #
 # [ API ]
@@ -531,6 +528,7 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/files_sharing/api/v1/shares
         "t:none,\
         ctl:ruleRemoveById=200002"
 
+
 #
 # [ Users ]
 #
@@ -544,6 +542,7 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/cloud/users/" \
     nolog,\
     ver:'OWASP_CRS/3.3.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
+
 
 #
 # [ Extensions ]

--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -549,7 +549,9 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/cloud/users/" \
 # [ Extensions ]
 #
 
-# Ransomware protection
+# Extension: Ransomware protection
+
+# Allow configure file extensions fields
 SecRule REQUEST_FILENAME "@contains /config/apps/ransomware_protection/extension_additions" \
     "id:9003900,\
     phase:2,\


### PR DESCRIPTION
- Fix issues during uploading e.g. PHP files (add PUT method to 9003106, 9003107 rules)
- Keep same syntax for match /ocs/v[0-9].php
- Add rule to allow Nextcloud users delete.
- Add rule to allow configure file extensions list in Ransomware protection extension.