### PR TITLE
phpMyAdmin exclusion rules package

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -359,6 +359,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  setvar:tx.crs_exclusions_drupal=1,\
 #  setvar:tx.crs_exclusions_nextcloud=1,\
 #  setvar:tx.crs_exclusions_phpbb=1,\
+#  setvar:tx.crs_exclusions_phpmyadmin=1,\
 #  setvar:tx.crs_exclusions_wordpress=1,\
 #  setvar:tx.crs_exclusions_xenforo=1"
 

--- a/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
@@ -37,7 +37,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_change.php" \
     t:none,\
     nolog,\
     chain"
-    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
         ctl:ruleRemoveTargetById=942100;ARGS:where_clause,\
         ctl:ruleRemoveTargetById=942100;ARGS:sql_query"
@@ -50,7 +50,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_replace.php" \
     t:none,\
     nolog,\
     chain"
-    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
         ctl:ruleRemoveTargetByTag=attack-xss;ARGS,\
         ctl:ruleRemoveTargetById=932150;ARGS,\
@@ -80,7 +80,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_get_field.php" \
     t:none,\
     nolog,\
     chain"
-    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
         ctl:ruleRemoveTargetById=942100;ARGS:where_clause,\
         ctl:ruleRemoveTargetById=942100;ARGS:sql_query"
@@ -93,7 +93,7 @@ SecRule REQUEST_FILENAME "@endsWith /sql.php" \
     t:none,\
     nolog,\
     chain"
-    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
         ctl:ruleRemoveTargetById=942140;ARGS:db,\
         ctl:ruleRemoveTargetById=942140;ARGS:sql_query,\
@@ -108,7 +108,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_row_action.php" \
     t:none,\
     nolog,\
     chain"
-    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
         ctl:ruleRemoveTargetById=942100;ARGS,\
         ctl:ruleRemoveTargetById=941100;ARGS"
@@ -121,8 +121,9 @@ SecRule REQUEST_FILENAME "@endsWith /lint.php" \
     t:none,\
     nolog,\
     chain"
-    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
+        ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:auto_saved_sql,\
         ctl:ruleRemoveTargetById=942170;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=942320;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
@@ -145,7 +146,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_sql.php" \
     t:none,\
     nolog,\
     chain"
-    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
         ctl:ruleRemoveTargetById=942100;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=942360;ARGS:sql_query"
@@ -158,7 +159,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_sql.php" \
     t:none,\
     nolog,\
     chain"
-    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
         ctl:ruleRemoveTargetById=942190;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=942270;ARGS:sql_query,\
@@ -173,8 +174,9 @@ SecRule REQUEST_FILENAME "@endsWith /import.php" \
     t:none,\
     nolog,\
     chain"
-    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
+        ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:auto_saved_sql,\
         ctl:ruleRemoveTargetById=942140;ARGS:db,\
         ctl:ruleRemoveTargetById=942100;ARGS:prev_sql_query,\
         ctl:ruleRemoveTargetById=942360;ARGS:prev_sql_query,\
@@ -202,7 +204,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_triggers.php" \
     t:none,\
     nolog,\
     chain"
-    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
         ctl:ruleRemoveTargetById=932115;ARGS:item_definition,\
         ctl:ruleRemoveTargetById=942170;ARGS:item_definition,\
@@ -216,7 +218,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_events.php" \
     t:none,\
     nolog,\
     chain"
-    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
         ctl:ruleRemoveTargetById=932115;ARGS:item_definition,\
         ctl:ruleRemoveTargetById=942350;ARGS:item_definition"
@@ -229,7 +231,7 @@ SecRule REQUEST_FILENAME "@endsWith /export.php" \
     t:none,\
     nolog,\
     chain"
-    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
         ctl:ruleRemoveTargetById=942100;ARGS:sql_query"
 
@@ -241,7 +243,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_export.php" \
     t:none,\
     nolog,\
     chain"
-    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
         ctl:ruleRemoveTargetById=942100;ARGS:sql_query"
 
@@ -253,7 +255,7 @@ SecRule REQUEST_FILENAME "@endsWith /error_report.php" \
     t:none,\
     nolog,\
     chain"
-    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
         ctl:ruleRemoveTargetById=932130;ARGS,\
         ctl:ruleRemoveTargetById=932140;ARGS,\
@@ -261,7 +263,7 @@ SecRule REQUEST_FILENAME "@endsWith /error_report.php" \
         ctl:ruleRemoveTargetById=942100;ARGS"
 
 # Session cookies whitelist
-SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
     "id:9008240,\
     phase:1,\
     pass,\
@@ -278,7 +280,7 @@ SecRule REQUEST_FILENAME "@endsWith /view_create.php" \
     t:none,\
     nolog,\
     chain"
-    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
         ctl:ruleRemoveTargetById=941100;ARGS:view[as],\
         ctl:ruleRemoveTargetById=942100;ARGS:view[as],\

