### PR TITLE
Introduction of Blocking Early feature

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -320,8 +320,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #
 # -- [[ Early Anomaly Scoring Mode Blocking ]] ------------------------------
 #
-# The anomaly scores for the request and the responses are summed up and
-# evaluated at the end of phase:2 and at the end of phase:4 respectively.
+# The anomaly scores for the request and the responses are generally summed up
+# and # evaluated at the end of phase:2 and at the end of phase:4 respectively.
 # However, it is possible to enable an early evaluation of these anomaly scores
 # at the end of phase:1 and at the end of phase:3.
 #
@@ -331,12 +331,13 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #
 # Enable the rule 900120 that sets the variable tx.blocking_early to 1 in order
 # to enable early blocking. The variable tx.blocking_early is set to 0 by
-# default.
+# default. Early blocking is thus disabled by default.
 #
-# Please note that blocking early will hide potential alerts from you. This means
-# that payload that would appear in an alert in phase 2 (or phase 4) do not get
-# evaluated if the request is being blocked early. So when you disabled
-# blocking early again, then new alerts from phase 2 might pop up.
+# Please note that blocking early will hide potential alerts from you. This 
+# means that a payload that would appear in an alert in phase 2 (or phase 4)
+# does not get evaluated if the request is being blocked early. So when you 
+# disabled blocking early again at some point in the future, then new alerts 
+# from phase 2 might pop up.
 #SecAction \
 #  "id:900120,\
 #  phase:1,\

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -321,7 +321,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # -- [[ Early Anomaly Scoring Mode Blocking ]] ------------------------------
 #
 # The anomaly scores for the request and the responses are generally summed up
-# and # evaluated at the end of phase:2 and at the end of phase:4 respectively.
+# and evaluated at the end of phase:2 and at the end of phase:4 respectively.
 # However, it is possible to enable an early evaluation of these anomaly scores
 # at the end of phase:1 and at the end of phase:3.
 #

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -332,6 +332,11 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # Enable the rule 900120 that sets the variable tx.blocking_early to 1 in order
 # to enable early blocking. The variable tx.blocking_early is set to 0 by 
 # default.
+#
+# Please note that blocking early will hide potential alerts from you. This means
+# that payload that would appear in an alert in phase 2 (or phase 4) do not get 
+# evaluated if the request is being blocked early. So when you disabled
+# blocking early again, then new alerts from phase 2 might pop up.
 #SecAction \
 #  "id:900120,\ 
 #  phase:1,\ 

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -330,18 +330,18 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # the phase 2 (and phase 4 respectively) will no longer be executed.
 #
 # Enable the rule 900120 that sets the variable tx.blocking_early to 1 in order
-# to enable early blocking. The variable tx.blocking_early is set to 0 by 
+# to enable early blocking. The variable tx.blocking_early is set to 0 by
 # default.
 #
 # Please note that blocking early will hide potential alerts from you. This means
-# that payload that would appear in an alert in phase 2 (or phase 4) do not get 
+# that payload that would appear in an alert in phase 2 (or phase 4) do not get
 # evaluated if the request is being blocked early. So when you disabled
 # blocking early again, then new alerts from phase 2 might pop up.
 #SecAction \
-#  "id:900120,\ 
-#  phase:1,\ 
-#  nolog,\ 
-#  pass,\ 
+#  "id:900120,\
+#  phase:1,\
+#  nolog,\
+#  pass,\
 #  t:none,\
 #  setvar:tx.blocking_early=1"
 

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -233,7 +233,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 
 
 #
-# -- [[ Anomaly Mode Severity Levels ]] ----------------------------------------
+# -- [[ Anomaly Scoring Mode Severity Levels ]] --------------------------------
 #
 # Each rule in the CRS has an associated severity level.
 # These are the default scoring points for each severity level.
@@ -269,7 +269,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 
 
 #
