### PR TITLE
Fix blind SQLi detection at PL1 Issue 1904

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -104,6 +104,14 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #
 # https://raw.github.com/PHPIDS/PHPIDS/master/lib/IDS/default_filter.xml
 #
+# The rule 942160 prevents time-based blind SQL injection attempts
+# by prohibiting sleep() or benchmark(,) functions.
+# The sleep command takes a number of seconds as an argument.
+# The benchmark command executes the specified expression multiple times.
+# Using a large number as the first parameter can create a delay.
+# Both commands can be used to determine if a response is slow or,
+# worse, will result in a DoS on the server.
+#
 SecRule REQUEST_BASENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:sleep\(\s*?\d*?\s*?\)|benchmark\(.*?\,.*?\))" \
     "id:942160,\
     phase:2,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -104,7 +104,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #
 # https://raw.github.com/PHPIDS/PHPIDS/master/lib/IDS/default_filter.xml
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:sleep\(\s*?\d*?\s*?\)|benchmark\(.*?\,.*?\))" \
+SecRule REQUEST_BASENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:sleep\(\s*?\d*?\s*?\)|benchmark\(.*?\,.*?\))" \
     "id:942160,\
     phase:2,\
     block,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -105,12 +105,21 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # https://raw.github.com/PHPIDS/PHPIDS/master/lib/IDS/default_filter.xml
 #
 # The rule 942160 prevents time-based blind SQL injection attempts
-# by prohibiting sleep() or benchmark(,) functions.
-# The sleep command takes a number of seconds as an argument.
-# The benchmark command executes the specified expression multiple times.
-# Using a large number as the first parameter can create a delay.
-# Both commands can be used to determine if a response is slow or,
-# worse, will result in a DoS on the server.
+# by prohibiting sleep() or benchmark(,) functions:
+#
+# * The sleep command takes a number of seconds as an argument.
+# * The benchmark command executes the specified expression multiple times.
+#
+# Using a long sleep time or high number of executions, you can create a delay
+# with the response from the server.  This allows to determine whether the
+# query has been executed or not.  A high response time proves that the SQLi
+# worked successfully. It can now be equipped with the real payload.
+#
+# Therefore this rule does not prevent the attack itself, but blocks an
+# attacker from using the standard utils to tinker with blind SQLi.
+#
+# A positive side effect is that it prevents certain DoS attacks via the directives
+# described above.
 #
 SecRule REQUEST_BASENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:sleep\(\s*?\d*?\s*?\)|benchmark\(.*?\,.*?\))" \
     "id:942160,\

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942160.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942160.yaml
@@ -1,6 +1,6 @@
 ---
   meta:
-    author: "Christian S.J. Peron, Christoph Hansen"
+    author: "Christian S.J. Peron, Christoph Hansen, Franziska Bühler"
     description: None
     enabled: true
     name: 942160.yaml
@@ -154,6 +154,22 @@
           port: 80
           uri: "/"
           data: "pay=BeNChMaRK(1000000, md5 AND 9796=4706('')"
+          version: HTTP/1.0
+        output:
+          log_contains: id "942160"
+  -
+    test_title: 942160-10
+    desc: "Detect blind SQLi attack in REQUEST_BASENAME. Issue #1904"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: GET
+          port: 80
+          uri: "/if(now()=sysdate(),sleep(12),0)"
           version: HTTP/1.0
         output:
           log_contains: id "942160"


### PR DESCRIPTION
This PR fixes issue #1904 by adding REQUEST_BASENAME to rule 942160 at PL1.

I think this is not super dangerous, the rule checks for `(?i:sleep\(\s*?\d*?\s*?\)|benchmark\(.*?\,.*?\))`.
Minimal strings that matches are:

- `sleep()` 
- `benchmark(,)` 

I think this is not super legit.

For further discussion about where to add REQUEST_BASENAME please see issue #1904.

This PR also adds a regression test that tests with the path provided by the original reporter: https://domain/if(now()=sysdate(),sleep(12),0)