### PR TITLE
Fix stricter sibling comment for SQL Injection

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -38,7 +38,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:942012,phase:2,pass,nolog,skipAf
 #
 # -=[ LibInjection Check ]=-
 #
-# There is a stricter sibling of this rule at 941101. It covers REQUEST_BASENAME.
+# There is a stricter sibling of this rule at 942101. It covers REQUEST_BASENAME.
 #
 # Ref: https://libinjection.client9.com/
 #


### PR DESCRIPTION
The comment referred to the wrong rule ID.