--- a/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
@@ -123,7 +123,6 @@ SecRule REQUEST_FILENAME "@endsWith /lint.php" \
     chain"
     SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
-        ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:auto_saved_sql,\
         ctl:ruleRemoveTargetById=942170;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=942320;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
@@ -176,7 +175,6 @@ SecRule REQUEST_FILENAME "@endsWith /import.php" \
     chain"
     SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
-        ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:auto_saved_sql,\
         ctl:ruleRemoveTargetById=942140;ARGS:db,\
         ctl:ruleRemoveTargetById=942100;ARGS:prev_sql_query,\
         ctl:ruleRemoveTargetById=942360;ARGS:prev_sql_query,\
@@ -285,6 +283,23 @@ SecRule REQUEST_FILENAME "@endsWith /view_create.php" \
         ctl:ruleRemoveTargetById=941100;ARGS:view[as],\
         ctl:ruleRemoveTargetById=942100;ARGS:view[as],\
         ctl:ruleRemoveTargetById=942360;ARGS:view[as]"
+
+# Persistent cookies
+# These cookies may persist beyond sessions and may block a user when trying
+# to access phpMyAdmin for a second time.
+SecAction \
+    "id:9008260,\
+    phase:1,\
+    t:none,\
+    nolog,\
+    pass,\
+    ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:auto_saved_sql,\
+    ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pmaAuth-1,\
+    ctl:ruleRemoveTargetById=942340;REQUEST_COOKIES:pmaAuth-1,\
+    ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pmaUser-1,\
+    ctl:ruleRemoveTargetById=942340;REQUEST_COOKIES:pmaUser-1,\
+    ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pma_console_config,\
+    ctl:ruleRemoveTargetById=942260;REQUEST_COOKIES:pma_console_config"
 
 
 SecMarker "END-PHPMYADMIN"

--- a/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
@@ -167,6 +167,14 @@ SecRule REQUEST_FILENAME "@endsWith /import.php" \
     chain"
     SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
+        ctl:ruleRemoveById=200003,\
+        ctl:ruleRemoveTargetById=942110;ARGS:csv_enclosed,\
+        ctl:ruleRemoveTargetById=942330;ARGS:csv_enclosed,\
+        ctl:ruleRemoveTargetById=942110;ARGS:csv_escaped,\
+        ctl:ruleRemoveTargetById=942330;ARGS:csv_escaped,\
+        ctl:ruleRemoveTargetById=942110;ARGS:ldi_enclosed,\
+        ctl:ruleRemoveTargetById=942330;ARGS:ldi_enclosed,\
+        ctl:ruleRemoveTargetById=942110;ARGS:ldi_terminated,\
         ctl:ruleRemoveTargetById=942140;ARGS:db,\
         ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:prev_sql_query,\
         ctl:ruleRemoveTargetById=932130;ARGS:prev_sql_query,\

--- a/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
@@ -54,6 +54,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_replace.php" \
         "t:none,\
         ctl:ruleRemoveTargetById=920230;ARGS:err_url,\
         ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:err_url,\
+        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:where_clause[],\
         ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:where_clause[0],\
         ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
         ctl:ruleRemoveTargetByTag=attack-xss;ARGS,\

--- a/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
@@ -128,6 +128,7 @@ SecRule REQUEST_FILENAME "@endsWith /lint.php" \
         ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=941310;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=941340;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=933210;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
@@ -179,13 +180,14 @@ SecRule REQUEST_FILENAME "@endsWith /import.php" \
         ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:prev_sql_query,\
         ctl:ruleRemoveTargetById=932130;ARGS:prev_sql_query,\
         ctl:ruleRemoveTargetById=942110;ARGS:sql_delimiter,\
-        ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
         ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=941310;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=932115;ARGS:sql_query"
+        ctl:ruleRemoveTargetById=941340;ARGS:sql_query"
 
 # Adding / editing triggers
 SecRule REQUEST_FILENAME "@endsWith /db_triggers.php" \

--- a/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
@@ -216,6 +216,10 @@ SecRule REQUEST_FILENAME "@endsWith /export.php" \
     chain"
     SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
+        ctl:ruleRemoveTargetById=942110;ARGS:csv_enclosed,\
+        ctl:ruleRemoveTargetById=942330;ARGS:csv_enclosed,\
+        ctl:ruleRemoveTargetById=942110;ARGS:csv_escaped,\
+        ctl:ruleRemoveTargetById=942330;ARGS:csv_escaped,\
         ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
 # Table export

