### PR TITLE
Decreased the 'phase' values where variable(s) allow(s)

### DIFF
--- a/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
@@ -116,7 +116,7 @@ SecAction "id:9001100,\
 #
 SecRule REQUEST_FILENAME "@endsWith /core/install.php" \
     "id:9001110,\
-    phase:2,\
+    phase:1,\
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:account[pass][pass1],\
@@ -125,7 +125,7 @@ SecRule REQUEST_FILENAME "@endsWith /core/install.php" \
 
 SecRule REQUEST_FILENAME "@endsWith /user/login" \
     "id:9001112,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -134,7 +134,7 @@ SecRule REQUEST_FILENAME "@endsWith /user/login" \
 
 SecRule REQUEST_FILENAME "@endsWith /admin/people/create" \
     "id:9001114,\
-    phase:2,\
+    phase:1,\
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass[pass1],\
@@ -143,7 +143,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/people/create" \
 
 SecRule REQUEST_FILENAME "@rx /user/[0-9]+/edit$" \
     "id:9001116,\
-    phase:2,\
+    phase:1,\
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:current_pass,\
@@ -165,7 +165,7 @@ SecRule REQUEST_FILENAME "@rx /user/[0-9]+/edit$" \
 #
 SecRule REQUEST_FILENAME "@contains /admin/config/" \
     "id:9001122,\
-    phase:2,\
+    phase:1,\
     pass,\
     nolog,\
     ctl:ruleRemoveById=942430,\
@@ -173,7 +173,7 @@ SecRule REQUEST_FILENAME "@contains /admin/config/" \
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/people/accounts" \
     "id:9001124,\
-    phase:2,\
+    phase:1,\
     pass,\
     nolog,\
     ctl:ruleRemoveById=920271,\
@@ -190,7 +190,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/people/accounts" \
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/development/configuration/single/import" \
     "id:9001126,\
-    phase:2,\
+    phase:1,\
     pass,\
     nolog,\
     ctl:ruleRemoveById=920271,\
@@ -199,7 +199,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/development/configuration/sing
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/development/maintenance" \
     "id:9001128,\
-    phase:2,\
+    phase:1,\
     pass,\
     nolog,\
     ctl:ruleRemoveById=942440,\
@@ -216,7 +216,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/development/maintenance" \
 #
 SecRule REQUEST_FILENAME "@endsWith /contextual/render" \
     "id:9001140,\
-    phase:2,\
+    phase:1,\
     pass,\
     nolog,\
     ctl:ruleRemoveTargetById=942130;ARGS:ids[],\
@@ -251,7 +251,7 @@ SecAction "id:9001160,\
 #
 SecRule REQUEST_FILENAME "@endsWith /admin/config/content/formats/manage/full_html" \
     "id:9001170,\
-    phase:2,\
+    phase:1,\
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:editor[settings][toolbar][button_groups],\
@@ -329,7 +329,7 @@ SecRule REQUEST_METHOD "@streq POST" \
 #
 SecRule REQUEST_FILENAME "@endsWith /node/add/article" \
     "id:9001200,\
-    phase:2,\
+    phase:1,\
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body[0][value],\
@@ -338,7 +338,7 @@ SecRule REQUEST_FILENAME "@endsWith /node/add/article" \
 
 SecRule REQUEST_FILENAME "@endsWith /node/add/page" \
     "id:9001202,\
-    phase:2,\
+    phase:1,\
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body[0][value],\
@@ -347,7 +347,7 @@ SecRule REQUEST_FILENAME "@endsWith /node/add/page" \
 
 SecRule REQUEST_FILENAME "@rx /node/[0-9]+/edit$" \
     "id:9001204,\
-    phase:2,\
+    phase:1,\
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body[0][value],\
@@ -357,7 +357,7 @@ SecRule REQUEST_FILENAME "@rx /node/[0-9]+/edit$" \
 
 SecRule REQUEST_FILENAME "@endsWith /block/add" \
     "id:9001206,\
-    phase:2,\
+    phase:1,\
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body[0][value],\
@@ -365,7 +365,7 @@ SecRule REQUEST_FILENAME "@endsWith /block/add" \
 
 SecRule REQUEST_FILENAME "@endsWith /admin/structure/block/block-content/manage/basic" \
     "id:9001208,\
-    phase:2,\
+    phase:1,\
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:description,\
@@ -373,7 +373,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/structure/block/block-content/manage/
 
 SecRule REQUEST_FILENAME "@rx /editor/filter_xss/(?:full|basic)_html$" \
     "id:9001210,\
-    phase:2,\
+    phase:1,\
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:value,\
@@ -381,7 +381,7 @@ SecRule REQUEST_FILENAME "@rx /editor/filter_xss/(?:full|basic)_html$" \
 
 SecRule REQUEST_FILENAME "@rx /user/[0-9]+/contact$" \
     "id:9001212,\
-    phase:2,\
+    phase:1,\
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message[0][value],\
@@ -389,7 +389,7 @@ SecRule REQUEST_FILENAME "@rx /user/[0-9]+/contact$" \
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/development/maintenance" \
     "id:9001214,\
-    phase:2,\
+    phase:1,\
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:maintenance_mode_message,\
@@ -397,7 +397,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/development/maintenance" \
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/services/rss-publishing" \
     "id:9001216,\
-    phase:2,\
+    phase:1,\
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:feed_description,\

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -47,7 +47,7 @@ SecRule &TX:crs_exclusions_wordpress|TX:crs_exclusions_wordpress "@eq 0" \
 # User login password
 SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
     "id:9002100,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -80,7 +80,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
 # Post comment
 SecRule REQUEST_FILENAME "@endsWith /wp-comments-post.php" \
     "id:9002130,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -270,7 +270,7 @@ SecRule REQUEST_FILENAME "!@contains /wp-admin/" \
 
 SecRule REQUEST_FILENAME "!@contains /wp-admin/" \
     "id:9002401,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -670,7 +670,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/options.php" \
 # permalink_structure=/index.php/%year%/%monthnum%/%day%/%postname%/
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/options-permalink.php" \
     "id:9002810,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -742,7 +742,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/edit.php" \
 # jquery-ui-accordion&ver=3f9999390861a0133beda3ee8acf152e
 SecRule REQUEST_FILENAME "@rx /wp-admin/load-(?:scripts|styles)\.php$" \
     "id:9002900,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -759,7 +759,7 @@ SecRule REQUEST_FILENAME "@rx /wp-admin/load-(?:scripts|styles)\.php$" \
 # Site health output can trigger database error rule.
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/site-health.php" \
     "id:9002910,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\

