### PR TITLE
fix(test): fixes tests lacking charset

### DIFF
--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941310.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941310.yaml
@@ -15,7 +15,7 @@
           dest_addr: 127.0.0.1
           headers:
             Host: localhost
-            Content-type: us-ascii
+            Content-Type: "application/x-www-form-urlencoded; charset=us-ascii"
           method: POST
           port: 80
           uri: /
@@ -32,7 +32,7 @@
           dest_addr: 127.0.0.1
           headers:
             Host: localhost
-            Content-type: us-ascii
+            Content-Type: "application/x-www-form-urlencoded; charset=us-ascii"
           method: POST
           port: 80
           uri: /
@@ -49,7 +49,7 @@
           dest_addr: 127.0.0.1
           headers:
             Host: localhost
-            Content-type: us-ascii
+            Content-Type: "application/x-www-form-urlencoded; charset=us-ascii"
           method: POST
           port: 80
           uri: /
@@ -66,7 +66,7 @@
           dest_addr: 127.0.0.1
           headers:
             Host: localhost
-            Content-type: us-ascii
+            Content-Type: "application/x-www-form-urlencoded; charset=us-ascii"
           method: POST
           port: 80
           uri: /


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

While doing tests for getting a new ftw version using py3, I found that these tests should have had the charset involved to be working properly.