--- a/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
@@ -52,45 +52,25 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_replace.php" \
     chain"
     SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
         "t:none,\
-        ctl:ruleRemoveTargetByTag=attack-xss;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
-        ctl:ruleRemoveTargetById=932150;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
-        ctl:ruleRemoveTargetById=933130;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
-        ctl:ruleRemoveTargetById=933160;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
-        ctl:ruleRemoveTargetById=942170;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
-        ctl:ruleRemoveTargetById=942190;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
-        ctl:ruleRemoveTargetById=921110;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
-        ctl:ruleRemoveTargetById=921130;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
-        ctl:ruleRemoveTargetById=932100;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
-        ctl:ruleRemoveTargetById=932105;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
-        ctl:ruleRemoveTargetById=932110;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
-        ctl:ruleRemoveTargetById=932115;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
-        ctl:ruleRemoveTargetById=932130;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
-        ctl:ruleRemoveTargetById=932140;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
-        ctl:ruleRemoveTargetById=933100;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
-        ctl:ruleRemoveTargetById=933120;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
-        ctl:ruleRemoveTargetById=942100;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
-        ctl:ruleRemoveTargetByTag=attack-xss;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
-        ctl:ruleRemoveTargetById=921110;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
-        ctl:ruleRemoveTargetById=921130;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
-        ctl:ruleRemoveTargetById=932150;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
-        ctl:ruleRemoveTargetById=932100;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
-        ctl:ruleRemoveTargetById=932105;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
-        ctl:ruleRemoveTargetById=932110;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
-        ctl:ruleRemoveTargetById=932115;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
-        ctl:ruleRemoveTargetById=932130;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
-        ctl:ruleRemoveTargetById=932140;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
-        ctl:ruleRemoveTargetById=933100;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
-        ctl:ruleRemoveTargetById=933120;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
-        ctl:ruleRemoveTargetById=942100;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
-        ctl:ruleRemoveTargetById=942100;ARGS:where_clause[],\
-        ctl:ruleRemoveTargetByTag=attack-xss;ARGS:fields[multi_edit][0][],\
-        ctl:ruleRemoveTargetById=932100;ARGS:fields[multi_edit][0][],\
-        ctl:ruleRemoveTargetById=932130;ARGS:fields[multi_edit][0][],\
-        ctl:ruleRemoveTargetById=932150;ARGS:fields[multi_edit][0][],\
+        ctl:ruleRemoveTargetByTag=attack-xss;ARGS,\
+        ctl:ruleRemoveTargetById=932150;ARGS,\
+        ctl:ruleRemoveTargetById=933130;ARGS,\
+        ctl:ruleRemoveTargetById=933160;ARGS,\
+        ctl:ruleRemoveTargetById=942170;ARGS,\
+        ctl:ruleRemoveTargetById=942190;ARGS,\
+        ctl:ruleRemoveTargetById=921110;ARGS,\
+        ctl:ruleRemoveTargetById=921130;ARGS,\
+        ctl:ruleRemoveTargetById=932100;ARGS,\
+        ctl:ruleRemoveTargetById=932105;ARGS,\
+        ctl:ruleRemoveTargetById=932110;ARGS,\
+        ctl:ruleRemoveTargetById=932115;ARGS,\
+        ctl:ruleRemoveTargetById=932130;ARGS,\
+        ctl:ruleRemoveTargetById=932140;ARGS,\
+        ctl:ruleRemoveTargetById=933100;ARGS,\
+        ctl:ruleRemoveTargetById=933120;ARGS,\
+        ctl:ruleRemoveTargetById=942100;ARGS,\
         ctl:ruleRemoveTargetById=933210;ARGS:fields[multi_edit][0][],\
-        ctl:ruleRemoveTargetById=934100;ARGS:fields[multi_edit][0][],\
-        ctl:ruleRemoveTargetById=942190;ARGS:fields[multi_edit][0][],\
-        ctl:ruleRemoveTargetById=942100;ARGS:sql_query"
+        ctl:ruleRemoveTargetById=934100;ARGS:fields[multi_edit][0][]"
 
 # Downloading row data
 SecRule REQUEST_FILENAME "@endsWith /tbl_get_field.php" \
@@ -130,11 +110,8 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_row_action.php" \
     chain"
     SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
         "t:none,\
-        ctl:ruleRemoveTargetById=942100;ARGS:/^selected\[[0-9]+\]$/,\
-        ctl:ruleRemoveTargetById=942100;ARGS:/^rows_to_delete\[[0-9]+\]$/,\
-        ctl:ruleRemoveTargetById=941100;ARGS:/^rows_to_delete\[[0-9]+\]$/,\
-        ctl:ruleRemoveTargetById=942100;ARGS:original_sql_query,\
-        ctl:ruleRemoveTargetById=942100;ARGS:sql_query"
+        ctl:ruleRemoveTargetById=942100;ARGS,\
+        ctl:ruleRemoveTargetById=941100;ARGS"
 
 # Opening custom SQL editor (general)
 SecRule REQUEST_FILENAME "@streq /lint.php" \