--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -64,7 +64,7 @@ SecRule &TX:crs_exclusions_nextcloud|TX:crs_exclusions_nextcloud "@eq 0" \
 
 SecRule REQUEST_FILENAME "@contains /remote.php/webdav" \
     "id:9003100,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -80,7 +80,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/webdav" \
 
 SecRule REQUEST_METHOD "@streq PUT" \
     "id:9003105,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -97,7 +97,7 @@ SecRule REQUEST_METHOD "@streq PUT" \
 # Fix for Nextcloud Desktop Client
 SecRule REQUEST_METHOD "@streq PROPFIND" \
     "id:9003106,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -110,7 +110,7 @@ SecRule REQUEST_METHOD "@streq PROPFIND" \
 # Fix for Nextcloud Desktop Client
 SecRule REQUEST_METHOD "@streq PROPFIND" \
     "id:9003107,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -124,7 +124,7 @@ SecRule REQUEST_METHOD "@streq PROPFIND" \
 
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     "id:9003110,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -135,7 +135,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
 
 SecRule REQUEST_METHOD "@rx ^(?:PUT|MOVE)$" \
     "id:9003115,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -148,7 +148,7 @@ SecRule REQUEST_METHOD "@rx ^(?:PUT|MOVE)$" \
 
 SecRule REQUEST_METHOD "@streq PUT" \
     "id:9003116,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -165,7 +165,7 @@ SecRule REQUEST_METHOD "@streq PUT" \
 
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     "id:9003120,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -179,7 +179,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
 
 SecRule REQUEST_METHOD "@streq REPORT" \
     "id:9003121,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -195,7 +195,7 @@ SecRule REQUEST_METHOD "@streq REPORT" \
 
 SecRule REQUEST_FILENAME "@contains /index.php/core/search" \
     "id:9003125,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -220,7 +220,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/core/search" \
 
 SecRule REQUEST_FILENAME "@rx /(?:remote|index|public)\.php/" \
     "id:9003130,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -234,7 +234,7 @@ SecRule REQUEST_FILENAME "@rx /(?:remote|index|public)\.php/" \
 
 SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/files_sharing/" \
     "id:9003140,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -246,7 +246,7 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/files_sharing/" \
 
 SecRule REQUEST_FILENAME "@contains /index.php/core/preview.png" \
     "id:9003150,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -257,7 +257,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/core/preview.png" \
 
 SecRule REQUEST_FILENAME "@contains /index.php/apps/files_trashbin/ajax/preview.php" \
     "id:9003155,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -267,7 +267,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/files_trashbin/ajax/preview.
 
 SecRule REQUEST_FILENAME "@rx /index\.php/(?:apps/gallery/thumbnails|logout$)" \
     "id:9003160,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -279,7 +279,7 @@ SecRule REQUEST_FILENAME "@rx /index\.php/(?:apps/gallery/thumbnails|logout$)" \
 
 SecRule REQUEST_FILENAME "@contains /index.php/apps/ownnote/" \
     "id:9003300,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -293,7 +293,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/ownnote/" \
 
 SecRule REQUEST_FILENAME "@contains /index.php/apps/files_texteditor/" \
     "id:9003310,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -311,7 +311,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/files_texteditor/" \
 
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/addressbooks/" \
     "id:9003320,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -337,7 +337,7 @@ SecRule REQUEST_METHOD "@streq PUT" \
 
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/calendars/" \
     "id:9003330,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -359,7 +359,7 @@ SecRule REQUEST_METHOD "@streq PUT" \
 # Fix for iOS Calender not syncing
 SecRule REQUEST_METHOD "@streq PROPFIND" \
     "id:9003332,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -371,7 +371,7 @@ SecRule REQUEST_METHOD "@streq PROPFIND" \
 
 SecRule REQUEST_METHOD "@streq PROPFIND" \
     "id:9003333,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -389,7 +389,7 @@ SecRule REQUEST_METHOD "@streq PROPFIND" \
 
 SecRule REQUEST_FILENAME "@contains /index.php/apps/notes/" \
     "id:9003340,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -403,7 +403,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/notes/" \
 
 SecRule REQUEST_FILENAME "@contains /index.php/apps/bookmarks/" \
     "id:9003350,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -421,7 +421,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/bookmarks/" \
 
 SecRule REQUEST_FILENAME "@contains /index.php/login" \
     "id:9003400,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -452,7 +452,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/login" \
 
 SecRule REQUEST_FILENAME "@endsWith /index.php/settings/users" \
     "id:9003500,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -472,7 +472,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/settings/users" \
 # Fixes deletion of auth tokens
 SecRule REQUEST_FILENAME "@contains /settings/personal/authtokens/" \
     "id:9003601,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -484,7 +484,7 @@ SecRule REQUEST_FILENAME "@contains /settings/personal/authtokens/" \
 # Fixed "Security & setup warnings" test
 SecRule REQUEST_FILENAME "@contains /.well-known/caldav" \
     "id:9003602,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -493,7 +493,7 @@ SecRule REQUEST_FILENAME "@contains /.well-known/caldav" \
 
 SecRule REQUEST_FILENAME "@contains /.well-known/carddav" \
     "id:9003603,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -508,7 +508,7 @@ SecRule REQUEST_FILENAME "@contains /.well-known/carddav" \
 # Allows notifications to be deleted
 SecRule REQUEST_FILENAME "@contains /ocs/v2.php/apps/notifications/api/v2/notifications" \
     "id:9003701,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\

--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------
 # OWASP ModSecurity Core Rule Set ver.3.3.0
-# Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
+# Copyright (c) 2006-2020 Trustwave and contributors. (not) All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
 # Apache Software License (ASL) version 2
@@ -8,7 +8,7 @@
 #
 # ------------------------------------------------------------------------
 
-# These exclusions remedy false positives in a default NextCloud install.
+# These exclusions remedy false positives in a default Nextcloud install.
 # They will likely work with OwnCloud too, but you may have to modify them.
 # The exclusions are only active if crs_exclusions_nextcloud=1 is set.
 # See rule 900130 in crs-setup.conf.example for instructions.
