### PR TITLE
Monitoring tools exclusion

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -792,6 +792,36 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 
 
 #
+# -- [[ Allow trusted IPs and User-Agent ]] ------------------------------------
+#
+# Uncomment this rule to allow all requests from trusted IPs and User-Agent.
+# This can be useful for monitoring tools like Monit, Nagios, or other agents.
+# For example, if you're using AWS Load Balancer, you may need to trust all
+# requests from "10.0.0.0/8" subnet that come with the user-agent
+# "ELB-HealthChecker/2.0". By doing this, all requests that match these
+# conditions will not be matched against the following rules:
+#
+# - id: 911100 (allowed methods)
+# - id: 913100,913110,913120,913101,913102 (scan detection)
+# - id: 920280 (missing/empty host header)
+# - id: 920350 (IP address in host header)
+# - tag: attack-dos (DoS protection)
+# - tag: attack-disclosure (all RESPONSE-*-DATA-LEAKAGES rules)
+#
+# This exclusion works only for methods GET and HEAD.
+# For more information see rule 901480.
+#
+#SecAction \
+# "id:900980,\
+#  phase:1,\
+#  nolog,\
+#  pass,\
+#  t:none,\
+#  setvar:'tx.trusted_ips=127.0.0.1,127.0.0.2',\
+#  setvar:'tx.trusted_ua=Nagios Monit HealthChecker'"
+
+
+#
 # -- [[ Collection timeout ]] --------------------------------------------------
 #
 # Set the SecCollectionTimeout directive from the ModSecurity default (1 hour)

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -436,6 +436,46 @@ SecRule TX:sampling_rnd100 "!@lt %{tx.sampling_percentage}" \
 SecMarker "END-SAMPLING"
 
 
+# Default trusted IPs and User-Agent
+SecRule &TX:trusted_ips "@eq 0" \
+    "id:901460,\
+    phase:1,\
+    pass,\
+    nolog,\
+    ver:'OWASP_CRS/3.4.0',\
+    skipAfter:END-MONITORING-TOOLS-EXCLUSION"
+
+SecRule &TX:trusted_ua "@eq 0" \
+    "id:901470,\
+    phase:1,\
+    pass,\
+    nolog,\
+    ver:'OWASP_CRS/3.4.0',\
+    skipAfter:END-MONITORING-TOOLS-EXCLUSION"
+
+SecRule REMOTE_ADDR "@ipMatch %{tx.trusted_ips}" \
+    "id:901480,\
+    phase:1,\
+    pass,\
+    nolog,\
+    ver:'OWASP_CRS/3.4.0',\
+    chain"
+    SecRule REQUEST_METHOD "@pm GET HEAD" "chain"
+    SecRule REQUEST_HEADERS:User-Agent "@pm %{tx.trusted_ua}" \
+        "ctl:ruleRemoveById=911100,\
+        ctl:ruleRemoveById=913100,\
+        ctl:ruleRemoveById=913110,\
+        ctl:ruleRemoveById=913120,\
+        ctl:ruleRemoveById=913101,\
+        ctl:ruleRemoveById=913102,\
+        ctl:ruleRemoveById=920280,\
+        ctl:ruleRemoveById=920350,\
+        ctl:ruleRemoveByTag=attack-disclosure,\
+        ctl:ruleRemoveByTag=attack-dos"
+
+SecMarker "END-MONITORING-TOOLS-EXCLUSION"
+
+
 #
 # Configuration Plausibility Checks
 #


### PR DESCRIPTION
Rule Logic:

A user must uncomment SecAction 900980 from crs-setup.conf to enable the exclusion. The SecAction has 2 variables that users must configure:

- tx.trusted_ips: a comma-separated list of IPs or classes
- tx.trusted_ua: a whitespace-separated list of User-Agent (partial match)

The exclusion occurs only for GET and HEAD methods, and it removes the following rules:

- id: 911100 (allowed methods)
- id: 913100,913110,913120,913101,913102 (scan detection)
- id: 920280 (missing/empty host header)
- id: 920350 (IP address in host header)
- tag: attack-dos (DoS protection)
- tag: attack-disclosure (all RESPONSE-*-DATA-LEAKAGES rules)