### PR TITLE
feat(ci): use relative paths in testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,37 +38,49 @@ jobs:
         # Will include soon for modsec3-nginx
 
     steps:
-      - name: Checkout repo
+      - name: "Checkout repo"
         uses: actions/checkout@v2
 
-      - name: Set up Python 2
-        uses: actions/setup-python@v1
+      - name: "Set up Python"
+        uses: actions/setup-python@v2
         with:
-          python-version: 2.7
+          python-version: '2.x'
 
-      - name: "Run tests for ${{ matrix.modsec_version }}`"
-        env:
-          CONFIG: ${{ matrix.modsec_version }}
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: "Install dependencies"
         run: |
-          python -V
-          mkdir -p logs/"${CONFIG}"
-          docker-compose -f ./tests/docker-compose.yml up -d "${CONFIG}"
-          pip install --upgrade setuptools
+          pip install --upgrade setuptools wheel
           pip install -r tests/regression/requirements.txt
+
+      - name: "Run tests for ${{ matrix.modsec_version }}"
+        run: |
+          mkdir -p tests/logs/${{ matrix.modsec_version }}/{nginx,apache2}
+          docker-compose -f ./tests/docker-compose.yml up -d "${{ matrix.modsec_version }}"
           # Use mounted volume path
-          if [[ "${CONFIG}" == *"nginx" ]]; then
-            LOGDIR="/var/log/nginx"
-          else
-            LOGDIR="/var/log/apache2"
-          fi
-          sed -ie "s:${LOGDIR}:${GITHUB_WORKSPACE}/logs/${CONFIG}:g" tests/regression/config.ini
-          py.test -vs tests/regression/CRS_Tests.py \
-            --config="${CONFIG}" \
+          py.test -vs --tb=short tests/regression/CRS_Tests.py \
+            --config="${{ matrix.modsec_version }}" \
             --ruledir=./tests/regression/tests/${{ matrix.tests }}
 
-      - name: Clean docker-compose
-        env:
-          CONFIG: modsec2-apache
+      - name: "Change permissions if failed"
+        if: failure()
         run: |
-          docker-compose -f ./tests/docker-compose.yml stop "${CONFIG}"
+            # we want to get the audit log, so change permissions (file is only for root on docker)
+            sudo chmod 644 tests/logs/${{ matrix.modsec_version }}/modsec_audit.log
+
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: waf-logs
+          path: tests/logs/${{ matrix.modsec_version }}
+
+      - name: Clean docker-compose
+        run: |
+          docker-compose -f ./tests/docker-compose.yml stop "${{ matrix.modsec_version }}"
           docker-compose -f ./tests/docker-compose.yml down

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ __pycache__/
 *$py.class
 
 .idea/
+
+# Ignore test logs
+tests/logs/

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,41 +1,45 @@
-version: '3.1'
+version: '3.2'
 
 # Only one of these will be up at a time for now.
 # Concurrency will be on the tests folder we have.
 
 services:
   modsec2-apache:
-    image: owasp/modsecurity-crs:v3.2-modsec2-apache
+    container_name: modsec2-apache
+    image: owasp/modsecurity-crs:3.3-apache
     environment:
-      - SERVERNAME=modsec2-apache
-      - MODSEC_RULE_ENGINE=DetectionOnly
-      - PARANOIA=5
+      SERVERNAME: modsec2-apache
+      BACKEND: https://www.example.com
+      PORT: "80"
+      MODSEC_RULE_ENGINE: DetectionOnly
+      PARANOIA: 5
+      ERRORLOG: "/var/log/apache2/error.log"
+      ACCESSLOG: "/var/log/apache2/access.log"
+      MODSEC_AUDIT_LOG_FORMAT: Native
+      MODSEC_AUDIT_LOG_TYPE: Serial
+      MODSEC_AUDIT_LOG: "/var/log/modsec_audit.log"
     volumes:
-      - ${GITHUB_WORKSPACE}/logs/modsec2-apache:/var/log/apache2
-      - ${GITHUB_WORKSPACE}/rules:/etc/modsecurity.d/owasp-crs/rules
-    ports:
-      - "80:80"
-
-  modsec3-apache:
-    image: owasp/modsecurity-crs:v3.2-modsec3-apache
-    environment:
-      - SERVERNAME=modsec3-apache
-      - MODSEC_RULE_ENGINE=DetectionOnly
-      - PARANOIA=5
-    volumes:
-      - ${GITHUB_WORKSPACE}/logs/modsec3-apache:/var/log/apache2
-      - ${GITHUB_WORKSPACE}/rules:/etc/modsecurity.d/owasp-crs/rules
+      - ./logs/modsec2-apache:/var/log:rw
+      - ../rules:/opt/owasp-crs/rules:ro
     ports:
       - "80:80"
 
   modsec3-nginx:
-    image: owasp/modsecurity-crs:v3.2-modsec3-nginx
+    container_name: modsec3-nginx
+    image: owasp/modsecurity-crs:3.3-nginx
     environment:
-      - SERVERNAME=modsec3-nginx
-      - MODSEC_RULE_ENGINE=DetectionOnly
-      - PARANOIA=5
+      SERVERNAME: modsec3-nginx
+      BACKEND: https://www.example.com
+      PORT: "80"
+      MODSEC_RULE_ENGINE: DetectionOnly
+      PARANOIA: 5
+      ERRORLOG: "/var/log/nginx/error.log"
+      ACCESSLOG: "/var/log/nginx/access.log"
+      MODSEC_AUDIT_LOG_FORMAT: Native
+      MODSEC_AUDIT_LOG_TYPE: Serial
+      MODSEC_AUDIT_LOG: "/var/log/modsec_audit.log"
     volumes:
-      - ${GITHUB_WORKSPACE}/logs/modsec3-nginx:/var/log/nginx
-      - ${GITHUB_WORKSPACE}/rules:/etc/modsecurity.d/owasp-crs/rules
+      - ./logs/modsec3-nginx:/var/log:rw
+      - ../rules:/opt/owasp-crs/rules:ro
     ports:
       - "80:80"

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       BACKEND: http://backend
       PORT: "80"
       MODSEC_RULE_ENGINE: DetectionOnly
-      PARANOIA: 5
+      PARANOIA: 4
       ERRORLOG: "/var/log/apache2/error.log"
       ACCESSLOG: "/var/log/apache2/access.log"
       MODSEC_AUDIT_LOG_FORMAT: Native
@@ -35,7 +35,7 @@ services:
       BACKEND: https://www.example.com
       PORT: "80"
       MODSEC_RULE_ENGINE: DetectionOnly
-      PARANOIA: 5
+      PARANOIA: 4
       ERRORLOG: "/var/log/nginx/error.log"
       ACCESSLOG: "/var/log/nginx/access.log"
       MODSEC_AUDIT_LOG_FORMAT: Native

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     image: owasp/modsecurity-crs:3.3-apache
     environment:
       SERVERNAME: modsec2-apache
-      BACKEND: https://www.example.com
+      BACKEND: http://backend
       PORT: "80"
       MODSEC_RULE_ENGINE: DetectionOnly
       PARANOIA: 5
@@ -23,6 +23,9 @@ services:
       - ../rules:/opt/owasp-crs/rules:ro
     ports:
       - "80:80"
+    depends_on:
+      - backend
+
 
   modsec3-nginx:
     container_name: modsec3-nginx
@@ -43,3 +46,11 @@ services:
       - ../rules:/opt/owasp-crs/rules:ro
     ports:
       - "80:80"
+    depends_on:
+      - backend
+
+  # our test originally targeted www.example.com as backend
+  # and that would do real traffic, to a real site
+  #
+  backend:
+    image: docker.io/kennethreitz/httpbin

--- a/tests/regression/config.ini
+++ b/tests/regression/config.ini
@@ -1,14 +1,9 @@
 [modsec2-apache]
 log_date_format = %a %b %d %H:%M:%S.%f %Y
 log_date_regex = \[([A-Z][a-z]{2} [A-z][a-z]{2} \d{1,2} \d{1,2}\:\d{1,2}\:\d{1,2}\.\d+? \d{4})\]
-log_location_linux = /var/log/apache2/error.log
-
-[modsec3-apache]
-log_date_format = %a %b %d %H:%M:%S.%f %Y
-log_date_regex = \[([A-Z][a-z]{2} [A-z][a-z]{2} \d{1,2} \d{1,2}\:\d{1,2}\:\d{1,2}\.\d+? \d{4})\]
-log_location_linux = /var/log/apache2/error.log
+log_location_linux = tests/logs/modsec2-apache/apache2/error.log
 
 [modsec3-nginx]
 log_date_format = %Y/%m/%d %H:%M:%S
 log_date_regex = (\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2})
-log_location_linux = /var/log/nginx/error.log
+log_location_linux = tests/logs/modsec3-nginx/nginx/error.log

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920160.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920160.yaml
@@ -62,6 +62,7 @@
             output:
               status: 400
     -
+      # Test is based in httpbin.org, so backend returns 405 if you are not posting to /post
       # Apache auto corrects for this error now so the log should not contain anything
       test_title: 920160-4
       desc: Content-Length HTTP header is not numeric (920160)  from old modsec regressions
@@ -82,7 +83,7 @@
               User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv
             method: POST
             port: 80
-            uri: /
+            uri: /post
             version: HTTP/1.0
             data: abc
           output:


### PR DESCRIPTION
Some improvements to the test pipeline:
- use relative paths, so when executing local tests would be easy to use
- provides artifacts when the build fails, so you can download the corresponding web server files
- switch to local container instead of using http://www.example.org as backend.

Changing to httpbin.org container has the side effect of returning 405 for one test so the url for the test needs to be fixed.

Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>