@@ -43,7 +43,7 @@ SecRule &TX:crs_exclusions_nextcloud|TX:crs_exclusions_nextcloud "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0',\
     skipAfter:END-NEXTCLOUD"
 
 SecRule &TX:crs_exclusions_nextcloud|TX:crs_exclusions_nextcloud "@eq 0" \
@@ -52,16 +52,15 @@ SecRule &TX:crs_exclusions_nextcloud|TX:crs_exclusions_nextcloud "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0',\
     skipAfter:END-NEXTCLOUD"
 
 
 #
 # [ File Manager ]
 #
-#
-# The web interface uploads files, and interacts with the user.
 
+# The web interface uploads files, and interacts with the user.
 SecRule REQUEST_FILENAME "@contains /remote.php/webdav" \
     "id:9003100,\
     phase:1,\
@@ -74,17 +73,16 @@ SecRule REQUEST_FILENAME "@contains /remote.php/webdav" \
     ctl:ruleRemoveById=953100-953130,\
     ctl:ruleRemoveById=920420,\
     ctl:ruleRemoveById=920440,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0'"
 
 # Skip PUT parsing for invalid encoding / protocol violations in binary files.
-
 SecRule REQUEST_METHOD "@streq PUT" \
     "id:9003105,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0',\
     chain"
     SecRule REQUEST_FILENAME "@contains /remote.php/webdav" \
         "t:none,\
@@ -94,75 +92,57 @@ SecRule REQUEST_METHOD "@streq PUT" \
         ctl:ruleRemoveById=930110,\
         ctl:ruleRemoveById=930120"
 
-# Fix for Nextcloud Desktop Client
-SecRule REQUEST_METHOD "@streq PROPFIND" \
+# Fix for Nextcloud Desktop Client / Allow sending source code
+SecRule REQUEST_METHOD "@pm PROPFIND PUT" \
     "id:9003106,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0',\
     chain"
-    SecRule REQUEST_FILENAME "@contains /remote.php/webdav" \
-        "t:none,\
-        ctl:ruleRemoveById=921110"
-
-# Fix for Nextcloud Desktop Client
-SecRule REQUEST_METHOD "@streq PROPFIND" \
-    "id:9003107,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'OWASP_CRS/3.3.0',\
-    chain"
-    SecRule REQUEST_FILENAME "@contains /remote.php/dav/files" \
+    SecRule REQUEST_FILENAME "@rx /remote\.php/(?:webdav|dav/files)" \
         "t:none,\
         ctl:ruleRemoveById=921110"
 
 # Allow the data type 'text/vcard'
-
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     "id:9003110,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0',\
     setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/vcard|'"
 
 # Allow the data type 'application/octet-stream'
-
-SecRule REQUEST_METHOD "@rx ^(?:PUT|MOVE)$" \
+SecRule REQUEST_METHOD "@pm PUT MOVE" \
     "id:9003115,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0',\
     chain"
     SecRule REQUEST_FILENAME "@rx /remote\.php/dav/(?:files|uploads)/" \
         "setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |application/octet-stream|'"
 
 # Allow data types like video/mp4
-
 SecRule REQUEST_METHOD "@streq PUT" \
     "id:9003116,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0',\
     chain"
-    SecRule REQUEST_FILENAME "@rx (?:/public\.php/webdav/|/remote\.php/dav/uploads/)" \
+    SecRule REQUEST_FILENAME "@rx /(?:public\.php/webdav|remote\.php/dav/uploads)/" \
         "ctl:ruleRemoveById=920340,\
         ctl:ruleRemoveById=920420"
-
 
 # Allow characters like /../ in files.
 # Allow all kind of filetypes.
 # Allow source code.
-
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     "id:9003120,\
     phase:1,\
@@ -173,10 +153,9 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     ctl:ruleRemoveById=951000-951999,\
     ctl:ruleRemoveById=953100-953130,\
     ctl:ruleRemoveById=920440,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0'"
 
 # Allow REPORT requests without Content-Type header (at least the iOS app does this)
-
 SecRule REQUEST_METHOD "@streq REPORT" \
     "id:9003121,\
     phase:1,\
@@ -189,10 +168,11 @@ SecRule REQUEST_METHOD "@streq REPORT" \
         ctl:ruleRemoveById=920340"
 
 
+#
 # [ Searchengine ]
 #
-# NexCloud uses a search field for filename or content queries.
 
+# Nextcloud uses a search field for filename or content queries.
 SecRule REQUEST_FILENAME "@contains /index.php/core/search" \
     "id:9003125,\
     phase:1,\
@@ -202,12 +182,14 @@ SecRule REQUEST_FILENAME "@contains /index.php/core/search" \
     ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:query,\
     ctl:ruleRemoveTargetById=941000-942999;ARGS:query,\
     ctl:ruleRemoveTargetById=932000-932999;ARGS:query,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0'"
 
 
+#
 # [ DAV ]
 #
-# NextCloud uses DAV methods with index.php and remote.php to do many things
+
+# Nextcloud uses DAV methods with index.php and remote.php to do many things
 # The default ones in ModSecurity are: GET HEAD POST OPTIONS
 #
 # Looking through the code, and via testing, I found these:
@@ -217,33 +199,33 @@ SecRule REQUEST_FILENAME "@contains /index.php/core/search" \
 # Others in the code or js files: PATCH MKCOL MOVE TRACE
 # Others that I added just in case, and they seem related:
 #   CHECKOUT COPY LOCK MERGE MKACTIVITY UNLOCK.
-
 SecRule REQUEST_FILENAME "@rx /(?:remote|index|public)\.php/" \
     "id:9003130,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT PATCH CHECKOUT COPY DELETE LOCK MERGE MKACTIVITY MKCOL MOVE PROPFIND PROPPATCH SEARCH UNLOCK REPORT TRACE jsonp'"
-
 
 # We need to allow DAV methods for sharing files, and removing shares
 # DELETE - when the share is removed
 # PUT - when setting a password / expiration time
-
 SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/files_sharing/" \
     "id:9003140,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT DELETE'"
 
 
+#
 # [ Preview and Thumbnails ]
+#
 
