### PR TITLE
WordPress Site Health Exclusion Rule

### DIFF
--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -715,7 +715,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/edit.php" \
 
 # Wordpress Site Health
 # The wordpress site health page makes use of embedded SQL/PHP
-# which triggers PHP/MySQL leak rules.
+# which triggers PHP/SQL leak rules.
 SecRule REQUEST_FILENAME "@rx /wp-admin/site-health.php" \
     "id:9002910,\
     phase:2,\

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -717,7 +717,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/edit.php" \
 # The wordpress site health page makes use of embedded SQL/PHP
 # which triggers PHP/SQL leak rules.
 SecRule REQUEST_FILENAME "@rx /wp-admin/site-health.php" \
-    "id:9002910,\
+    "id:9002840,\
     phase:2,\
     pass,\
     t:none,\

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -713,6 +713,18 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/edit.php" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:s,\
     ver:'OWASP_CRS/3.3.0'"
 
+# Wordpress Site Health
+# The wordpress site health page makes use of embedded SQL/PHP
+# which triggers PHP/MySQL leak rules.
+SecRule REQUEST_FILENAME "@rx /wp-admin/site-health.php" \
+    "id:9002910,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveById=951220,\
+    ctl:ruleRemoveById=953110,\
+    ver:'OWASP_CRS/3.3.0'"
 
 #
 # [ Helpers ]


### PR DESCRIPTION
Add a WordPress Exclusion Rule

WordPress has a site health page in the admin portal that triggers 2 data leakages errors in the current default rule set up even when using the WordPress exclusion package.
* 951220 - 951-DATA-LEAKAGES-SQL.conf 
* 953110 - 951-DATA-LEAKAGES-PHP.conf

This adds an exclusion rule for the site health page to disable these 2 rules.

This implements #1919 