@@ -278,10 +255,10 @@ SecRule REQUEST_FILENAME "@endsWith /error_report.php" \
     chain"
     SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
         "t:none,\
-        ctl:ruleRemoveTargetById=932130;ARGS:/^exception\[stack\]\[[0-9]+\]\[context\]\[\]$/,\
-        ctl:ruleRemoveTargetById=932140;ARGS:/^exception\[stack\]\[[0-9]+\]\[context\]\[\]$/,\
-        ctl:ruleRemoveTargetById=934100;ARGS:/^exception\[stack\]\[[0-9]+\]\[context\]\[\]$/,\
-        ctl:ruleRemoveTargetById=942100;ARGS:/^exception\[stack\]\[[0-9]+\]\[context\]\[\]$/"
+        ctl:ruleRemoveTargetById=932130;ARGS,\
+        ctl:ruleRemoveTargetById=932140;ARGS,\
+        ctl:ruleRemoveTargetById=934100;ARGS,\
+        ctl:ruleRemoveTargetById=942100;ARGS"
 
 # Session cookies whitelist
 SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
@@ -290,10 +267,8 @@ SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetById=941100;REQUEST_COOKIES:/^pmaUser-[0-9]+_https$/,\
-    ctl:ruleRemoveTargetById=941120;REQUEST_COOKIES:/^pmaUser-[0-9]+_https$/,\
-    ctl:ruleRemoveTargetById=941100;REQUEST_COOKIES:/^pmaAuth-[0-9]+_https$/,\
-    ctl:ruleRemoveTargetById=941120;REQUEST_COOKIES:/^pmaAuth-[0-9]+_https$/"
+    ctl:ruleRemoveTargetById=941100;REQUEST_COOKIES,\
+    ctl:ruleRemoveTargetById=941120;REQUEST_COOKIES"
 
 
 SecMarker "END-PHPMYADMIN"

--- a/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
@@ -285,5 +285,19 @@ SecAction \
     ctl:ruleRemoveTargetById=942200;REQUEST_COOKIES:pma_console_config,\
     ctl:ruleRemoveTargetById=942260;REQUEST_COOKIES:pma_console_config"
 
+# Search rows in a table
+# MySQL chars such as '%' trigger rules on ARGS:criteriaColumnTypes[n]
+SecRule REQUEST_FILENAME "@endsWith /tbl_select.php" \
+    "id:9008270,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=942440;ARGS:orderByColumn,\
+        ctl:ruleRemoveTargetById=942470;ARGS,\
+        ctl:ruleRemoveTargetById=942300;ARGS"
 
 SecMarker "END-PHPMYADMIN"

--- a/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
@@ -114,6 +114,13 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_row_action.php" \
     SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
         ctl:ruleRemoveTargetById=942100;ARGS,\
+        ctl:ruleRemoveTargetById=942110;ARGS,\
+        ctl:ruleRemoveTargetById=942180;ARGS,\
+        ctl:ruleRemoveTargetById=942370;ARGS,\
+        ctl:ruleRemoveTargetById=942380;ARGS,\
+        ctl:ruleRemoveTargetById=942430;ARGS,\
+        ctl:ruleRemoveTargetById=942480;ARGS,\
+        ctl:ruleRemoveTargetById=942510;ARGS,\
         ctl:ruleRemoveTargetById=941100;ARGS"
 
 # Opening custom SQL editor (general)

--- a/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
@@ -114,7 +114,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_row_action.php" \
         ctl:ruleRemoveTargetById=941100;ARGS"
 
 # Opening custom SQL editor (general)
-SecRule REQUEST_FILENAME "@streq /lint.php" \
+SecRule REQUEST_FILENAME "@endsWith /lint.php" \
     "id:9008150,\
     phase:1,\
     pass,\

--- a/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
@@ -52,6 +52,9 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_replace.php" \
     chain"
     SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
+        ctl:ruleRemoveTargetById=920230;ARGS:err_url,\
+        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:err_url,\
+        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:where_clause[0],\
         ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
         ctl:ruleRemoveTargetByTag=attack-xss;ARGS,\
         ctl:ruleRemoveTargetById=932150;ARGS,\

--- a/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
@@ -39,8 +39,8 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_change.php" \
     chain"
     SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
-        ctl:ruleRemoveTargetById=942100;ARGS:where_clause,\
-        ctl:ruleRemoveTargetById=942100;ARGS:sql_query"
+        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:where_clause,\
+        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
 # Editing / copying a row - saving row data
 SecRule REQUEST_FILENAME "@endsWith /tbl_replace.php" \
@@ -52,6 +52,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_replace.php" \
     chain"
     SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
+        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
         ctl:ruleRemoveTargetByTag=attack-xss;ARGS,\
         ctl:ruleRemoveTargetById=932150;ARGS,\
         ctl:ruleRemoveTargetById=933130;ARGS,\
@@ -82,8 +83,8 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_get_field.php" \
     chain"
     SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
-        ctl:ruleRemoveTargetById=942100;ARGS:where_clause,\
-        ctl:ruleRemoveTargetById=942100;ARGS:sql_query"
+        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:where_clause,\
+        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
 # Deleting a row
 SecRule REQUEST_FILENAME "@endsWith /sql.php" \