+# Preview
 SecRule REQUEST_FILENAME "@contains /index.php/core/preview.png" \
     "id:9003150,\
     phase:1,\
@@ -251,10 +233,9 @@ SecRule REQUEST_FILENAME "@contains /index.php/core/preview.png" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=932150;ARGS:file,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0'"
 
 # Filepreview for trashbin
-
 SecRule REQUEST_FILENAME "@contains /index.php/apps/files_trashbin/ajax/preview.php" \
     "id:9003155,\
     phase:1,\
@@ -263,19 +244,22 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/files_trashbin/ajax/preview.
     nolog,\
     ctl:ruleRemoveTargetById=932150;ARGS:file,\
     ctl:ruleRemoveTargetById=942190;ARGS:file,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0'"
 
-SecRule REQUEST_FILENAME "@rx /index\.php/(?:apps/gallery/thumbnails|logout$)" \
+# Thumbnails
+SecRule REQUEST_FILENAME "@contains /index.php/apps/gallery/thumbnails" \
     "id:9003160,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=941120;ARGS:requesttoken,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0'"
 
 
+#
 # [ Ownnote ]
+#
 
 SecRule REQUEST_FILENAME "@contains /index.php/apps/ownnote/" \
     "id:9003300,\
@@ -284,13 +268,14 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/ownnote/" \
     t:none,\
     nolog,\
     ctl:ruleRemoveById=941150,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0'"
 
 
+#
 # [ Text Editor ]
 #
-# This file can save anything, and it's name could be lots of things.
 
+# This file can save anything, and it's name could be lots of things.
 SecRule REQUEST_FILENAME "@contains /index.php/apps/files_texteditor/" \
     "id:9003310,\
     phase:1,\
@@ -302,20 +287,21 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/files_texteditor/" \
     ctl:ruleRemoveTargetById=932150;ARGS:filename,\
     ctl:ruleRemoveTargetById=920370-920390;ARGS:filecontents,\
     ctl:ruleRemoveTargetById=920370-920390;ARGS_COMBINED_SIZE,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0'"
 
 
+#
 # [ Address Book ]
 #
-# Allow the data type 'text/vcard'
 
+# Allow the data type 'text/vcard'
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/addressbooks/" \
     "id:9003320,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0',\
     setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/vcard|'"
 
 # Allow modifying contacts via the web interface
@@ -325,23 +311,25 @@ SecRule REQUEST_METHOD "@streq PUT" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.4.0',\
     chain"
     SecRule REQUEST_FILENAME "@contains /remote.php/dav/addressbooks/" \
         "t:none,\
         ctl:ruleRemoveById=200002"
 
 
+#
 # [ Calendar ]
 #
-# Allow the data type 'text/calendar'
 
+# Allow the data type 'text/calendar'
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/calendars/" \
     "id:9003330,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0',\
     setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/calendar|'"
 
 # Allow modifying calendar events via the web interface
@@ -351,6 +339,7 @@ SecRule REQUEST_METHOD "@streq PUT" \
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.4.0',\
     chain"
     SecRule REQUEST_FILENAME "@contains /remote.php/dav/calendars/" \
         "t:none,\
@@ -363,30 +352,19 @@ SecRule REQUEST_METHOD "@streq PROPFIND" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0',\
     chain"
-    SecRule REQUEST_FILENAME "@contains /remote.php/dav/principals/users/" \
-        "t:none,\
-        ctl:ruleRemoveById=921110"
-
-SecRule REQUEST_METHOD "@streq PROPFIND" \
-    "id:9003333,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'OWASP_CRS/3.3.0',\
-    chain"
-    SecRule REQUEST_FILENAME "@contains /remote.php/dav/calendars/" \
+    SecRule REQUEST_FILENAME "@rx /remote\.php/dav/(?:principals/users|calendars)/" \
         "t:none,\
         ctl:ruleRemoveById=921110"
 
 
+#
 # [ Notes ]
 #
+
 # We want to allow a lot of things as the user is
 # allowed to note on anything.
-
 SecRule REQUEST_FILENAME "@contains /index.php/apps/notes/" \
     "id:9003340,\
     phase:1,\
@@ -394,13 +372,14 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/notes/" \
     t:none,\
     nolog,\
     ctl:ruleRemoveByTag=attack-injection-php,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0'"
 
 
+#
 # [ Bookmarks ]
 #
-# Allow urls in data.
 
+# Allow urls in data.
 SecRule REQUEST_FILENAME "@contains /index.php/apps/bookmarks/" \
     "id:9003350,\
     phase:1,\
@@ -408,17 +387,15 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/bookmarks/" \
     t:none,\
     nolog,\
     ctl:ruleRemoveById=931130,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0'"
 
 
 #
-# [ Login forms ]
+# [ Login forms and Logout ]
 #
-
 # This removes checks on the 'password' and related fields:
 
 # User login password.
-
 SecRule REQUEST_FILENAME "@contains /index.php/login" \
     "id:9003400,\
     phase:1,\
@@ -427,17 +404,16 @@ SecRule REQUEST_FILENAME "@contains /index.php/login" \
     nolog,\
     ctl:ruleRemoveTargetById=941100;ARGS:requesttoken,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0'"
 
 # Reset password.
-
 SecRule REQUEST_FILENAME "@endsWith /index.php/login" \
     "id:9003410,\
     phase:2,\
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0',\
     chain"
     SecRule ARGS:action "@streq resetpass" \
         "t:none,\
@@ -448,8 +424,17 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/login" \
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1-text,\
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass2"
 
-# Change Password and Setting up a new user/password
+# Logout token
+SecRule REQUEST_FILENAME "@endsWith /index.php/logout" \
+    "id:9003420,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetById=941120;ARGS:requesttoken,\
+    ver:'OWASP_CRS/3.4.0'"
 
+# Change Password and Setting up a new user/password
 SecRule REQUEST_FILENAME "@endsWith /index.php/settings/users" \
     "id:9003500,\
     phase:1,\
@@ -458,13 +443,12 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/settings/users" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:newuserpassword,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0'"
 
 
 #
 # [ Settings pages ]
 #
-
 # This removes checks on multiple settings pages
 
 # Personal: Security
@@ -476,7 +460,7 @@ SecRule REQUEST_FILENAME "@contains /settings/personal/authtokens/" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
 
 # Administration: Overview