-# -- [[ Anomaly Mode Blocking Threshold Levels ]] ------------------------------
+# -- [[ Anomaly Scoring Mode Blocking Threshold Levels ]] ----------------------
 #
 # Here, you can specify at which cumulative anomaly score an inbound request,
 # or outbound response, gets blocked.
@@ -317,27 +317,28 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  setvar:tx.inbound_anomaly_score_threshold=5,\
 #  setvar:tx.outbound_anomaly_score_threshold=4"
 
-# -- [[ Early Anomaly Mode Blocking ]] ------------------------------
-# The anomaly scores for the request and the responses are summed up
-# and evaluate at the end of phase:2 and at the end of phase:4 respectively.
-# However, it is possible to enable an early evaluation of these anomaly
-# scores at the end of phase:1 and at the end of phase:3.
 #
-# If a request (or a response) hits the anomaly threshold in this rule,
-# then blocking happens immediately (if configured) and the phase 2 and
-# phase 4 respectively, will no longer be executed.
+# -- [[ Early Anomaly Scoring Mode Blocking ]] ------------------------------
 #
-# Enable the rule 900120 that sets the variable tx.blocking_early to 1 in 
-# order to enable this early blocking. The variable tx.blocking_early 
-# is set to 0 by default.
+# The anomaly scores for the request and the responses are summed up and
+# evaluated at the end of phase:2 and at the end of phase:4 respectively.
+# However, it is possible to enable an early evaluation of these anomaly scores
+# at the end of phase:1 and at the end of phase:3.
 #
+# If a request (or a response) hits the anomaly threshold in this early
+# evaluation, then blocking happens immediately (if blocking is enabled) and
+# the phase 2 (and phase 4 respectively) will no longer be executed.
+#
+# Enable the rule 900120 that sets the variable tx.blocking_early to 1 in order
+# to enable early blocking. The variable tx.blocking_early is set to 0 by 
+# default.
 #SecAction \
-# "id:900120,\
-#  phase:1,\
-#  nolog,\
-#  pass,\
+#  "id:900120,\ 
+#  phase:1,\ 
+#  nolog,\ 
+#  pass,\ 
 #  t:none,\
-#  setvar:tx.blocking_early=0"
+#  setvar:tx.blocking_early=1"
 
 
 # -- [[ Application Specific Rule Exclusions ]] ----------------------------------------

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -317,7 +317,29 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  setvar:tx.inbound_anomaly_score_threshold=5,\
 #  setvar:tx.outbound_anomaly_score_threshold=4"
 
+# -- [[ Early Anomaly Mode Blocking ]] ------------------------------
+# The anomaly scores for the request and the responses are summed up
+# and evaluate at the end of phase:2 and at the end of phase:4 respectively.
+# However, it is possible to enable an early evaluation of these anomaly
+# scores at the end of phase:1 and at the end of phase:3.
 #
+# If a request (or a response) hits the anomaly threshold in this rule,
+# then blocking happens immediately (if configured) and the phase 2 and
+# phase 4 respectively, will no longer be executed.
+#
+# Enable the rule 900120 that sets the variable tx.blocking_early to 1 in 
+# order to enable this early blocking. The variable tx.blocking_early 
+# is set to 0 by default.
+#
+#SecAction \
+# "id:900120,\
+#  phase:1,\
+#  nolog,\
+#  pass,\
+#  t:none,\
+#  setvar:tx.blocking_early=0"
+
+
 # -- [[ Application Specific Rule Exclusions ]] ----------------------------------------
 #
 # Some well-known applications may undertake actions that appear to be

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -88,6 +88,15 @@ SecRule &TX:outbound_anomaly_score_threshold "@eq 0" \
     ver:'OWASP_CRS/3.3.0',\
     setvar:'tx.outbound_anomaly_score_threshold=4'"
 