@@ -96,9 +97,7 @@ SecRule REQUEST_FILENAME "@endsWith /sql.php" \
     SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
         ctl:ruleRemoveTargetById=942140;ARGS:db,\
-        ctl:ruleRemoveTargetById=942140;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=942190;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=942100;ARGS:sql_query"
+        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
 # Mass actions on rows
 SecRule REQUEST_FILENAME "@endsWith /tbl_row_action.php" \
@@ -123,19 +122,13 @@ SecRule REQUEST_FILENAME "@endsWith /lint.php" \
     chain"
     SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
-        ctl:ruleRemoveTargetById=942170;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=942320;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=941310;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=933210;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=942350;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=942190;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=942270;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=942100;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=942360;ARGS:sql_query"
+        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
 # Opening custom SQL editor (tables)
 SecRule REQUEST_FILENAME "@endsWith /tbl_sql.php" \
@@ -147,8 +140,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_sql.php" \
     chain"
     SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
-        ctl:ruleRemoveTargetById=942100;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=942360;ARGS:sql_query"
+        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
 # Opening custom SQL editor (databases)
 SecRule REQUEST_FILENAME "@endsWith /db_sql.php" \
@@ -160,10 +152,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_sql.php" \
     chain"
     SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
-        ctl:ruleRemoveTargetById=942190;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=942270;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=942100;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=942360;ARGS:sql_query"
+        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
 # Importing data and executing of custom SQL
 SecRule REQUEST_FILENAME "@endsWith /import.php" \
@@ -176,23 +165,15 @@ SecRule REQUEST_FILENAME "@endsWith /import.php" \
     SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
         ctl:ruleRemoveTargetById=942140;ARGS:db,\
-        ctl:ruleRemoveTargetById=942100;ARGS:prev_sql_query,\
-        ctl:ruleRemoveTargetById=942360;ARGS:prev_sql_query,\
+        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:prev_sql_query,\
         ctl:ruleRemoveTargetById=932130;ARGS:prev_sql_query,\
-        ctl:ruleRemoveTargetById=942190;ARGS:prev_sql_query,\
-        ctl:ruleRemoveTargetById=942270;ARGS:prev_sql_query,\
         ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=942270;ARGS:sql_query,\
+        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=941310;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=942140;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=942190;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=942350;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=942360;ARGS:sql_query,\
-        ctl:ruleRemoveTargetById=942100;ARGS:sql_query"
+        ctl:ruleRemoveTargetById=932115;ARGS:sql_query"
 
 # Adding / editing triggers
 SecRule REQUEST_FILENAME "@endsWith /db_triggers.php" \
@@ -231,7 +212,7 @@ SecRule REQUEST_FILENAME "@endsWith /export.php" \
     chain"
     SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
-        ctl:ruleRemoveTargetById=942100;ARGS:sql_query"
+        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
 # Table export
 SecRule REQUEST_FILENAME "@endsWith /tbl_export.php" \
@@ -243,7 +224,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_export.php" \
     chain"
     SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
-        ctl:ruleRemoveTargetById=942100;ARGS:sql_query"
+        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
 # Sending error report
 SecRule REQUEST_FILENAME "@endsWith /error_report.php" \

--- a/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
@@ -170,6 +170,7 @@ SecRule REQUEST_FILENAME "@endsWith /import.php" \
         ctl:ruleRemoveTargetById=942140;ARGS:db,\
         ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:prev_sql_query,\
         ctl:ruleRemoveTargetById=932130;ARGS:prev_sql_query,\
+        ctl:ruleRemoveTargetById=942110;ARGS:sql_delimiter,\
         ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
         ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\