@@ -488,7 +472,7 @@ SecRule REQUEST_FILENAME "@contains /.well-known/caldav" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PROPFIND'"
 
 SecRule REQUEST_FILENAME "@contains /.well-known/carddav" \
@@ -497,39 +481,74 @@ SecRule REQUEST_FILENAME "@contains /.well-known/carddav" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PROPFIND'"
+
 
 #
 # [ Notifications ]
 #
-# NexCloud uses notifictions to inform the user of important new details.
+# Nextcloud uses notifictions to inform the user of important new details.
 
 # Allows notifications to be deleted
-SecRule REQUEST_FILENAME "@contains /ocs/v2.php/apps/notifications/api/v2/notifications" \
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/notifications/api/v2/notifications" \
     "id:9003701,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
 
 
+#
 # [ API ]
 #
-# Allow access to the shares API URL from mobile app
 
-SecRule REQUEST_FILENAME "@contains /ocs/v2.php/apps/files_sharing/api/v1/shares" \
+# Allow access to the shares API URL from mobile app
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/files_sharing/api/v1/shares" \
     "id:9003800,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
+    ver:'OWASP_CRS/3.4.0',\
     chain"
     SecRule REQUEST_METHOD "@streq GET" \
         "t:none,\
         ctl:ruleRemoveById=200002"
+
+
+#
+# [ Users ]
+#
+
+# Allow users to be deleted
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/cloud/users/" \
+    "id:9003850,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.4.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
+
+
+#
+# [ Extensions ]
+#
+
+# Extension: Ransomware protection
+
+# Allow configure file extensions fields
+SecRule REQUEST_FILENAME "@contains /config/apps/ransomware_protection/extension_additions" \
+    "id:9003900,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetById=932130;ARGS:value,\
+    ver:'OWASP_CRS/3.4.0'"
 
 
 SecMarker "END-NEXTCLOUD-ADMIN"

--- a/rules/REQUEST-903.9004-DOKUWIKI-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9004-DOKUWIKI-EXCLUSION-RULES.conf
@@ -76,7 +76,7 @@ SecRule &TX:crs_exclusions_dokuwiki|TX:crs_exclusions_dokuwiki "@eq 0" \
 
 SecRule REQUEST_FILENAME "@rx (?:/doku.php|/lib/exe/ajax.php)$" \
     "id:9004100,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -100,7 +100,7 @@ SecRule REQUEST_FILENAME "@rx (?:/doku.php|/lib/exe/ajax.php)$" \
 
 SecRule REQUEST_FILENAME "@endsWith /lib/exe/ajax.php" \
     "id:9004110,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\