+# Default Blocking Early (rule 900120 in setup.conf)
+SecRule &TX:blocking_early "@eq 0" \
+    "id:901115,\
+    phase:1,\
+    pass,\
+    nolog,\
+    ver:'OWASP_CRS/3.3.0',\
+    setvar:'tx.blocking_early=0'"
+
 # Default Paranoia Level (rule 900000 in setup.conf)
 SecRule &TX:paranoia_level "@eq 0" \
     "id:901120,\

--- a/rules/REQUEST-949-BLOCKING-EVALUATION.conf
+++ b/rules/REQUEST-949-BLOCKING-EVALUATION.conf
@@ -11,7 +11,68 @@
 # -= Paranoia Level 0 (empty) =- (apply unconditionally)
 #
 
-# Summing up the anomaly score.
+# Skipping early blocking
+
+SecRule TX:BLOCKING_EARLY "!@eq 1" \
+    "id:949050,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    skipAfter:BLOCKING_EARLY_ANOMALY_SCORING"
+
+SecRule TX:BLOCKING_EARLY "!@eq 1" \
+    "id:949051,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    skipAfter:BLOCKING_EARLY_ANOMALY_SCORING"
+
+# Summing up the anomaly score for early blocking
+
+SecRule TX:PARANOIA_LEVEL "@ge 1" \
+    "id:949052,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.anomaly_score=+%{tx.anomaly_score_pl1}'"
+
+SecRule TX:PARANOIA_LEVEL "@ge 2" \
+    "id:949053,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.anomaly_score=+%{tx.anomaly_score_pl2}'"
+
+SecRule TX:PARANOIA_LEVEL "@ge 3" \
+    "id:949054,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.anomaly_score=+%{tx.anomaly_score_pl3}'"
+
+SecRule TX:PARANOIA_LEVEL "@ge 4" \
+    "id:949055,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.anomaly_score=+%{tx.anomaly_score_pl4}'"
+
+SecAction "id:949059,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.anomaly_score=0'"
+
+SecMarker BLOCKING_EARLY_ANOMALY_SCORING
+
+# FIXME: Do this conditionally when block-early is enabled
 
 # NOTE: tx.anomaly_score should not be set initially, but masking would lead to difficult bugs.
 # So we add to it.
@@ -89,6 +150,24 @@ SecRule TX:ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score=%{tx.anomaly_score}'"
+
+SecRule TX:BLOCKING_EARLY "@eq 1" \
+    "id:949111,\
+    phase:1,\
+    deny,\
+    t:none,\
+    msg:'Inbound Anomaly Score Exceeded in phase 1 (Total Score: %{TX.ANOMALY_SCORE})',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-generic',\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'CRITICAL',\
+    chain"
+    SecRule TX:ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
+    	"setvar:'tx.inbound_anomaly_score=%{tx.anomaly_score}'"
+
+
 
 
 

--- a/rules/REQUEST-949-BLOCKING-EVALUATION.conf
+++ b/rules/REQUEST-949-BLOCKING-EVALUATION.conf
@@ -72,8 +72,6 @@ SecAction "id:949059,\
 
 SecMarker BLOCKING_EARLY_ANOMALY_SCORING
 
-# FIXME: Do this conditionally when block-early is enabled
-
 # NOTE: tx.anomaly_score should not be set initially, but masking would lead to difficult bugs.
 # So we add to it.
 SecRule TX:PARANOIA_LEVEL "@ge 1" \
@@ -166,9 +164,6 @@ SecRule TX:BLOCKING_EARLY "@eq 1" \
     chain"
     SecRule TX:ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
     	"setvar:'tx.inbound_anomaly_score=%{tx.anomaly_score}'"
-
-
-
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:949011,phase:1,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"

--- a/rules/REQUEST-949-BLOCKING-EVALUATION.conf
+++ b/rules/REQUEST-949-BLOCKING-EVALUATION.conf
@@ -163,7 +163,7 @@ SecRule TX:BLOCKING_EARLY "@eq 1" \
     severity:'CRITICAL',\
     chain"
     SecRule TX:ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
