### PR TITLE
Fixing and improving environment for testing (docker/nginx)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,9 @@ __pycache__/
 *$py.class
 
 .idea/
+
+# ignore .env in tests for docker-compose variables
+tests/.env
+
+# ignore logs created after docker-compose up
+logs/

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - SERVERNAME=modsec2-apache
       - MODSEC_RULE_ENGINE=DetectionOnly
       - PARANOIA=5
+      - TZ=${TZ}
     volumes:
       - ${GITHUB_WORKSPACE}/logs/modsec2-apache:/var/log/apache2
       - ${GITHUB_WORKSPACE}/rules:/etc/modsecurity.d/owasp-crs/rules
@@ -22,6 +23,7 @@ services:
       - SERVERNAME=modsec3-apache
       - MODSEC_RULE_ENGINE=DetectionOnly
       - PARANOIA=5
+      - TZ=${TZ}
     volumes:
       - ${GITHUB_WORKSPACE}/logs/modsec3-apache:/var/log/apache2
       - ${GITHUB_WORKSPACE}/rules:/etc/modsecurity.d/owasp-crs/rules
@@ -34,6 +36,7 @@ services:
       - SERVERNAME=modsec3-nginx
       - MODSEC_RULE_ENGINE=DetectionOnly
       - PARANOIA=5
+      - TZ=${TZ}
     volumes:
       - ${GITHUB_WORKSPACE}/logs/modsec3-nginx:/var/log/nginx
       - ${GITHUB_WORKSPACE}/rules:/etc/modsecurity.d/owasp-crs/rules

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -37,5 +37,6 @@ services:
     volumes:
       - ${GITHUB_WORKSPACE}/logs/modsec3-nginx:/var/log/nginx
       - ${GITHUB_WORKSPACE}/rules:/etc/modsecurity.d/owasp-crs/rules
+      - ${GITHUB_WORKSPACE}/tests/nginx-default.conf:/etc/nginx/conf.d/default.conf
     ports:
       - "80:80"

--- a/tests/nginx-default.conf
+++ b/tests/nginx-default.conf
@@ -1,0 +1,20 @@
+server {
+    listen       80;
+    server_name localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    # Workaround to allow POST method on static page
+    error_page 405 = @fallback;
+    location @fallback {
+      return 200 $uri;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
While working on issue #1886 ad PR #1887 I've noticed some needs to be done with testing environment:

1) Allowing nginx to return 200 not 405 (Method Not Allowed) if the rule is not triggered using POST method on static uri / (index), it's important if we want to check output header not the rule id in testing framework rule, ie.
        output:
          header: 200
it's possible to use set of headers like [200,405] or check assert of 405 instead 200 but it's not clear.

2) Using .env file with environmental variables loaded by Docker in docker-composer.yaml file for TZ variable. It's important to run proper timezone for log parser of FTW testing framework. It was a little bit confusing because my localhost had got 2 hours time ahead (CEST timezone) and the log parser could not find entries of tests in error.log file during using log_contains id rule asserts approach. Setting proper timezone in .env file and passing TZ variable to environment of container has resolved the issue.

3) .gitignore .env file and logs/ dir added