### PR TITLE
Fix for issue #1922

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -255,6 +255,7 @@ SecRule &TX:enforce_bodyproc_urlencoded "@eq 0" \
 # All _score variables start at 0, and are incremented by the various rules
 # upon detection of a possible attack.
 # sql_error_match is used for shortcutting rules for performance reasons.
+# google_oauth2_callback_detected is used for detecting Google OAuth2 callbacks.
 
 SecAction \
     "id:901200,\
@@ -282,7 +283,8 @@ SecAction \
     setvar:'tx.outbound_anomaly_score_pl2=0',\
     setvar:'tx.outbound_anomaly_score_pl3=0',\
     setvar:'tx.outbound_anomaly_score_pl4=0',\
-    setvar:'tx.sql_error_match=0'"
+    setvar:'tx.sql_error_match=0',\
+    setvar:'tx.google_oauth2_callback_detected=0'"
 
 
 #

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -255,7 +255,6 @@ SecRule &TX:enforce_bodyproc_urlencoded "@eq 0" \
 # All _score variables start at 0, and are incremented by the various rules
 # upon detection of a possible attack.
 # sql_error_match is used for shortcutting rules for performance reasons.
-# google_oauth2_callback_detected is used for detecting Google OAuth2 callbacks.
 
 SecAction \
     "id:901200,\
@@ -283,8 +282,7 @@ SecAction \
     setvar:'tx.outbound_anomaly_score_pl2=0',\
     setvar:'tx.outbound_anomaly_score_pl3=0',\
     setvar:'tx.outbound_anomaly_score_pl4=0',\
-    setvar:'tx.sql_error_match=0',\
-    setvar:'tx.google_oauth2_callback_detected=0'"
+    setvar:'tx.sql_error_match=0'"
 
 
 #

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -101,7 +101,7 @@ SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@rx (?
 #
 # Ref: https://github.com/lightos/Panoptic/blob/master/cases.xml
 #
-SecRule TX:google_oauth2_callback_detected "@eq 0" \
+SecRule &TX:google_oauth2_callback_detected|TX:google_oauth2_callback_detected "@eq 0" \
     "id:930120,\
     phase:2,\
     block,\

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -115,10 +115,18 @@ SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@rx (?
 #
 # 920120 OS Files Access check for ARGS
 # 920121 OS Files Access check for REQUEST_COOKIES and XML (stricter sibling)
-SecRule &TX:google_oauth2_callback_detected|TX:google_oauth2_callback_detected "@eq 0" \
+#
+# Check for Google OAuth2 callback must be in the chained rule, otherwise this
+# rule cannot be excluded using exclusion rule (because of the way how ModSecurity
+# works). Unfortunately, this is causing unclear logs when this rule is triggered.
+# We decided that possibility of doing an exclusion is more important than nice
+# and clear logs.
+SecRule ARGS_NAMES|ARGS "@pmFromFile lfi-os-files.data" \
     "id:930120,\
     phase:2,\
     block,\
+    capture,\
+    t:none,t:utf8toUnicode,t:urlDecodeUni,t:normalizePathWin,t:lowercase,\
     msg:'OS File Access Attempt',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
@@ -132,10 +140,8 @@ SecRule &TX:google_oauth2_callback_detected|TX:google_oauth2_callback_detected "
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
-    SecRule ARGS_NAMES|ARGS "@pmFromFile lfi-os-files.data" \
-        "capture,\
-        t:none,t:utf8toUnicode,t:urlDecodeUni,t:normalizePathWin,t:lowercase,\
-        setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
+    SecRule &TX:google_oauth2_callback_detected|TX:google_oauth2_callback_detected "@eq 0" \
+        "setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # This rule is a stricter sibling of rule 930120 - for more info, see comment

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -22,10 +22,12 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:930012,phase:2,pass,nolog,skipAf
 #
 # -=[ Google OAuth2 callback detection ]=-
 #
-# This rule is trying to decide as hard as possible if the request is a callback of Google OAuth2. It is supposed
-# to be tight enough to not activate on bogus or invalid Google OAuth2 callbacks as this may result in bypass of
-# rules with are using this detection to do a whitelist.
-SecRule REQUEST_METHOD "@streq GET" \
+# This rule is trying to decide as hard as possible if the request is a callback
+# of Google OAuth2. It is supposed to be tight enough to not activate on bogus
+# or invalid Google OAuth2 callbacks as this may result in bypass of rules with
+# are using this detection to do a whitelist.
+# Currently used by rule 930120.
+SecRule &ARGS_GET "@eq 3" \
     "id:930050,\
     phase:2,\
     pass,\
@@ -33,7 +35,7 @@ SecRule REQUEST_METHOD "@streq GET" \
     nolog,\
     ver:'OWASP_CRS/3.3.0',\
     chain
-    SecRule &ARGS_GET "@eq 3" \
+    SecRule REQUEST_METHOD "@streq GET" \
         "chain"
         SecRule &ARGS_GET:state "@eq 1" \
             "chain"
@@ -99,14 +101,20 @@ SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@rx (?
 #
 # -=[ OS File Access ]=-
 #
+# We check for OS file access with the help of a local file with OS files data.
+#
 # Ref: https://github.com/lightos/Panoptic/blob/master/cases.xml
 #
-# This rule is using rule 930050 (see above) to whitelist Google OAuth2 callback requests. Check with
-# @pmFromFile must be the last in the chain to keep correct logging. Original rule 930120 was matching
-# also Cookies and XML targets but these needed to be shifted into rule 930121 (see below), as Google
-# OAuth2 callback detection is unable to handle attacks carried via Cookies (in other words: we cannot
-# whitelist cookies). XML target was moved with Cookies just to simplify this rule.
-# When editing this rule, check also rule 930121.
+# We need to avoid false positives with Google OAuth2 callback requests. We
+# detect those with the help of rule 930050. The OS file access detection rule
+# itself is split in a simple version 930121 and a chained version 930120 that
+# takes said callback requests into consideration in a chained rule. 930120 has
+# to start with the OAuth2 check, since we want to log information in
+# MATCHED_VAR in logdata and that variable points to the infos from the last
+# chained rule.
+#
+# 920120 OS Files Access check for ARGS
+# 920121 OS Files Access check for REQUEST_COOKIES and XML (stricter sibling)
 SecRule &TX:google_oauth2_callback_detected|TX:google_oauth2_callback_detected "@eq 0" \
     "id:930120,\
     phase:2,\
@@ -130,7 +138,8 @@ SecRule &TX:google_oauth2_callback_detected|TX:google_oauth2_callback_detected "
         setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
-# This rule was created by splitting rule 930120 - for more info, see comment above rule 930120.
+# This rule is a stricter sibling of rule 930120 - for more info, see comment
+# above rule 930120.
 # When editing this rule, check also rule 930120.
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|XML:/* "@pmFromFile lfi-os-files.data" \
     "id:930121,\

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -20,6 +20,33 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:930012,phase:2,pass,nolog,skipAf
 #
 
 #
+# -=[ Google OAuth2 callback detection ]=-
+#
+SecRule &ARGS "@eq 3" \
+    "id:930050,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-lfi',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/255/153/126',\
+    ver:'OWASP_CRS/3.3.0',\
+    chain"
+    SecRule &ARGS:state "@eq 1" \
+        chain"
+        SecRule &ARGS:code "@eq 1" \
+            chain"
+            SecRule &ARGS:scope "@eq 1" \
+                chain"
+                SecRule ARGS:scope "@rx ^(?:email|profile|openid){1}(?: email| profile| openid){0,2}(?: https:\/\/www\.googleapis\.com\/auth\/userinfo\.(?:email|profile|openid)){1,3}$" \
+                    setvar:'tx.google_oauth2_callback_detected=1'"
+
+#
 # -=[ Directory Traversal Attacks ]=-
 #
 # Ref: https://github.com/wireghoul/dotdotpwn
@@ -93,8 +120,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'PCI/6.5.4',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
-    setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    chain"
+    SecRule TX:google_oauth2_callback_detected "@eq 0" \
+        setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
+        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #
 # -=[ Restricted File Access ]=-

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -121,8 +121,9 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
-    SecRule TX:google_oauth2_callback_detected "@eq 0" \
-        "setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
+    SecRule TX:google_oauth2_callback_detected "!@eq 1" \
+        "capture,\
+        setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -22,28 +22,28 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:930012,phase:2,pass,nolog,skipAf
 #
 # -=[ Google OAuth2 callback detection ]=-
 #
-SecRule &ARGS "@eq 3" \
+# This rule is trying to decide as hard as possible if the request is a callback of Google OAuth2. It is supposed
+# to be tight enough to not activate on bogus or invalid Google OAuth2 callbacks as this may result in bypass of
+# rules with are using this detection to do a whitelist.
+SecRule REQUEST_METHOD "@streq GET" \
     "id:930050,\
     phase:2,\
     pass,\
     t:none,\
     nolog,\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-multi',\
-    tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/3.3.0',\
-    chain"
-    SecRule &ARGS:state "@eq 1" \
+    chain
+    SecRule &ARGS_GET "@eq 3" \
         "chain"
-        SecRule &ARGS:code "@eq 1" \
+        SecRule &ARGS_GET:state "@eq 1" \
             "chain"
-            SecRule &ARGS:scope "@eq 1" \
+            SecRule &ARGS_GET:code "@eq 1" \
                 "chain"
-                SecRule ARGS:scope "@rx ^(?:email|profile|openid)(?: email| profile| openid){0,2}(?: https://www\.googleapis\.com/auth/userinfo\.(?:email|profile|openid)){1,3}$" \
-                    "t:none,t:urlDecodeUni,t:lowercase,\
-                    setvar:'tx.google_oauth2_callback_detected=1'"
+                SecRule &ARGS_GET:scope "@eq 1" \
+                    "chain"
+                    SecRule ARGS_GET:scope "@rx ^(?:email|profile|openid)(?: email| profile| openid){0,2}(?: https://www\.googleapis\.com/auth/userinfo\.(?:email|profile|openid)){1,3}$" \
+                        "t:none,t:urlDecodeUni,t:lowercase,\
+                        setvar:'tx.google_oauth2_callback_detected=1'
 
 #
 # -=[ Directory Traversal Attacks ]=-
@@ -101,6 +101,12 @@ SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@rx (?
 #
 # Ref: https://github.com/lightos/Panoptic/blob/master/cases.xml
 #
+# This rule is using rule 930050 (see above) to whitelist Google OAuth2 callback requests. Check with
+# @pmFromFile must be the last in the chain to keep correct logging. Original rule 930120 was matching
+# also Cookies and XML targets but these needed to be shifted into rule 930121 (see below), as Google
+# OAuth2 callback detection is unable to handle attacks carried via Cookies (in other words: we cannot
+# whitelist cookies). XML target was moved with Cookies just to simplify this rule.
+# When editing this rule, check also rule 930121.
 SecRule &TX:google_oauth2_callback_detected|TX:google_oauth2_callback_detected "@eq 0" \
     "id:930120,\
     phase:2,\
@@ -118,11 +124,34 @@ SecRule &TX:google_oauth2_callback_detected|TX:google_oauth2_callback_detected "
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
-    SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pmFromFile lfi-os-files.data" \
+    SecRule ARGS_NAMES|ARGS "@pmFromFile lfi-os-files.data" \
         "capture,\
         t:none,t:utf8toUnicode,t:urlDecodeUni,t:normalizePathWin,t:lowercase,\
         setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# This rule was created by splitting rule 930120 - for more info, see comment above rule 930120.
+# When editing this rule, check also rule 930120.
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|XML:/* "@pmFromFile lfi-os-files.data" \
+    "id:930121,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:utf8toUnicode,t:urlDecodeUni,t:normalizePathWin,t:lowercase,\
+    msg:'OS File Access Attempt',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-lfi',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/255/153/126',\
+    tag:'PCI/6.5.4',\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'CRITICAL',\
+    setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #
 # -=[ Restricted File Access ]=-

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -38,13 +38,13 @@ SecRule &ARGS "@eq 3" \
     ver:'OWASP_CRS/3.3.0',\
     chain"
     SecRule &ARGS:state "@eq 1" \
-        chain"
+        "chain"
         SecRule &ARGS:code "@eq 1" \
-            chain"
+            "chain"
             SecRule &ARGS:scope "@eq 1" \
-                chain"
+                "chain"
                 SecRule ARGS:scope "@rx ^(?:email|profile|openid){1}(?: email| profile| openid){0,2}(?: https:\/\/www\.googleapis\.com\/auth\/userinfo\.(?:email|profile|openid)){1,3}$" \
-                    setvar:'tx.google_oauth2_callback_detected=1'"
+                    "setvar:'tx.google_oauth2_callback_detected=1'"
 
 #
 # -=[ Directory Traversal Attacks ]=-

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -43,8 +43,9 @@ SecRule &ARGS "@eq 3" \
             "chain"
             SecRule &ARGS:scope "@eq 1" \
                 "chain"
-                SecRule ARGS:scope "@rx ^(?:email|profile|openid){1}(?: email| profile| openid){0,2}(?: https:\/\/www\.googleapis\.com\/auth\/userinfo\.(?:email|profile|openid)){1,3}$" \
-                    "setvar:'tx.google_oauth2_callback_detected=1'"
+                SecRule ARGS:scope "@rx ^(?:email|profile|openid)(?: email| profile| openid){0,2}(?: https://www\.googleapis\.com/auth/userinfo\.(?:email|profile|openid)){1,3}$" \
+                    "t:none,t:urlDecodeUni,t:lowercase,\
+                    setvar:'tx.google_oauth2_callback_detected=1'"
 
 #
 # -=[ Directory Traversal Attacks ]=-
@@ -122,8 +123,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     severity:'CRITICAL',\
     chain"
     SecRule TX:google_oauth2_callback_detected "!@eq 1" \
-        "capture,\
-        setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
+        "setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -31,10 +31,8 @@ SecRule &ARGS "@eq 3" \
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
-    tag:'attack-lfi',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/255/153/126',\
     ver:'OWASP_CRS/3.3.0',\
     chain"
     SecRule &ARGS:state "@eq 1" \
@@ -103,12 +101,10 @@ SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@rx (?
 #
 # Ref: https://github.com/lightos/Panoptic/blob/master/cases.xml
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pmFromFile lfi-os-files.data" \
+SecRule TX:google_oauth2_callback_detected "@eq 0" \
     "id:930120,\
     phase:2,\
     block,\
-    capture,\
-    t:none,t:utf8toUnicode,t:urlDecodeUni,t:normalizePathWin,t:lowercase,\
     msg:'OS File Access Attempt',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
@@ -122,8 +118,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     chain"
-    SecRule TX:google_oauth2_callback_detected "!@eq 1" \
-        "setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
+    SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pmFromFile lfi-os-files.data" \
+        "capture,\
+        t:none,t:utf8toUnicode,t:urlDecodeUni,t:normalizePathWin,t:lowercase,\
+        setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -120,7 +120,8 @@ SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@rx (?
 # rule cannot be excluded using exclusion rule (because of the way how ModSecurity
 # works). Unfortunately, this is causing unclear logs when this rule is triggered.
 # We decided that possibility of doing an exclusion is more important than nice
-# and clear logs.
+# and clear logs. Additionally, we were able to lower negative impact on logs
+# using setvar actions and custom logdata action.
 SecRule ARGS_NAMES|ARGS "@pmFromFile lfi-os-files.data" \
     "id:930120,\
     phase:2,\
@@ -128,7 +129,7 @@ SecRule ARGS_NAMES|ARGS "@pmFromFile lfi-os-files.data" \
     capture,\
     t:none,t:utf8toUnicode,t:urlDecodeUni,t:normalizePathWin,t:lowercase,\
     msg:'OS File Access Attempt',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{tx.930120_matched_var_name}: %{tx.930120_matched_var}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -139,6 +140,8 @@ SecRule ARGS_NAMES|ARGS "@pmFromFile lfi-os-files.data" \
     tag:'PCI/6.5.4',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
+    setvar:'tx.930120_matched_var_name=%{MATCHED_VAR_NAME}',\
+    setvar:'tx.930120_matched_var=%{MATCHED_VAR}',\
     chain"
     SecRule &TX:google_oauth2_callback_detected|TX:google_oauth2_callback_detected "@eq 0" \
         "setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -122,7 +122,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     severity:'CRITICAL',\
     chain"
     SecRule TX:google_oauth2_callback_detected "@eq 0" \
-        setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
+        "setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #

--- a/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930120.yaml
+++ b/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930120.yaml
@@ -108,7 +108,6 @@
          headers:
            User-Agent: "ModSecurity CRS 3 Tests"
            Host: "localhost"
-         protocol: "http"
          uri: "/?state=test&code=test&scope=email+profile+https://www.googleapis.com/auth/userinfo.profile+https://www.googleapis.com/auth/userinfo.email"
        output:
          no_log_contains: id "930120"

--- a/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930120.yaml
+++ b/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930120.yaml
@@ -111,7 +111,7 @@
          uri: "/?state=test&code=test&scope=email+profile+https://www.googleapis.com/auth/userinfo.profile+https://www.googleapis.com/auth/userinfo.email"
        output:
          no_log_contains: id "930120"
--
+  -
    test_title: 930120-6
    desc: "Google OAuth2 callback data injection"
    stages:
@@ -126,4 +126,4 @@
            Host: "localhost"
          uri: "/?state=test&code=test&scope=email+profile+https://www.googleapis.com/auth/userinfo.profile+https://www.googleapis.com/auth/userinfo.email&inject=data"
        output:
-         log_contains: id "930120"
+         no_log_contains: id "930120"

--- a/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930120.yaml
+++ b/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930120.yaml
@@ -111,3 +111,19 @@
          uri: "/?state=test&code=test&scope=email+profile+https://www.googleapis.com/auth/userinfo.profile+https://www.googleapis.com/auth/userinfo.email"
        output:
          no_log_contains: id "930120"
+-
+   test_title: 930120-6
+   desc: "Google OAuth2 callback data injection"
+   stages:
+   -
+     stage:
+       input:
+         dest_addr: "127.0.0.1"
+         method: "GET"
+         port: 80
+         headers:
+           User-Agent: "ModSecurity CRS 3 Tests"
+           Host: "localhost"
+         uri: "/?state=test&code=test&scope=email+profile+https://www.googleapis.com/auth/userinfo.profile+https://www.googleapis.com/auth/userinfo.email&inject=data"
+       output:
+         log_contains: id "930120"

--- a/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930120.yaml
+++ b/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930120.yaml
@@ -126,4 +126,4 @@
            Host: "localhost"
          uri: "/?state=test&code=test&scope=email+profile+https://www.googleapis.com/auth/userinfo.profile+https://www.googleapis.com/auth/userinfo.email&inject=data"
        output:
-         no_log_contains: id "930120"
+         log_contains: id "930120"

--- a/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930120.yaml
+++ b/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930120.yaml
@@ -97,7 +97,7 @@
          log_contains: id "930120"
   -
    test_title: 930120-5
-   desc: "Google OAuth2 callback"
+   desc: "Google OAuth2 callback whitelist"
    stages:
    -
      stage:

--- a/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930120.yaml
+++ b/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930120.yaml
@@ -94,4 +94,21 @@
            Host: "localhost"
          uri: "/?foo=arg&path_comp=.ssh/id_rsa"
        output:
-         log_contains: "930120"
+         log_contains: id "930120"
+  -
+   test_title: 930120-5
+   desc: "Google OAuth2 callback"
+   stages:
+   -
+     stage:
+       input:
+         dest_addr: "127.0.0.1"
+         method: "GET"
+         port: 80
+         headers:
+           User-Agent: "ModSecurity CRS 3 Tests"
+           Host: "localhost"
+         protocol: "http"
+         uri: "/?state=test&code=test&scope=email+profile+https://www.googleapis.com/auth/userinfo.profile+https://www.googleapis.com/auth/userinfo.email"
+       output:
+         no_log_contains: id "930120"

--- a/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930121.yaml
+++ b/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930121.yaml
@@ -1,0 +1,61 @@
+---
+  meta:
+    author: azurit
+    description: None
+    enabled: true
+    name: 930121.yaml
+  tests:
+  -
+    test_title: 930121-1
+    desc: LFI via cookies
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: "127.0.0.1"
+          port: 80
+          method: "GET"
+          headers:
+            User-Agent: "ModSecurity CRS 3 Tests"
+            Host: "localhost"
+            Cookie: file=/etc/passwd;
+          uri: /
+          version: HTTP/1.1
+        output:
+          log_contains: id "930121"
+-
+    test_title: 930121-2
+    desc: LFI via cookies 2
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: "127.0.0.1"
+          port: 80
+          method: "GET"
+          headers:
+            User-Agent: "ModSecurity CRS 3 Tests"
+            Host: "localhost"
+            Cookie: /etc/passwd=lfi
+          uri: /
+          version: HTTP/1.1
+        output:
+          log_contains: id "930121"
+-
+    test_title: 930121-3
+    desc: LFI via cookies 3
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: "127.0.0.1"
+          port: 80
+          method: "GET"
+          headers:
+            User-Agent: "ModSecurity CRS 3 Tests"
+            Host: "localhost"
+            Cookie: __utm=/etc/passwd;
+          uri: /
+          version: HTTP/1.1
+        output:
+          no_log_contains: id "930121"

--- a/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930121.yaml
+++ b/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930121.yaml
@@ -23,7 +23,7 @@
           version: HTTP/1.1
         output:
           log_contains: id "930121"
--
+  -
     test_title: 930121-2
     desc: LFI via cookies 2
     stages:
@@ -41,7 +41,7 @@
           version: HTTP/1.1
         output:
           log_contains: id "930121"
--
+  -
     test_title: 930121-3
     desc: LFI via cookies 3
     stages:


### PR DESCRIPTION
I'm not sure if i'm approaching this correctly. The target situation is:
 - do not block Google OAuth2 callback requests (we need to whitelist it)
 - make sure that GOAuth2 whitelist won't open new holes in the firewall

This would be an easy task if 'logical OR' was available in SecRule or in chaining of multiple SecRules (i don't know of any at least similar functionality in modsecurity).

I decided to create a detection rule (930050) for Google OAuth2 callback, which is as tight as possible to not allow any bypass or data injection. Finally, i chained rule 930120 (which was triggering with Google OAuth2 callback) with new one which checks if Google OAuth2 callback request was detected.