-    	"setvar:'tx.inbound_anomaly_score=%{tx.anomaly_score}'"
+        "setvar:'tx.inbound_anomaly_score=%{tx.anomaly_score}'"
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:949011,phase:1,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"

--- a/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
+++ b/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
@@ -21,7 +21,67 @@
 # -= Paranoia Level 0 (empty) =- (apply unconditionally)
 #
 
-# Summing up the anomaly score.
+
+# Skipping early blocking
+
+SecRule TX:BLOCKING_EARLY "!@eq 1" \
+    "id:959050,\
+    phase:3,\
+    pass,\
+    t:none,\
+    nolog,\
+    skipAfter:BLOCKING_EARLY_ANOMALY_SCORING"
+
+SecRule TX:BLOCKING_EARLY "!@eq 1" \
+    "id:959051,\
+    phase:4,\
+    pass,\
+    t:none,\
+    nolog,\
+    skipAfter:BLOCKING_EARLY_ANOMALY_SCORING"
+
+# Summing up the anomaly score for early blocking
+
+SecRule TX:PARANOIA_LEVEL "@ge 1" \
+    "id:959052,\
+    phase:3,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.outbound_anomaly_score=+%{tx.anomaly_score_pl1}'"
+
+SecRule TX:PARANOIA_LEVEL "@ge 2" \
+    "id:959053,\
+    phase:3,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.outbound_anomaly_score=+%{tx.anomaly_score_pl2}'"
+
+SecRule TX:PARANOIA_LEVEL "@ge 3" \
+    "id:959054,\
+    phase:3,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.outbound_anomaly_score=+%{tx.anomaly_score_pl3}'"
+
+SecRule TX:PARANOIA_LEVEL "@ge 4" \
+    "id:959055,\
+    phase:3,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.outbound_anomaly_score=+%{tx.anomaly_score_pl4}'"
+
+SecAction "id:959059,\
+    phase:4,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.outbound_anomaly_score=0'"
+
+SecMarker BLOCKING_EARLY_ANOMALY_SCORING
 
 # NOTE: tx.anomaly_score should not be set initially, but masking would lead to difficult bugs.
 # So we add to it.
@@ -75,6 +135,21 @@ SecRule TX:OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
     ver:'OWASP_CRS/3.3.0',\
     setvar:'tx.anomaly_score=+%{tx.outbound_anomaly_score}'"
 
+SecRule TX:BLOCKING_EARLY "@eq 1" \
+    "id:959101,\
+    phase:3,\
+    deny,\
+    t:none,\
+    msg:'Outbound Anomaly Score Exceeded in phase 3 (Total Score: %{TX.OUTBOUND_ANOMALY_SCORE})',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-generic',\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'CRITICAL',\
+    chain"
+    SecRule TX:OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
+        "setvar:'tx.anomaly_score=%{tx.outbound_anomaly_score}'"
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:959011,phase:3,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"


### PR DESCRIPTION
This bring a new config item tx.blocking_early that will (when enabled) evaluate anomaly
scores at the end of phase 1 (in addition to phase 2) and at the end of phase 3 (instead of phase 4).

## Here is how to test for request early blocking:
* Enable early blocking in crs-setup.conf
* Set inbound anomaly threshold to 5
* Set PL to 2
* Issue this request: `curl -v -H "Accept:" -H "Host: 1.1.1.1"
http://localhost`
* Rule 949111 should trigger and the request should be blocked.

## Here is how to test for response early blocking
* Enable early blocking in crs-setup.conf
* Set outbound anomaly threshold to 4
* Set PL to 2
* Enable a proxying on the test machine to a non-existing backend (-> status 502)
* Access the test machine on the path that is being proxied (-> `curl -k https://localhost/proxy/foobar`)
* Rule 959101 should trigger and the request should be blocked
* Please note that there is a single phase:3 rule in CRS. The one looking for response status codes.