--- a/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
@@ -1,0 +1,299 @@
+# ------------------------------------------------------------------------
+# OWASP ModSecurity Core Rule Set ver.3.4.0
+# Copyright (c) 2006-2020 Trustwave and contributors. (not) All rights reserved.
+#
+# The OWASP ModSecurity Core Rule Set is distributed under
+# Apache Software License (ASL) version 2
+# Please see the enclosed LICENSE file for full details.
+# ------------------------------------------------------------------------
+
+# These exclusions remedy false positives in a default phpMyAdmin install.
+# The exclusions are only active if crs_exclusions_phpmyadmin=1 is set.
+# See rule 900130 in crs-setup.conf.example for instructions.
+
+SecRule &TX:crs_exclusions_phpmyadmin|TX:crs_exclusions_phpmyadmin "@eq 0" \
+    "id:9008000,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.4.0',\
+    skipAfter:END-PHPMYADMIN"
+
+SecRule &TX:crs_exclusions_phpmyadmin|TX:crs_exclusions_phpmyadmin "@eq 0" \
+    "id:9008001,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.4.0',\
+    skipAfter:END-PHPMYADMIN"
+
+# Editing / copying a row - loading row data
+SecRule REQUEST_FILENAME "@endsWith /tbl_change.php" \
+    "id:9008100,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=942100;ARGS:where_clause,\
+        ctl:ruleRemoveTargetById=942100;ARGS:sql_query"
+
+# Editing / copying a row - saving row data
+SecRule REQUEST_FILENAME "@endsWith /tbl_replace.php" \
+    "id:9008110,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+        "t:none,\
+        ctl:ruleRemoveTargetByTag=attack-xss;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
+        ctl:ruleRemoveTargetById=932150;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
+        ctl:ruleRemoveTargetById=933130;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
+        ctl:ruleRemoveTargetById=933160;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
+        ctl:ruleRemoveTargetById=942170;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
+        ctl:ruleRemoveTargetById=942190;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
+        ctl:ruleRemoveTargetById=921110;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
+        ctl:ruleRemoveTargetById=921130;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
+        ctl:ruleRemoveTargetById=932100;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
+        ctl:ruleRemoveTargetById=932105;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
+        ctl:ruleRemoveTargetById=932110;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
+        ctl:ruleRemoveTargetById=932115;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
+        ctl:ruleRemoveTargetById=932130;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
+        ctl:ruleRemoveTargetById=932140;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
+        ctl:ruleRemoveTargetById=933100;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
+        ctl:ruleRemoveTargetById=933120;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
+        ctl:ruleRemoveTargetById=942100;ARGS:/^fields_prev\[multi_edit\]\[[0-9]\]\[[a-z0-9]+\]$/,\
+        ctl:ruleRemoveTargetByTag=attack-xss;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
+        ctl:ruleRemoveTargetById=921110;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
+        ctl:ruleRemoveTargetById=921130;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
+        ctl:ruleRemoveTargetById=932150;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
+        ctl:ruleRemoveTargetById=932100;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
+        ctl:ruleRemoveTargetById=932105;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
+        ctl:ruleRemoveTargetById=932110;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
+        ctl:ruleRemoveTargetById=932115;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
+        ctl:ruleRemoveTargetById=932130;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
+        ctl:ruleRemoveTargetById=932140;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
+        ctl:ruleRemoveTargetById=933100;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
+        ctl:ruleRemoveTargetById=933120;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
+        ctl:ruleRemoveTargetById=942100;ARGS:/^fields\[multi_edit\]\[[0-9]\]\[[a-z0-9]*\]$/,\
+        ctl:ruleRemoveTargetById=942100;ARGS:where_clause[],\
+        ctl:ruleRemoveTargetByTag=attack-xss;ARGS:fields[multi_edit][0][],\
+        ctl:ruleRemoveTargetById=932100;ARGS:fields[multi_edit][0][],\
+        ctl:ruleRemoveTargetById=932130;ARGS:fields[multi_edit][0][],\
+        ctl:ruleRemoveTargetById=932150;ARGS:fields[multi_edit][0][],\
+        ctl:ruleRemoveTargetById=933210;ARGS:fields[multi_edit][0][],\
+        ctl:ruleRemoveTargetById=934100;ARGS:fields[multi_edit][0][],\
+        ctl:ruleRemoveTargetById=942190;ARGS:fields[multi_edit][0][],\
+        ctl:ruleRemoveTargetById=942100;ARGS:sql_query"
+
+# Downloading row data
+SecRule REQUEST_FILENAME "@endsWith /tbl_get_field.php" \
+    "id:9008120,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=942100;ARGS:where_clause,\
+        ctl:ruleRemoveTargetById=942100;ARGS:sql_query"
+
+# Deleting a row
+SecRule REQUEST_FILENAME "@endsWith /sql.php" \
+    "id:9008130,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=942140;ARGS:db,\
+        ctl:ruleRemoveTargetById=942140;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=942190;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=942100;ARGS:sql_query"
+
+# Mass actions on rows
+SecRule REQUEST_FILENAME "@endsWith /tbl_row_action.php" \
+    "id:9008140,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=942100;ARGS:/^selected\[[0-9]+\]$/,\
+        ctl:ruleRemoveTargetById=942100;ARGS:/^rows_to_delete\[[0-9]+\]$/,\
+        ctl:ruleRemoveTargetById=941100;ARGS:/^rows_to_delete\[[0-9]+\]$/,\
+        ctl:ruleRemoveTargetById=942100;ARGS:original_sql_query,\
+        ctl:ruleRemoveTargetById=942100;ARGS:sql_query"
+
+# Opening custom SQL editor (general)
+SecRule REQUEST_FILENAME "@streq /lint.php" \
+    "id:9008150,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=942170;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=942320;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=941310;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=933210;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=942350;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=942190;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=942270;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=942100;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=942360;ARGS:sql_query"
+
+# Opening custom SQL editor (tables)
+SecRule REQUEST_FILENAME "@endsWith /tbl_sql.php" \
+    "id:9008160,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=942100;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=942360;ARGS:sql_query"
+
+# Opening custom SQL editor (databases)
+SecRule REQUEST_FILENAME "@endsWith /db_sql.php" \
+    "id:9008170,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=942190;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=942270;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=942100;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=942360;ARGS:sql_query"
+
+# Importing data and executing of custom SQL
+SecRule REQUEST_FILENAME "@endsWith /import.php" \
+    "id:9008180,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=942140;ARGS:db,\
+        ctl:ruleRemoveTargetById=942100;ARGS:prev_sql_query,\
+        ctl:ruleRemoveTargetById=942360;ARGS:prev_sql_query,\
+        ctl:ruleRemoveTargetById=932130;ARGS:prev_sql_query,\
+        ctl:ruleRemoveTargetById=942190;ARGS:prev_sql_query,\
+        ctl:ruleRemoveTargetById=942270;ARGS:prev_sql_query,\
+        ctl:ruleRemoveTargetById=932130;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=942270;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=921110;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=941310;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=942140;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=942190;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=932105;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=942350;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=932115;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=942360;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=942100;ARGS:sql_query"
+
+# Adding / editing triggers
+SecRule REQUEST_FILENAME "@endsWith /db_triggers.php" \
+    "id:9008190,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=932115;ARGS:item_definition,\
+        ctl:ruleRemoveTargetById=942170;ARGS:item_definition,\
+        ctl:ruleRemoveTargetById=942320;ARGS:item_definition"
+
+# Adding / editing events
+SecRule REQUEST_FILENAME "@endsWith /db_events.php" \
+    "id:9008200,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=932115;ARGS:item_definition,\
+        ctl:ruleRemoveTargetById=942350;ARGS:item_definition"
+
+# Database export
+SecRule REQUEST_FILENAME "@endsWith /export.php" \
+    "id:9008210,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=942100;ARGS:sql_query"
+
+# Table export
+SecRule REQUEST_FILENAME "@endsWith /tbl_export.php" \
+    "id:9008220,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=942100;ARGS:sql_query"
+
+# Sending error report
+SecRule REQUEST_FILENAME "@endsWith /error_report.php" \
+    "id:9008230,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=932130;ARGS:/^exception\[stack\]\[[0-9]+\]\[context\]\[\]$/,\
+        ctl:ruleRemoveTargetById=932140;ARGS:/^exception\[stack\]\[[0-9]+\]\[context\]\[\]$/,\
+        ctl:ruleRemoveTargetById=934100;ARGS:/^exception\[stack\]\[[0-9]+\]\[context\]\[\]$/,\
+        ctl:ruleRemoveTargetById=942100;ARGS:/^exception\[stack\]\[[0-9]+\]\[context\]\[\]$/"
+
+# Session cookies whitelist
+SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+    "id:9008240,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetById=941100;REQUEST_COOKIES:/^pmaUser-[0-9]+_https$/,\
+    ctl:ruleRemoveTargetById=941120;REQUEST_COOKIES:/^pmaUser-[0-9]+_https$/,\
+    ctl:ruleRemoveTargetById=941100;REQUEST_COOKIES:/^pmaAuth-[0-9]+_https$/,\
+    ctl:ruleRemoveTargetById=941120;REQUEST_COOKIES:/^pmaAuth-[0-9]+_https$/"
+
+
+SecMarker "END-PHPMYADMIN"