--- a/rules/REQUEST-903.9006-XENFORO-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9006-XENFORO-EXCLUSION-RULES.conf
@@ -60,7 +60,7 @@ SecRule REQUEST_FILENAME "@endsWith /proxy.php" \
 # {"type":"post","context":{"post_id":12345},"hash":"0123456789abcdef..."}
 SecRule REQUEST_FILENAME "@rx /(?:conversations|(?:conversations|forums|threads)/.*)/draft$" \
     "id:9006110,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -94,7 +94,7 @@ SecRule REQUEST_FILENAME "@rx /(?:conversations|(?:conversations|forums|threads)
 # POST /xf/forums/forum-title.12345/create-thread/preview
 SecRule REQUEST_FILENAME "@rx /(?:conversations/add(?:-preview)?|conversations/messages/\d+/edit|posts/\d+/(?:edit|preview|save-inline|save)|(?:conversations|threads)/.*\.\d+/(?:add-reply|reply-preview|save-draft)|forums/.*/(?:post-thread|thread-preview|create-thread|add-thread|save-draft)(?:/preview|))$" \
     "id:9006120,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -111,7 +111,7 @@ SecRule REQUEST_FILENAME "@rx /(?:conversations/add(?:-preview)?|conversations/m
 # POST /xf/posts/12345/quote
 SecRule REQUEST_FILENAME "@rx /posts/\d+/quote$" \
     "id:9006130,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -124,7 +124,7 @@ SecRule REQUEST_FILENAME "@rx /posts/\d+/quote$" \
 # quotes={"12345":["quote-html"]}
 SecRule REQUEST_FILENAME "@rx /(?:conversations|threads)/.*\.\d+/multi-quote$" \
     "id:9006140,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -145,7 +145,7 @@ SecRule REQUEST_FILENAME "@rx /(?:conversations|threads)/.*\.\d+/multi-quote$" \
 # POST /xf/threads/thread-title.12345/delete
 SecRule REQUEST_FILENAME "@rx /threads/.*\.\d+/delete$" \
     "id:9006150,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -156,7 +156,7 @@ SecRule REQUEST_FILENAME "@rx /threads/.*\.\d+/delete$" \
 # POST /xf/threads/thread-title.12345/feature-edit
 SecRule REQUEST_FILENAME "@rx /threads/.*\.\d+/feature-edit$" \
     "id:9006155,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -166,7 +166,7 @@ SecRule REQUEST_FILENAME "@rx /threads/.*\.\d+/feature-edit$" \
 # POST /xf/inline-mod/
 SecRule REQUEST_FILENAME "@endsWith /inline-mod/" \
     "id:9006160,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -179,7 +179,7 @@ SecRule REQUEST_FILENAME "@endsWith /inline-mod/" \
 # POST /xf/posts/12345/warn
 SecRule REQUEST_FILENAME "@rx /(?:members/.*\.\d+|posts/\d+)/warn$" \
     "id:9006170,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -190,7 +190,7 @@ SecRule REQUEST_FILENAME "@rx /(?:members/.*\.\d+|posts/\d+)/warn$" \
 # Editor
 SecRule REQUEST_URI "@endsWith /index.php?editor/to-html" \
     "id:9006200,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -204,7 +204,7 @@ SecRule REQUEST_URI "@endsWith /index.php?editor/to-html" \
 # Editor
 SecRule REQUEST_URI "@endsWith /index.php?editor/to-bb-code" \
     "id:9006210,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -231,7 +231,7 @@ SecRule REQUEST_FILENAME "@rx /(?:account/avatar|attachments/upload)$" \
 # POST /xf/index.php?editor/media
 SecRule REQUEST_URI "@endsWith /index.php?editor/media" \
     "id:9006230,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -254,7 +254,7 @@ SecRule REQUEST_URI "@rx /index\.php\?misc/find-emoji&q=" \
 # POST /xf/login/login
 SecRule REQUEST_FILENAME "@endsWith /login/login" \
     "id:9006300,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -269,7 +269,7 @@ SecRule REQUEST_FILENAME "@endsWith /login/login" \
 # unacceptable bypass. So, we exclude only commonly hit rules.
 SecRule REQUEST_FILENAME "@endsWith /register/register" \
     "id:9006310,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -281,7 +281,7 @@ SecRule REQUEST_FILENAME "@endsWith /register/register" \
 # GET /xf/account-confirmation/name.12345/email?c=foo
 SecRule REQUEST_FILENAME "@rx /account-confirmation/.*\.\d+/email$" \
     "id:9006315,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -291,7 +291,7 @@ SecRule REQUEST_FILENAME "@rx /account-confirmation/.*\.\d+/email$" \
 # POST /xf/account/account-details
 SecRule REQUEST_FILENAME "@endsWith /account/account-details" \
     "id:9006320,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -303,7 +303,7 @@ SecRule REQUEST_FILENAME "@endsWith /account/account-details" \
 # POST /xf/lost-password/user-name.12345/confirm?c=foo
 SecRule REQUEST_FILENAME "@rx /lost-password/.*\.\d+/confirm$" \
     "id:9006330,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -314,7 +314,7 @@ SecRule REQUEST_FILENAME "@rx /lost-password/.*\.\d+/confirm$" \
 # POST /xf/account/signature
 SecRule REQUEST_FILENAME "@endsWith /account/signature" \
     "id:9006340,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -325,7 +325,7 @@ SecRule REQUEST_FILENAME "@endsWith /account/signature" \
 # POST /xf/search/search
 SecRule REQUEST_FILENAME "@endsWith /search/search" \
     "id:9006400,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -362,7 +362,7 @@ SecRule REQUEST_FILENAME "@rx /search/\d+/$" \
 # POST /xf/misc/contact
 SecRule REQUEST_FILENAME "@endsWith /misc/contact" \
     "id:9006500,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -374,7 +374,7 @@ SecRule REQUEST_FILENAME "@endsWith /misc/contact" \
 # POST /xf/posts/12345/report
 SecRule REQUEST_FILENAME "@rx /posts/\d+/report$" \
     "id:9006510,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -411,7 +411,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php" \
 # May Contain various javascript/XSS false positives
 SecRule REQUEST_URI "@endsWith /index.php?dbtech-security/fingerprint" \
     "id:9006700,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -423,7 +423,7 @@ SecRule REQUEST_URI "@endsWith /index.php?dbtech-security/fingerprint" \
 # Get location info
 SecRule REQUEST_FILENAME "@endsWith /misc/location-info" \
     "id:9006710,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -480,7 +480,7 @@ SecRule REQUEST_FILENAME "!@endsWith /admin.php" \
 
 SecRule REQUEST_FILENAME "!@endsWith /admin.php" \
     "id:9006901,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -491,7 +491,7 @@ SecRule REQUEST_FILENAME "!@endsWith /admin.php" \
 # POST /xf/admin.php?users/the-user-name.12345/edit
 SecRule REQUEST_URI "@rx /admin\.php\?users/.*\.\d+/edit$" \
     "id:9006910,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -524,7 +524,7 @@ SecRule REQUEST_URI "@rx /admin\.php\?users/.*\.\d+/save$" \
 # POST /xf/admin.php?notices/forum-name.12345/save
 SecRule REQUEST_URI "@rx /admin\.php\?notices/(?:.*\.)?\d+/save$" \
     "id:9006930,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -536,7 +536,7 @@ SecRule REQUEST_URI "@rx /admin\.php\?notices/(?:.*\.)?\d+/save$" \
 # POST /xf/admin.php?threads/batch-update/action
 SecRule REQUEST_URI "@rx /admin\.php\?(?:threads|users)/batch-update/action$" \
     "id:9006940,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -551,7 +551,7 @@ SecRule REQUEST_URI "@rx /admin\.php\?(?:threads|users)/batch-update/action$" \
 # POST /xf/admin.php?styles/title.1234/style-properties/group&group=basic
 SecRule REQUEST_URI "@rx /admin\.php\?styles/" \
     "id:9006950,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -568,7 +568,7 @@ SecRule REQUEST_URI "@rx /admin\.php\?styles/" \
 # POST /xf/admin.php?options/update
 SecRule REQUEST_URI "@rx /admin\.php\?options/update" \
     "id:9006960,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -581,7 +581,7 @@ SecRule REQUEST_URI "@rx /admin\.php\?options/update" \
 # POST /xf/admin.php?templates/foo.1234/save
 SecRule REQUEST_URI "@rx /admin\.php\?(?:pages|templates)/.*/save" \
     "id:9006970,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\

--- a/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
@@ -197,7 +197,7 @@ SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
 # Installation
 SecRule REQUEST_FILENAME "@endsWith /install/app.php/install" \
     "id:9007190,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\

--- a/rules/REQUEST-910-IP-REPUTATION.conf
+++ b/rules/REQUEST-910-IP-REPUTATION.conf
@@ -59,7 +59,7 @@ SecRule TX:DO_REPUT_BLOCK "@eq 1" \
 #
 SecRule TX:HIGH_RISK_COUNTRY_CODES "!@rx ^$" \
     "id:910100,\
-    phase:2,\
+    phase:1,\
     block,\
     t:none,\
     msg:'Client IP is from a HIGH Risk Country Location',\

--- a/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
+++ b/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
@@ -26,7 +26,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:911012,phase:2,pass,nolog,skipAf
 #
 SecRule REQUEST_METHOD "!@within %{tx.allowed_methods}" \
     "id:911100,\
-    phase:2,\
+    phase:1,\
     block,\
     msg:'Method is not allowed by policy',\
     logdata:'%{MATCHED_VAR}',\

--- a/rules/REQUEST-913-SCANNER-DETECTION.conf
+++ b/rules/REQUEST-913-SCANNER-DETECTION.conf
@@ -32,7 +32,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:913012,phase:2,pass,nolog,skipAf
 #
 SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scanners-user-agents.data" \
     "id:913100,\
-    phase:2,\
+    phase:1,\
     block,\
     capture,\
     t:none,t:lowercase,\
@@ -55,7 +55,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scanners-user-agents.data" \
 
 SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@pmFromFile scanners-headers.data" \
     "id:913110,\
-    phase:2,\
+    phase:1,\
     block,\
     capture,\
     t:none,t:lowercase,\
@@ -120,7 +120,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:913014,phase:2,pass,nolog,skipAf
 #
 SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scripting-user-agents.data" \
     "id:913101,\
-    phase:2,\
+    phase:1,\
     block,\
     capture,\
     t:none,t:lowercase,\
@@ -154,7 +154,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scripting-user-agents.data" \
 #
 SecRule REQUEST_HEADERS:User-Agent "@pmFromFile crawlers-user-agents.data" \
     "id:913102,\
-    phase:2,\
+    phase:1,\
     block,\
     capture,\
     t:none,t:lowercase,\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -46,7 +46,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:920012,phase:2,pass,nolog,skipAf
 #
 SecRule REQUEST_LINE "!@rx ^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+)?)?/[^?#]*(?:\?[^#\s]*)?(?:#[\S]*)?|connect (?:\d{1,3}\.){3}\d{1,3}\.?(?::\d+)?|options \*)\s+[\w\./]+|get /[^?#]*(?:\?[^#\s]*)?(?:#[\S]*)?)$" \
     "id:920100,\
-    phase:2,\
+    phase:1,\
     block,\
     t:none,\
     msg:'Invalid HTTP Request Line',\
@@ -160,7 +160,7 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^\d+$" \
 #
 SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
     "id:920170,\
-    phase:2,\
+    phase:1,\
     block,\
     t:none,\
     msg:'GET or HEAD Request with Body Content',\
@@ -185,7 +185,7 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
 #
 SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
     "id:920171,\
-    phase:2,\
+    phase:1,\
     block,\
     t:none,\
     msg:'GET or HEAD Request with Transfer-Encoding',\
@@ -221,7 +221,7 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
 #
 SecRule REQUEST_PROTOCOL "!@within HTTP/2 HTTP/2.0" \
     "id:920180,\
-    phase:2,\
+    phase:1,\
     block,\
     t:none,\
     msg:'POST without Content-Length or Transfer-Encoding headers',\
@@ -252,7 +252,7 @@ SecRule REQUEST_PROTOCOL "!@within HTTP/2 HTTP/2.0" \
 #
 SecRule &REQUEST_HEADERS:Transfer-Encoding "!@eq 0" \
     "id:920181,\
-    phase:2,\
+    phase:1,\
     block,\
     t:none,\
     msg:'Content-Length and Transfer-Encoding headers present.',\
@@ -288,7 +288,7 @@ SecRule &REQUEST_HEADERS:Transfer-Encoding "!@eq 0" \
 #
 SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx (\d+)-(\d+)" \
     "id:920190,\
-    phase:2,\
+    phase:1,\
     block,\
     capture,\
     t:none,\
@@ -322,7 +322,7 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx (\d+)-(\d+)" \
 #
 SecRule REQUEST_HEADERS:Connection "@rx \b(?:keep-alive|close),\s?(?:keep-alive|close)\b" \
     "id:920210,\
-    phase:2,\
+    phase:1,\
     block,\
     t:none,\
     msg:'Multiple/Conflicting Connection Header Data Found',\
@@ -355,7 +355,7 @@ SecRule REQUEST_HEADERS:Connection "@rx \b(?:keep-alive|close),\s?(?:keep-alive|
 #
 SecRule REQUEST_URI "@rx \x25" \
     "id:920220,\
-    phase:2,\
+    phase:1,\
     block,\
     t:none,\
     msg:'URL Encoding Abuse Attack Attempt',\
@@ -532,7 +532,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 1-255" \
 #
 SecRule &REQUEST_HEADERS:Host "@eq 0" \
     "id:920280,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     msg:'Request Missing a Host Header',\
@@ -552,7 +552,7 @@ SecRule &REQUEST_HEADERS:Host "@eq 0" \
 
 SecRule REQUEST_HEADERS:Host "@rx ^$" \
     "id:920290,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     msg:'Empty Host Header',\
@@ -592,7 +592,7 @@ SecMarker "END-HOST-CHECK"
 
 SecRule REQUEST_HEADERS:Accept "@rx ^$" \
     "id:920310,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     msg:'Request Has an Empty Accept Header',\
@@ -617,7 +617,7 @@ SecRule REQUEST_HEADERS:Accept "@rx ^$" \
 #
 SecRule REQUEST_HEADERS:Accept "@rx ^$" \
     "id:920311,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     msg:'Request Has an Empty Accept Header',\
@@ -650,7 +650,7 @@ SecRule REQUEST_HEADERS:Accept "@rx ^$" \
 
 SecRule REQUEST_HEADERS:User-Agent "@rx ^$" \
     "id:920330,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     msg:'Empty User Agent Header',\
@@ -687,7 +687,7 @@ SecRule REQUEST_HEADERS:User-Agent "@rx ^$" \
 
 SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
     "id:920340,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     msg:'Request Containing Content, but Missing Content-Type header',\
@@ -718,7 +718,7 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
 
 SecRule REQUEST_HEADERS:Host "@rx ^[\d.:]+$" \
     "id:920350,\
-    phase:2,\
+    phase:1,\
     block,\
     t:none,\
     msg:'Host header is a numeric IP address',\
@@ -853,7 +853,7 @@ SecRule &TX:TOTAL_ARG_LENGTH "@eq 1" \
 # Individual file size is limited
 SecRule &TX:MAX_FILE_SIZE "@eq 1" \
     "id:920400,\
-    phase:2,\
+    phase:1,\
     block,\
     t:none,\
     msg:'Uploaded file size too large',\
@@ -938,7 +938,7 @@ SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+-]+(?:\s?;\s?(?:action|boundar
 # To change your policy, edit crs-setup.conf and activate rule 900220.
 SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
     "id:920420,\
-    phase:2,\
+    phase:1,\
     block,\
     capture,\
     t:none,\
@@ -1016,7 +1016,7 @@ SecRule REQUEST_PROTOCOL "!@within %{tx.allowed_http_versions}" \
 #
 SecRule REQUEST_BASENAME "@rx \.([^.]+)$" \
     "id:920440,\
-    phase:2,\
+    phase:1,\
     block,\
     capture,\
     t:none,\
@@ -1044,7 +1044,7 @@ SecRule REQUEST_BASENAME "@rx \.([^.]+)$" \
 #
 SecRule REQUEST_FILENAME "@rx \.[^.~]+~(?:/.*|)$" \
     "id:920500,\
-    phase:2,\
+    phase:1,\
     block,\
     t:none,t:urlDecodeUni,\
     msg:'Attempt to access a backup or working file',\
@@ -1088,7 +1088,7 @@ SecRule REQUEST_FILENAME "@rx \.[^.~]+~(?:/.*|)$" \
 #
 SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
     "id:920450,\
-    phase:2,\
+    phase:1,\
     block,\
     capture,\
     t:none,t:lowercase,\
@@ -1137,7 +1137,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:920014,phase:2,pass,nolog,skipAf
 
 SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d+)?-(?:\d+)?\s*,?\s*){6}" \
     "id:920200,\
-    phase:2,\
+    phase:1,\
     block,\
     t:none,\
     msg:'Range: Too many fields (6 or more)',\
@@ -1161,7 +1161,7 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d
 
 SecRule REQUEST_BASENAME "@endsWith .pdf" \
     "id:920201,\
-    phase:2,\
+    phase:1,\
     block,\
     t:none,\
     msg:'Range: Too many fields for pdf request (63 or more)',\
@@ -1213,7 +1213,7 @@ SecRule ARGS "@rx %[0-9a-fA-F]{2}" \
 #
 SecRule &REQUEST_HEADERS:Accept "@eq 0" \
     "id:920300,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     msg:'Request Missing an Accept Header',\
@@ -1266,7 +1266,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 9,10,13,
 
 SecRule &REQUEST_HEADERS:User-Agent "@eq 0" \
     "id:920320,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     msg:'Missing User Agent Header',\
@@ -1314,7 +1314,7 @@ SecRule FILES_NAMES|FILES "@rx ['\";=]" \
 
 SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
     "id:920341,\
-    phase:2,\
+    phase:1,\
     block,\
     t:none,\
     msg:'Request Containing Content Requires Content-Type header',\
@@ -1459,7 +1459,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:920018,phase:2,pass,nolog,skipAf
 
 SecRule REQUEST_BASENAME "@endsWith .pdf" \
     "id:920202,\
-    phase:2,\
+    phase:1,\
     block,\
     t:none,\
     msg:'Range: Too many fields for pdf request (6 or more)',\
@@ -1507,7 +1507,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteRange 38,44-46,48-58,61,65-90
 #
 SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!REQUEST_HEADERS:Cookie|!REQUEST_HEADERS:Sec-Fetch-User "@validateByteRange 32,34,38,42-59,61,65-90,95,97-122" \
     "id:920274,\
-    phase:2,\
+    phase:1,\
     block,\
     t:none,t:urlDecodeUni,\
     msg:'Invalid character in request headers (outside of very strict set)',\
@@ -1531,7 +1531,7 @@ SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!RE
 #
 SecRule REQUEST_HEADERS:Sec-Fetch-User "@validateByteRange 32,34,38,42-59,61,63,65-90,95,97-122" \
     "id:920275,\
-    phase:2,\
+    phase:1,\
     block,\
     t:none,t:urlDecodeUni,\
     msg:'Invalid character in request headers (outside of very strict set)',\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -122,7 +122,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #
 SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@rx [\n\r]" \
     "id:921140,\
-    phase:2,\
+    phase:1,\
     block,\
     capture,\
     t:none,t:htmlEntityDecode,\
@@ -267,7 +267,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:921014,phase:2,pass,nolog,skipAf
 #
 SecRule ARGS_GET "@rx [\n\r]" \
     "id:921151,\
-    phase:2,\
+    phase:1,\
     block,\
     capture,\
     t:none,t:urlDecodeUni,t:htmlEntityDecode,\

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -104,7 +104,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #
 SecRule REQUEST_FILENAME "@pmFromFile restricted-files.data" \
     "id:930130,\
-    phase:2,\
+    phase:1,\
     block,\
     capture,\
     t:none,t:utf8toUnicode,t:urlDecodeUni,t:normalizePathWin,t:lowercase,\

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -511,7 +511,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #
 SecRule REQUEST_HEADERS|REQUEST_LINE "@rx ^\(\s*\)\s+{" \
     "id:932170,\
-    phase:2,\
+    phase:1,\
     block,\
     capture,\
     t:none,t:urlDecode,\

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -660,7 +660,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:941014,phase:2,pass,nolog,skipAf
 #
 SecRule REQUEST_HEADERS:Referer "@detectXSS" \
     "id:941101,\
-    phase:2,\
+    phase:1,\
     block,\
     capture,\
     t:none,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,t:removeNulls,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1364,7 +1364,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'´’‘`<>][^~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'´’‘`<>]*?){8})" \
     "id:942420,\
-    phase:2,\
+    phase:1,\
     block,\
     capture,\
     t:none,t:urlDecodeUni,\
@@ -1457,7 +1457,7 @@ SecRule ARGS "@rx \W{4}" \
 #
 SecRule REQUEST_BASENAME "@detectSQLi" \
     "id:942101,\
-    phase:2,\
+    phase:1,\
     block,\
     capture,\
     t:none,t:utf8toUnicode,t:urlDecodeUni,t:removeNulls,\
@@ -1540,7 +1540,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:942018,phase:2,pass,nolog,skipAf
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'´’‘`<>][^~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'´’‘`<>]*?){3})" \
     "id:942421,\
-    phase:2,\
+    phase:1,\
     block,\
     capture,\
     t:none,t:urlDecodeUni,\

--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -95,7 +95,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:950014,phase:4,pass,nolog,skipAf
 #
 SecRule RESPONSE_STATUS "@rx ^5\d{2}$" \
     "id:950100,\
-    phase:4,\
+    phase:3,\
     block,\
     capture,\
     t:none,\


### PR DESCRIPTION
Decreased the `phase` values where variable activated the previous phase - eg. `REQUEST_FILENAME` available in `phase:1`, not necessary to wait to 2nd phase (body processing). All changes are from `phase:2` to `phase:1`, except in case of rule 950100, which is a response rule - there the old phase value is 4, now it's 3.