### PR TITLE
feat(ci): add test plugin to annotate failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,7 @@ jobs:
         run: |
           pip install --upgrade setuptools wheel
           pip install -r tests/regression/requirements.txt
+          pip install pytest-github-actions-annotate-failures
 
       - name: "Run tests for ${{ matrix.modsec_version }}"
         run: |


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

This PR should annotate failed tests in the github interface.