--- a/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
@@ -101,6 +101,11 @@ SecRule REQUEST_FILENAME "@endsWith /sql.php" \
     SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
         ctl:ruleRemoveTargetById=942140;ARGS:db,\
+        ctl:ruleRemoveTargetById=920230;ARGS:goto,\
+        ctl:ruleRemoveTargetById=942200;ARGS:goto,\
+        ctl:ruleRemoveTargetById=942260;ARGS:goto,\
+        ctl:ruleRemoveTargetById=942430;ARGS:goto,\
+        ctl:ruleRemoveTargetById=942510;ARGS:goto,\
         ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
 
 # Mass actions on rows

--- a/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
@@ -198,8 +198,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_triggers.php" \
     SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
         ctl:ruleRemoveTargetById=932115;ARGS:item_definition,\
-        ctl:ruleRemoveTargetById=942170;ARGS:item_definition,\
-        ctl:ruleRemoveTargetById=942320;ARGS:item_definition"
+        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:item_definition"
 
 # Adding / editing events
 SecRule REQUEST_FILENAME "@endsWith /db_events.php" \

--- a/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
@@ -343,4 +343,30 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_structure.php" \
         "t:none,\
         ctl:ruleRemoveTargetById=942470;ARGS"
 
+# Query -> Multi-table query
+SecRule REQUEST_FILENAME "@endsWith /db_multi_table_query.php" \
+    "id:9008300,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
+        "t:none,\
+        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=932115;ARGS:sql_query"
+
+# Query -> Query by example
+SecRule REQUEST_FILENAME "@endsWith /db_qbe.php" \
+    "id:9008310,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
+        "t:none,\
+        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=932115;ARGS:sql_query"
+
 SecMarker "END-PHPMYADMIN"

--- a/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
@@ -32,7 +32,7 @@ SecRule &TX:crs_exclusions_phpmyadmin|TX:crs_exclusions_phpmyadmin "@eq 0" \
 # Editing / copying a row - loading row data
 SecRule REQUEST_FILENAME "@endsWith /tbl_change.php" \
     "id:9008100,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -45,7 +45,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_change.php" \
 # Editing / copying a row - saving row data
 SecRule REQUEST_FILENAME "@endsWith /tbl_replace.php" \
     "id:9008110,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -75,7 +75,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_replace.php" \
 # Downloading row data
 SecRule REQUEST_FILENAME "@endsWith /tbl_get_field.php" \
     "id:9008120,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -88,7 +88,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_get_field.php" \
 # Deleting a row
 SecRule REQUEST_FILENAME "@endsWith /sql.php" \
     "id:9008130,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -103,7 +103,7 @@ SecRule REQUEST_FILENAME "@endsWith /sql.php" \
 # Mass actions on rows
 SecRule REQUEST_FILENAME "@endsWith /tbl_row_action.php" \
     "id:9008140,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -116,7 +116,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_row_action.php" \
 # Opening custom SQL editor (general)
 SecRule REQUEST_FILENAME "@streq /lint.php" \
     "id:9008150,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -140,7 +140,7 @@ SecRule REQUEST_FILENAME "@streq /lint.php" \
 # Opening custom SQL editor (tables)
 SecRule REQUEST_FILENAME "@endsWith /tbl_sql.php" \
     "id:9008160,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -153,7 +153,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_sql.php" \
 # Opening custom SQL editor (databases)
 SecRule REQUEST_FILENAME "@endsWith /db_sql.php" \
     "id:9008170,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -168,7 +168,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_sql.php" \
 # Importing data and executing of custom SQL
 SecRule REQUEST_FILENAME "@endsWith /import.php" \
     "id:9008180,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -197,7 +197,7 @@ SecRule REQUEST_FILENAME "@endsWith /import.php" \
 # Adding / editing triggers
 SecRule REQUEST_FILENAME "@endsWith /db_triggers.php" \
     "id:9008190,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -211,7 +211,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_triggers.php" \
 # Adding / editing events
 SecRule REQUEST_FILENAME "@endsWith /db_events.php" \
     "id:9008200,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -224,7 +224,7 @@ SecRule REQUEST_FILENAME "@endsWith /db_events.php" \
 # Database export
 SecRule REQUEST_FILENAME "@endsWith /export.php" \
     "id:9008210,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -236,7 +236,7 @@ SecRule REQUEST_FILENAME "@endsWith /export.php" \
 # Table export
 SecRule REQUEST_FILENAME "@endsWith /tbl_export.php" \
     "id:9008220,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -248,7 +248,7 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_export.php" \
 # Sending error report
 SecRule REQUEST_FILENAME "@endsWith /error_report.php" \
     "id:9008230,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -263,12 +263,26 @@ SecRule REQUEST_FILENAME "@endsWith /error_report.php" \
 # Session cookies whitelist
 SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
     "id:9008240,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=941100;REQUEST_COOKIES,\
     ctl:ruleRemoveTargetById=941120;REQUEST_COOKIES"
+
+# Creating view
+SecRule REQUEST_FILENAME "@endsWith /view_create.php" \
+    "id:9008250,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule &REQUEST_COOKIES_NAMES:phpMyAdmin_https "@eq 1" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=941100;ARGS:view[as],\
+        ctl:ruleRemoveTargetById=942100;ARGS:view[as],\
+        ctl:ruleRemoveTargetById=942360;ARGS:view[as]"
 
 
 SecMarker "END-PHPMYADMIN"

--- a/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
@@ -312,4 +312,32 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_select.php" \
         ctl:ruleRemoveTargetById=942470;ARGS,\
         ctl:ruleRemoveTargetById=942300;ARGS"
 
+# Structure -> Add columns
+# Column types contain SQL keyword. One commonly adds multiple columns.
+# The column types are in ARGS:field_type[n] and could get arbitrarily high.
+SecRule REQUEST_FILENAME "@endsWith /tbl_addfield.php" \
+    "id:9008280,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=942470;ARGS"
+
+# Structure -> Change columns
+# Column types contain SQL keyword. One commonly adds multiple columns.
+# The column types are in ARGS:field_type[n] and ARGS:field_type_orig[n].
+SecRule REQUEST_FILENAME "@endsWith /tbl_structure.php" \
+    "id:9008290,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=942470;ARGS"
+
 SecMarker "END-PHPMYADMIN"


### PR DESCRIPTION
First, not-valid, version of exclusion rules package for phpMyAdmin. I decided to do a pull request because i need to discuss one thing with you.

See these rules:
9008110
9008140
9008230
9008240

There's, currently, no way in modsecurity to use a regexp in variable names within `ctl:ruleRemoveTargetById` (and similar options). How to properly resolve this problem?