### PR TITLE
New respose body blocking: Web shells

### DIFF
--- a/rules/RESPONSE-955-WEB-SHELLS.conf
+++ b/rules/RESPONSE-955-WEB-SHELLS.conf
@@ -23,7 +23,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:955012,phase:4,pass,nolog,skipAf
 SecRule RESPONSE_BODY "@rx (<title>r57 Shell Version [0-9.]+</title>|<title>r57 shell</title>)" \
     "id:955100,\
     phase:4,\
-    block,\
+    deny,\
     capture,\
     t:none,\
     msg:'r57 web shell',\
@@ -46,7 +46,7 @@ SecRule RESPONSE_BODY "@rx (<title>r57 Shell Version [0-9.]+</title>|<title>r57 
 SecRule RESPONSE_BODY "@rx <title>.*? - WSO [0-9.]+</title>" \
     "id:955110,\
     phase:4,\
-    block,\
+    deny,\
     capture,\
     t:none,\
     msg:'WSO web shell',\
@@ -69,7 +69,7 @@ SecRule RESPONSE_BODY "@rx <title>.*? - WSO [0-9.]+</title>" \
 SecRule RESPONSE_BODY "@rx B4TM4N SH3LL</title>.*<meta name='author' content='k4mpr3t'/>" \
     "id:955120,\
     phase:4,\
-    block,\
+    deny,\
     capture,\
     t:none,\
     msg:'b4tm4n web shell',\
@@ -92,7 +92,7 @@ SecRule RESPONSE_BODY "@rx B4TM4N SH3LL</title>.*<meta name='author' content='k4
 SecRule RESPONSE_BODY "@rx <title>Mini Shell</title>.*Developed By LameHacker" \
     "id:955130,\
     phase:4,\
-    block,\
+    deny,\
     capture,\
     t:none,\
     msg:'Mini Shell web shell',\
@@ -115,7 +115,7 @@ SecRule RESPONSE_BODY "@rx <title>Mini Shell</title>.*Developed By LameHacker" \
 SecRule RESPONSE_BODY "@contains <title>Loader'z WEB shell</title>" \
     "id:955150,\
     phase:4,\
-    block,\
+    deny,\
     capture,\
     t:none,\
     msg:'Loader\'z web shell',\
@@ -138,7 +138,7 @@ SecRule RESPONSE_BODY "@contains <title>Loader'z WEB shell</title>" \
 SecRule RESPONSE_BODY "@contains <title>Con7ext Shell V.2</title>" \
     "id:955160,\
     phase:4,\
-    block,\
+    deny,\
     capture,\
     t:none,\
     msg:'Con7ext Shell V.2 web shell',\
@@ -161,7 +161,7 @@ SecRule RESPONSE_BODY "@contains <title>Con7ext Shell V.2</title>" \
 SecRule RESPONSE_BODY "@contains <title>Yourman.sh Mini Shell</title>" \
     "id:955170,\
     phase:4,\
-    block,\
+    deny,\
     capture,\
     t:none,\
     msg:'Yourman.sh Mini Shell web shell',\
@@ -184,7 +184,7 @@ SecRule RESPONSE_BODY "@contains <title>Yourman.sh Mini Shell</title>" \
 SecRule RESPONSE_BODY "@contains <title>ZEROSHELL | ZEROSTORE</title>" \
     "id:955180,\
     phase:4,\
-    block,\
+    deny,\
     capture,\
     t:none,\
     msg:'Zerostore web shell',\
@@ -207,7 +207,7 @@ SecRule RESPONSE_BODY "@contains <title>ZEROSHELL | ZEROSTORE</title>" \
 SecRule RESPONSE_BODY "@contains <font color=\"red\">USTADCAGE_48</font> <font color=\"dodgerblue\">FILE MANAGER</font>" \
     "id:955190,\
     phase:4,\
-    block,\
+    deny,\
     capture,\
     t:none,\
     msg:'Ustadcage48 Filemanager',\
@@ -230,7 +230,7 @@ SecRule RESPONSE_BODY "@contains <font color=\"red\">USTADCAGE_48</font> <font c
 SecRule RESPONSE_BODY "@contains <title>0byt3m1n1-V2</title>" \
     "id:955200,\
     phase:4,\
-    block,\
+    deny,\
     capture,\
     t:none,\
     msg:'Zero Byte Mini Shell V2 web shell',\
@@ -253,7 +253,7 @@ SecRule RESPONSE_BODY "@contains <title>0byt3m1n1-V2</title>" \
 SecRule RESPONSE_BODY "@contains <link rel='SHORTCUT ICON' href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMy1jMDExIDY2LjE0NTY2MSwgMjAxMi8wMi8wNi0xNDo1NjoyNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoV2luZG93cykiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6MkRFNDY2MDQ4MDgyMTFFM0FDRDdBN0MzOTAxNzZFQUYiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6MkRFNDY2MDU4MDgyMTFFM0FDRDdBN0MzOTAxNzZFQUYiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDoyREU0NjYwMjgwODIxMUUzQUNEN0E3QzM5MDE3NkVBRiIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDoyREU0NjYwMzgwODIxMUUzQUNEN0E3QzM5MDE3NkVBRiIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pu6UWJYAAAKySURBVHjafFNdSJNhFH7e/fhDkrm2i03QphsxhYSgMIUgIeiiK6/SCAKTKNlFoEtBRfEvXYhM+0GQMtMUL7qSgqS0QCNKTDS6cJWGi6n577Zv3/e+b+934ZgxPfDBd3jP85xznnOOzufz4SCr7R7knKOg4eaVd9WPBgsZY/3NZcWJ0TGaaKeuZzgz2ueMgFF+p6WnL0OAjzMK+f8k+wg4xXxN91D5ns8ok8CRH5S2GogS8HBKk1xud+uBBIwpm5zyRvW/+sHAJuM8nsrMIElHi0/aHAmFl/OI2WRyOevrK/YwJFoD0ecFkfWthpDNRH1Cct4ZOzRaglX/DsY+TcNqTUd2phEjo1OiWg5KKUhJTbua6XTT7SKvSlLpGWB6DUjuWQeW/m4iJIWho8DvBT+2tgOwpZsxM/tm/sn9Trsar2OMq6rOV3X19wncJUNSEsnKSsWifx0BKYTgdhDxiENBfjZCuxJejX0W4frZiAZNZUVxVKYfmcyuKTI15ZxKw4IA74aCCIiMeqZDptWIuV8+hAkXOlFo9eaLNyrvOfdp4Gp/FjKlpMSbLMlY2dhCaCcEnUJgt5sF4QqkkIKsDAtGXn9QSThlMmFCg8gUmELpkXg99FoNwgEJ2jBBWpoBP/8sC7AMi/EY/EvLUBQJCpOMT921hDG5JkIglPd8/7EIFpShCQMnrAYsrW0gLERUwTNfv2FyaloddWmvu25NxTzvaG6MELRVXK/SgL8fHZ9AjsMCKUzFqBhSjQZAkrC6viqyy+ILdxU775bH3APVblW3j3POzuc4bGIHNPgyM4dAcFdtslT07OWcvhRVJIvVtg0/9nhJrGMqqWzpFb1eFYuiVfdbACcGOlvzYx0cOewaVStyuiY5U3JFVbahhx3eQ48plr3obDtHqSxTRZ6K9f5PgAEAm/hvADIkGOQAAAAASUVORK5CYII='>" \
     "id:955210,\
     phase:4,\
-    block,\
+    deny,\
     capture,\
     t:none,\
     msg:'B374k web shell',\
@@ -276,7 +276,7 @@ SecRule RESPONSE_BODY "@contains <link rel='SHORTCUT ICON' href='data:image/png;
 SecRule RESPONSE_BODY "@contains <title>Ani-Shell | India</title>" \
     "id:955220,\
     phase:4,\
-    block,\
+    deny,\
     capture,\
     t:none,\
     msg:'Ani-Shell web shell',\
@@ -299,7 +299,7 @@ SecRule RESPONSE_BODY "@contains <title>Ani-Shell | India</title>" \
 SecRule RESPONSE_BODY "@contains <title>IndoXploit</title>" \
     "id:955230,\
     phase:4,\
-    block,\
+    deny,\
     capture,\
     t:none,\
     msg:'IndoXploit web shell',\
@@ -322,7 +322,7 @@ SecRule RESPONSE_BODY "@contains <title>IndoXploit</title>" \
 SecRule RESPONSE_BODY "@contains <title>Dive Shell - Emperor Hacking Team</title>" \
     "id:955240,\
     phase:4,\
-    block,\
+    deny,\
     capture,\
     t:none,\
     msg:'Dive Shell web shell',\
@@ -345,7 +345,7 @@ SecRule RESPONSE_BODY "@contains <title>Dive Shell - Emperor Hacking Team</title
 SecRule RESPONSE_BODY "@contains <title>=[ 1n73ct10n privat shell ]=</title>" \
     "id:955250,\
     phase:4,\
-    block,\
+    deny,\
     capture,\
     t:none,\
     msg:'1n73ction web shell',\
@@ -368,7 +368,7 @@ SecRule RESPONSE_BODY "@contains <title>=[ 1n73ct10n privat shell ]=</title>" \
 SecRule RESPONSE_BODY "@contains <font face=Webdings size=6><b>!</b></font>" \
     "id:955260,\
     phase:4,\
-    block,\
+    deny,\
     capture,\
     t:none,\
     msg:'C99Shell web shell',\
@@ -391,7 +391,7 @@ SecRule RESPONSE_BODY "@contains <font face=Webdings size=6><b>!</b></font>" \
 SecRule RESPONSE_BODY "@contains ~ ALFA TEaM Shell -" \
     "id:955270,\
     phase:4,\
-    block,\
+    deny,\
     capture,\
     t:none,\
     msg:'ALFA-SHELL web shell',\
@@ -414,7 +414,7 @@ SecRule RESPONSE_BODY "@contains ~ ALFA TEaM Shell -" \
 SecRule RESPONSE_BODY "@rx <title>\.:: .* ~ Ashiyane V [0-9.]+ ::\.</title>" \
     "id:955280,\
     phase:4,\
-    block,\
+    deny,\
     capture,\
     t:none,\
     msg:'Ashiyane web shell',\
@@ -437,7 +437,7 @@ SecRule RESPONSE_BODY "@rx <title>\.:: .* ~ Ashiyane V [0-9.]+ ::\.</title>" \
 SecRule RESPONSE_BODY "@contains <font color=lime>./rusuh</font>" \
     "id:955290,\
     phase:4,\
-    block,\
+    deny,\
     capture,\
     t:none,\
     msg:'rusuh web shell',\
@@ -460,7 +460,7 @@ SecRule RESPONSE_BODY "@contains <font color=lime>./rusuh</font>" \
 SecRule RESPONSE_BODY "@contains Safe0ver Shell //Safe Mod Bypass  Safe0ver Shell" \
     "id:955300,\
     phase:4,\
-    block,\
+    deny,\
     capture,\
     t:none,\
     msg:'Safe0ver web shell',\
@@ -483,7 +483,7 @@ SecRule RESPONSE_BODY "@contains Safe0ver Shell //Safe Mod Bypass  Safe0ver Shel
 SecRule RESPONSE_BODY "@rx <title>Symlink_Sa [0-9.]+</title>" \
     "id:955310,\
     phase:4,\
-    block,\
+    deny,\
     capture,\
     t:none,\
     msg:'Symlink_Sa web shell',\
@@ -506,7 +506,7 @@ SecRule RESPONSE_BODY "@rx <title>Symlink_Sa [0-9.]+</title>" \
 SecRule RESPONSE_BODY "@contains <title>SyRiAn Sh3ll ~ " \
     "id:955320,\
     phase:4,\
-    block,\
+    deny,\
     capture,\
     t:none,\
     msg:'SyRiAn Sh3ll web shell',\
@@ -529,7 +529,7 @@ SecRule RESPONSE_BODY "@contains <title>SyRiAn Sh3ll ~ " \
 SecRule RESPONSE_BODY "@contains <h1 style=\"margin-bottom: 0\">webadmin.php</h1>" \
     "id:955330,\
     phase:4,\
-    block,\
+    deny,\
     capture,\
     t:none,\
     msg:'webadmin.php file manager',\
@@ -552,7 +552,7 @@ SecRule RESPONSE_BODY "@contains <h1 style=\"margin-bottom: 0\">webadmin.php</h1
 SecRule RESPONSE_BODY "@contains <b>--[ x2300 Locus7Shell v. " \
     "id:955340,\
     phase:4,\
-    block,\
+    deny,\
     capture,\
     t:none,\
     msg:'Locus7Shell web shell',\

--- a/rules/RESPONSE-955-WEB-SHELLS.conf
+++ b/rules/RESPONSE-955-WEB-SHELLS.conf
@@ -23,19 +23,17 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:955012,phase:4,pass,nolog,skipAf
 SecRule RESPONSE_BODY "@rx (<title>r57 Shell Version [0-9.]+</title>|<title>r57 shell</title>)" \
     "id:955100,\
     phase:4,\
-    deny,\
+    block,\
     capture,\
     t:none,\
     msg:'r57 web shell',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-iis',\
-    tag:'platform-windows',\
-    tag:'attack-disclosure',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/118/116',\
+    tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -46,19 +44,17 @@ SecRule RESPONSE_BODY "@rx (<title>r57 Shell Version [0-9.]+</title>|<title>r57 
 SecRule RESPONSE_BODY "@rx <title>.*? - WSO [0-9.]+</title>" \
     "id:955110,\
     phase:4,\
-    deny,\
+    block,\
     capture,\
     t:none,\
     msg:'WSO web shell',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-iis',\
-    tag:'platform-windows',\
-    tag:'attack-disclosure',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/118/116',\
+    tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -69,19 +65,17 @@ SecRule RESPONSE_BODY "@rx <title>.*? - WSO [0-9.]+</title>" \
 SecRule RESPONSE_BODY "@rx B4TM4N SH3LL</title>.*<meta name='author' content='k4mpr3t'/>" \
     "id:955120,\
     phase:4,\
-    deny,\
+    block,\
     capture,\
     t:none,\
     msg:'b4tm4n web shell',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-iis',\
-    tag:'platform-windows',\
-    tag:'attack-disclosure',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/118/116',\
+    tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -92,19 +86,17 @@ SecRule RESPONSE_BODY "@rx B4TM4N SH3LL</title>.*<meta name='author' content='k4
 SecRule RESPONSE_BODY "@rx <title>Mini Shell</title>.*Developed By LameHacker" \
     "id:955130,\
     phase:4,\
-    deny,\
+    block,\
     capture,\
     t:none,\
     msg:'Mini Shell web shell',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-iis',\
-    tag:'platform-windows',\
-    tag:'attack-disclosure',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/118/116',\
+    tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -115,19 +107,17 @@ SecRule RESPONSE_BODY "@rx <title>Mini Shell</title>.*Developed By LameHacker" \
 SecRule RESPONSE_BODY "@contains <title>Loader'z WEB shell</title>" \
     "id:955150,\
     phase:4,\
-    deny,\
+    block,\
     capture,\
     t:none,\
     msg:'Loader\'z web shell',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-iis',\
-    tag:'platform-windows',\
-    tag:'attack-disclosure',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/118/116',\
+    tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -138,19 +128,17 @@ SecRule RESPONSE_BODY "@contains <title>Loader'z WEB shell</title>" \
 SecRule RESPONSE_BODY "@contains <title>Con7ext Shell V.2</title>" \
     "id:955160,\
     phase:4,\
-    deny,\
+    block,\
     capture,\
     t:none,\
     msg:'Con7ext Shell V.2 web shell',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-iis',\
-    tag:'platform-windows',\
-    tag:'attack-disclosure',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/118/116',\
+    tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -161,19 +149,17 @@ SecRule RESPONSE_BODY "@contains <title>Con7ext Shell V.2</title>" \
 SecRule RESPONSE_BODY "@contains <title>Yourman.sh Mini Shell</title>" \
     "id:955170,\
     phase:4,\
-    deny,\
+    block,\
     capture,\
     t:none,\
     msg:'Yourman.sh Mini Shell web shell',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-iis',\
-    tag:'platform-windows',\
-    tag:'attack-disclosure',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/118/116',\
+    tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -184,19 +170,17 @@ SecRule RESPONSE_BODY "@contains <title>Yourman.sh Mini Shell</title>" \
 SecRule RESPONSE_BODY "@contains <title>ZEROSHELL | ZEROSTORE</title>" \
     "id:955180,\
     phase:4,\
-    deny,\
+    block,\
     capture,\
     t:none,\
     msg:'Zerostore web shell',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-iis',\
-    tag:'platform-windows',\
-    tag:'attack-disclosure',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/118/116',\
+    tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -207,19 +191,17 @@ SecRule RESPONSE_BODY "@contains <title>ZEROSHELL | ZEROSTORE</title>" \
 SecRule RESPONSE_BODY "@contains <font color=\"red\">USTADCAGE_48</font> <font color=\"dodgerblue\">FILE MANAGER</font>" \
     "id:955190,\
     phase:4,\
-    deny,\
+    block,\
     capture,\
     t:none,\
     msg:'Ustadcage48 Filemanager',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-iis',\
-    tag:'platform-windows',\
-    tag:'attack-disclosure',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/118/116',\
+    tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -230,19 +212,17 @@ SecRule RESPONSE_BODY "@contains <font color=\"red\">USTADCAGE_48</font> <font c
 SecRule RESPONSE_BODY "@contains <title>0byt3m1n1-V2</title>" \
     "id:955200,\
     phase:4,\
-    deny,\
+    block,\
     capture,\
     t:none,\
     msg:'Zero Byte Mini Shell V2 web shell',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-iis',\
-    tag:'platform-windows',\
-    tag:'attack-disclosure',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/118/116',\
+    tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -253,19 +233,17 @@ SecRule RESPONSE_BODY "@contains <title>0byt3m1n1-V2</title>" \
 SecRule RESPONSE_BODY "@contains <link rel='SHORTCUT ICON' href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMy1jMDExIDY2LjE0NTY2MSwgMjAxMi8wMi8wNi0xNDo1NjoyNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoV2luZG93cykiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6MkRFNDY2MDQ4MDgyMTFFM0FDRDdBN0MzOTAxNzZFQUYiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6MkRFNDY2MDU4MDgyMTFFM0FDRDdBN0MzOTAxNzZFQUYiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDoyREU0NjYwMjgwODIxMUUzQUNEN0E3QzM5MDE3NkVBRiIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDoyREU0NjYwMzgwODIxMUUzQUNEN0E3QzM5MDE3NkVBRiIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pu6UWJYAAAKySURBVHjafFNdSJNhFH7e/fhDkrm2i03QphsxhYSgMIUgIeiiK6/SCAKTKNlFoEtBRfEvXYhM+0GQMtMUL7qSgqS0QCNKTDS6cJWGi6n577Zv3/e+b+934ZgxPfDBd3jP85xznnOOzufz4SCr7R7knKOg4eaVd9WPBgsZY/3NZcWJ0TGaaKeuZzgz2ueMgFF+p6WnL0OAjzMK+f8k+wg4xXxN91D5ns8ok8CRH5S2GogS8HBKk1xud+uBBIwpm5zyRvW/+sHAJuM8nsrMIElHi0/aHAmFl/OI2WRyOevrK/YwJFoD0ecFkfWthpDNRH1Cct4ZOzRaglX/DsY+TcNqTUd2phEjo1OiWg5KKUhJTbua6XTT7SKvSlLpGWB6DUjuWQeW/m4iJIWho8DvBT+2tgOwpZsxM/tm/sn9Trsar2OMq6rOV3X19wncJUNSEsnKSsWifx0BKYTgdhDxiENBfjZCuxJejX0W4frZiAZNZUVxVKYfmcyuKTI15ZxKw4IA74aCCIiMeqZDptWIuV8+hAkXOlFo9eaLNyrvOfdp4Gp/FjKlpMSbLMlY2dhCaCcEnUJgt5sF4QqkkIKsDAtGXn9QSThlMmFCg8gUmELpkXg99FoNwgEJ2jBBWpoBP/8sC7AMi/EY/EvLUBQJCpOMT921hDG5JkIglPd8/7EIFpShCQMnrAYsrW0gLERUwTNfv2FyaloddWmvu25NxTzvaG6MELRVXK/SgL8fHZ9AjsMCKUzFqBhSjQZAkrC6viqyy+ILdxU775bH3APVblW3j3POzuc4bGIHNPgyM4dAcFdtslT07OWcvhRVJIvVtg0/9nhJrGMqqWzpFb1eFYuiVfdbACcGOlvzYx0cOewaVStyuiY5U3JFVbahhx3eQ48plr3obDtHqSxTRZ6K9f5PgAEAm/hvADIkGOQAAAAASUVORK5CYII='>" \
     "id:955210,\
     phase:4,\
-    deny,\
+    block,\
     capture,\
     t:none,\
     msg:'B374k web shell',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-iis',\
-    tag:'platform-windows',\
-    tag:'attack-disclosure',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/118/116',\
+    tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -276,19 +254,17 @@ SecRule RESPONSE_BODY "@contains <link rel='SHORTCUT ICON' href='data:image/png;
 SecRule RESPONSE_BODY "@contains <title>Ani-Shell | India</title>" \
     "id:955220,\
     phase:4,\
-    deny,\
+    block,\
     capture,\
     t:none,\
     msg:'Ani-Shell web shell',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-iis',\
-    tag:'platform-windows',\
-    tag:'attack-disclosure',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/118/116',\
+    tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -299,19 +275,17 @@ SecRule RESPONSE_BODY "@contains <title>Ani-Shell | India</title>" \
 SecRule RESPONSE_BODY "@contains <title>IndoXploit</title>" \
     "id:955230,\
     phase:4,\
-    deny,\
+    block,\
     capture,\
     t:none,\
     msg:'IndoXploit web shell',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-iis',\
-    tag:'platform-windows',\
-    tag:'attack-disclosure',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/118/116',\
+    tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -322,19 +296,17 @@ SecRule RESPONSE_BODY "@contains <title>IndoXploit</title>" \
 SecRule RESPONSE_BODY "@contains <title>Dive Shell - Emperor Hacking Team</title>" \
     "id:955240,\
     phase:4,\
-    deny,\
+    block,\
     capture,\
     t:none,\
     msg:'Dive Shell web shell',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-iis',\
-    tag:'platform-windows',\
-    tag:'attack-disclosure',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/118/116',\
+    tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -345,19 +317,17 @@ SecRule RESPONSE_BODY "@contains <title>Dive Shell - Emperor Hacking Team</title
 SecRule RESPONSE_BODY "@contains <title>=[ 1n73ct10n privat shell ]=</title>" \
     "id:955250,\
     phase:4,\
-    deny,\
+    block,\
     capture,\
     t:none,\
     msg:'1n73ction web shell',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-iis',\
-    tag:'platform-windows',\
-    tag:'attack-disclosure',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/118/116',\
+    tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -368,19 +338,17 @@ SecRule RESPONSE_BODY "@contains <title>=[ 1n73ct10n privat shell ]=</title>" \
 SecRule RESPONSE_BODY "@contains <font face=Webdings size=6><b>!</b></font>" \
     "id:955260,\
     phase:4,\
-    deny,\
+    block,\
     capture,\
     t:none,\
     msg:'C99Shell web shell',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-iis',\
-    tag:'platform-windows',\
-    tag:'attack-disclosure',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/118/116',\
+    tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -391,19 +359,17 @@ SecRule RESPONSE_BODY "@contains <font face=Webdings size=6><b>!</b></font>" \
 SecRule RESPONSE_BODY "@contains ~ ALFA TEaM Shell -" \
     "id:955270,\
     phase:4,\
-    deny,\
+    block,\
     capture,\
     t:none,\
     msg:'ALFA-SHELL web shell',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-iis',\
-    tag:'platform-windows',\
-    tag:'attack-disclosure',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/118/116',\
+    tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -414,19 +380,17 @@ SecRule RESPONSE_BODY "@contains ~ ALFA TEaM Shell -" \
 SecRule RESPONSE_BODY "@rx <title>\.:: .* ~ Ashiyane V [0-9.]+ ::\.</title>" \
     "id:955280,\
     phase:4,\
-    deny,\
+    block,\
     capture,\
     t:none,\
     msg:'Ashiyane web shell',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-iis',\
-    tag:'platform-windows',\
-    tag:'attack-disclosure',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/118/116',\
+    tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -437,19 +401,17 @@ SecRule RESPONSE_BODY "@rx <title>\.:: .* ~ Ashiyane V [0-9.]+ ::\.</title>" \
 SecRule RESPONSE_BODY "@contains <font color=lime>./rusuh</font>" \
     "id:955290,\
     phase:4,\
-    deny,\
+    block,\
     capture,\
     t:none,\
     msg:'rusuh web shell',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-iis',\
-    tag:'platform-windows',\
-    tag:'attack-disclosure',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/118/116',\
+    tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -460,19 +422,17 @@ SecRule RESPONSE_BODY "@contains <font color=lime>./rusuh</font>" \
 SecRule RESPONSE_BODY "@contains Safe0ver Shell //Safe Mod Bypass  Safe0ver Shell" \
     "id:955300,\
     phase:4,\
-    deny,\
+    block,\
     capture,\
     t:none,\
     msg:'Safe0ver web shell',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-iis',\
-    tag:'platform-windows',\
-    tag:'attack-disclosure',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/118/116',\
+    tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -483,19 +443,17 @@ SecRule RESPONSE_BODY "@contains Safe0ver Shell //Safe Mod Bypass  Safe0ver Shel
 SecRule RESPONSE_BODY "@rx <title>Symlink_Sa [0-9.]+</title>" \
     "id:955310,\
     phase:4,\
-    deny,\
+    block,\
     capture,\
     t:none,\
     msg:'Symlink_Sa web shell',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-iis',\
-    tag:'platform-windows',\
-    tag:'attack-disclosure',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/118/116',\
+    tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -506,42 +464,17 @@ SecRule RESPONSE_BODY "@rx <title>Symlink_Sa [0-9.]+</title>" \
 SecRule RESPONSE_BODY "@contains <title>SyRiAn Sh3ll ~ " \
     "id:955320,\
     phase:4,\
-    deny,\
+    block,\
     capture,\
     t:none,\
     msg:'SyRiAn Sh3ll web shell',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-iis',\
-    tag:'platform-windows',\
-    tag:'attack-disclosure',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/118/116',\
-    ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
-    severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
-
-# webadmin.php file manager
-SecRule RESPONSE_BODY "@contains <h1 style=\"margin-bottom: 0\">webadmin.php</h1>" \
-    "id:955330,\
-    phase:4,\
-    deny,\
-    capture,\
-    t:none,\
-    msg:'webadmin.php file manager',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-iis',\
-    tag:'platform-windows',\
-    tag:'attack-disclosure',\
-    tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'capec/1000/118/116',\
+    tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -550,21 +483,19 @@ SecRule RESPONSE_BODY "@contains <h1 style=\"margin-bottom: 0\">webadmin.php</h1
 
 # Locus7Shell web shell
 SecRule RESPONSE_BODY "@contains <b>--[ x2300 Locus7Shell v. " \
-    "id:955340,\
+    "id:955330,\
     phase:4,\
-    deny,\
+    block,\
     capture,\
     t:none,\
     msg:'Locus7Shell web shell',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-iis',\
-    tag:'platform-windows',\
-    tag:'attack-disclosure',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/118/116',\
+    tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
@@ -579,7 +510,27 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:955014,phase:4,pass,nolog,skipAf
 # -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
 #
 
-
+# webadmin.php file manager
+# This is placed in PL2 because of too generic pattern.
+SecRule RESPONSE_BODY "@contains <h1 style=\"margin-bottom: 0\">webadmin.php</h1>" \
+    "id:955340,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'webadmin.php file manager',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
+    tag:'paranoia-level/2',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/225/122/17/650',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'CRITICAL',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:955015,phase:3,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:955016,phase:4,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"

--- a/rules/RESPONSE-955-WEB-SHELLS.conf
+++ b/rules/RESPONSE-955-WEB-SHELLS.conf
@@ -39,8 +39,8 @@ SecRule RESPONSE_BODY "@rx (<title>r57 Shell Version [0-9.]+</title>|<title>r57 
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # WSO web shell
 SecRule RESPONSE_BODY "@rx <title>.*? - WSO [0-9.]+</title>" \
@@ -62,8 +62,8 @@ SecRule RESPONSE_BODY "@rx <title>.*? - WSO [0-9.]+</title>" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # b4tm4n web shell (https://github.com/k4mpr3t/b4tm4n)
 SecRule RESPONSE_BODY "@rx B4TM4N SH3LL</title>.*<meta name='author' content='k4mpr3t'/>" \
@@ -85,8 +85,8 @@ SecRule RESPONSE_BODY "@rx B4TM4N SH3LL</title>.*<meta name='author' content='k4
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Mini Shell web shell
 SecRule RESPONSE_BODY "@rx <title>Mini Shell</title>.*Developed By LameHacker" \
@@ -108,8 +108,8 @@ SecRule RESPONSE_BODY "@rx <title>Mini Shell</title>.*Developed By LameHacker" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Loader'z web shell
 SecRule RESPONSE_BODY "@contains <title>Loader'z WEB shell</title>" \
@@ -131,8 +131,8 @@ SecRule RESPONSE_BODY "@contains <title>Loader'z WEB shell</title>" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Con7ext Shell V.2 web shell
 SecRule RESPONSE_BODY "@contains <title>Con7ext Shell V.2</title>" \
@@ -154,8 +154,8 @@ SecRule RESPONSE_BODY "@contains <title>Con7ext Shell V.2</title>" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Yourman.sh Mini Shell web shell
 SecRule RESPONSE_BODY "@contains <title>Yourman.sh Mini Shell</title>" \
@@ -177,8 +177,8 @@ SecRule RESPONSE_BODY "@contains <title>Yourman.sh Mini Shell</title>" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Zerostore web shell
 SecRule RESPONSE_BODY "@contains <title>ZEROSHELL | ZEROSTORE</title>" \
@@ -200,8 +200,8 @@ SecRule RESPONSE_BODY "@contains <title>ZEROSHELL | ZEROSTORE</title>" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Ustadcage48 Filemanager
 SecRule RESPONSE_BODY "@contains <font color=\"red\">USTADCAGE_48</font> <font color=\"dodgerblue\">FILE MANAGER</font>" \
@@ -223,8 +223,8 @@ SecRule RESPONSE_BODY "@contains <font color=\"red\">USTADCAGE_48</font> <font c
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Zero Byte Mini Shell V2 web shell
 SecRule RESPONSE_BODY "@contains <title>0byt3m1n1-V2</title>" \
@@ -246,8 +246,8 @@ SecRule RESPONSE_BODY "@contains <title>0byt3m1n1-V2</title>" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # B374k web shell
 SecRule RESPONSE_BODY "@contains <link rel='SHORTCUT ICON' href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMy1jMDExIDY2LjE0NTY2MSwgMjAxMi8wMi8wNi0xNDo1NjoyNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoV2luZG93cykiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6MkRFNDY2MDQ4MDgyMTFFM0FDRDdBN0MzOTAxNzZFQUYiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6MkRFNDY2MDU4MDgyMTFFM0FDRDdBN0MzOTAxNzZFQUYiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDoyREU0NjYwMjgwODIxMUUzQUNEN0E3QzM5MDE3NkVBRiIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDoyREU0NjYwMzgwODIxMUUzQUNEN0E3QzM5MDE3NkVBRiIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pu6UWJYAAAKySURBVHjafFNdSJNhFH7e/fhDkrm2i03QphsxhYSgMIUgIeiiK6/SCAKTKNlFoEtBRfEvXYhM+0GQMtMUL7qSgqS0QCNKTDS6cJWGi6n577Zv3/e+b+934ZgxPfDBd3jP85xznnOOzufz4SCr7R7knKOg4eaVd9WPBgsZY/3NZcWJ0TGaaKeuZzgz2ueMgFF+p6WnL0OAjzMK+f8k+wg4xXxN91D5ns8ok8CRH5S2GogS8HBKk1xud+uBBIwpm5zyRvW/+sHAJuM8nsrMIElHi0/aHAmFl/OI2WRyOevrK/YwJFoD0ecFkfWthpDNRH1Cct4ZOzRaglX/DsY+TcNqTUd2phEjo1OiWg5KKUhJTbua6XTT7SKvSlLpGWB6DUjuWQeW/m4iJIWho8DvBT+2tgOwpZsxM/tm/sn9Trsar2OMq6rOV3X19wncJUNSEsnKSsWifx0BKYTgdhDxiENBfjZCuxJejX0W4frZiAZNZUVxVKYfmcyuKTI15ZxKw4IA74aCCIiMeqZDptWIuV8+hAkXOlFo9eaLNyrvOfdp4Gp/FjKlpMSbLMlY2dhCaCcEnUJgt5sF4QqkkIKsDAtGXn9QSThlMmFCg8gUmELpkXg99FoNwgEJ2jBBWpoBP/8sC7AMi/EY/EvLUBQJCpOMT921hDG5JkIglPd8/7EIFpShCQMnrAYsrW0gLERUwTNfv2FyaloddWmvu25NxTzvaG6MELRVXK/SgL8fHZ9AjsMCKUzFqBhSjQZAkrC6viqyy+ILdxU775bH3APVblW3j3POzuc4bGIHNPgyM4dAcFdtslT07OWcvhRVJIvVtg0/9nhJrGMqqWzpFb1eFYuiVfdbACcGOlvzYx0cOewaVStyuiY5U3JFVbahhx3eQ48plr3obDtHqSxTRZ6K9f5PgAEAm/hvADIkGOQAAAAASUVORK5CYII='>" \
@@ -269,8 +269,8 @@ SecRule RESPONSE_BODY "@contains <link rel='SHORTCUT ICON' href='data:image/png;
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Ani-Shell web shell (http://ani-shell.sourceforge.net/)
 SecRule RESPONSE_BODY "@contains <title>Ani-Shell | India</title>" \
@@ -292,8 +292,8 @@ SecRule RESPONSE_BODY "@contains <title>Ani-Shell | India</title>" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # IndoXploit web shell
 SecRule RESPONSE_BODY "@contains <title>IndoXploit</title>" \
@@ -315,8 +315,8 @@ SecRule RESPONSE_BODY "@contains <title>IndoXploit</title>" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Dive Shell web shell
 SecRule RESPONSE_BODY "@contains <title>Dive Shell - Emperor Hacking Team</title>" \
@@ -338,8 +338,8 @@ SecRule RESPONSE_BODY "@contains <title>Dive Shell - Emperor Hacking Team</title
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # 1n73ction web shell
 SecRule RESPONSE_BODY "@contains <title>=[ 1n73ct10n privat shell ]=</title>" \
@@ -361,8 +361,8 @@ SecRule RESPONSE_BODY "@contains <title>=[ 1n73ct10n privat shell ]=</title>" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # C99Shell web shell
 SecRule RESPONSE_BODY "@contains <font face=Webdings size=6><b>!</b></font>" \
@@ -384,8 +384,8 @@ SecRule RESPONSE_BODY "@contains <font face=Webdings size=6><b>!</b></font>" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # ALFA-SHELL web shell (https://github.com/solevisible)
 SecRule RESPONSE_BODY "@contains ~ ALFA TEaM Shell -" \
@@ -407,8 +407,8 @@ SecRule RESPONSE_BODY "@contains ~ ALFA TEaM Shell -" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Ashiyane web shell
 SecRule RESPONSE_BODY "@rx <title>\.:: .* ~ Ashiyane V [0-9.]+ ::\.</title>" \
@@ -430,8 +430,8 @@ SecRule RESPONSE_BODY "@rx <title>\.:: .* ~ Ashiyane V [0-9.]+ ::\.</title>" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # rusuh web shell
 SecRule RESPONSE_BODY "@contains <font color=lime>./rusuh</font>" \
@@ -453,8 +453,8 @@ SecRule RESPONSE_BODY "@contains <font color=lime>./rusuh</font>" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Safe0ver web shell
 SecRule RESPONSE_BODY "@contains Safe0ver Shell //Safe Mod Bypass  Safe0ver Shell" \
@@ -476,8 +476,8 @@ SecRule RESPONSE_BODY "@contains Safe0ver Shell //Safe Mod Bypass  Safe0ver Shel
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Symlink_Sa web shell
 SecRule RESPONSE_BODY "@rx <title>Symlink_Sa [0-9.]+</title>" \
@@ -499,8 +499,8 @@ SecRule RESPONSE_BODY "@rx <title>Symlink_Sa [0-9.]+</title>" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # SyRiAn Sh3ll web shell
 SecRule RESPONSE_BODY "@contains <title>SyRiAn Sh3ll ~ " \
@@ -522,8 +522,8 @@ SecRule RESPONSE_BODY "@contains <title>SyRiAn Sh3ll ~ " \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # webadmin.php file manager
 SecRule RESPONSE_BODY "@contains <h1 style=\"margin-bottom: 0\">webadmin.php</h1>" \
@@ -545,8 +545,8 @@ SecRule RESPONSE_BODY "@contains <h1 style=\"margin-bottom: 0\">webadmin.php</h1
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Locus7Shell web shell
 SecRule RESPONSE_BODY "@contains <b>--[ x2300 Locus7Shell v. " \
@@ -568,8 +568,8 @@ SecRule RESPONSE_BODY "@contains <b>--[ x2300 Locus7Shell v. " \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 

--- a/rules/RESPONSE-955-WEB-SHELLS.conf
+++ b/rules/RESPONSE-955-WEB-SHELLS.conf
@@ -38,7 +38,7 @@ SecRule RESPONSE_BODY "@rx (<title>r57 Shell Version [0-9.]+</title>|<title>r57 
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
-    severity:'ERROR',\
+    severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -61,7 +61,7 @@ SecRule RESPONSE_BODY "@rx <title>.*? - WSO [0-9.]+</title>" \
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
-    severity:'ERROR',\
+    severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -84,7 +84,7 @@ SecRule RESPONSE_BODY "@rx B4TM4N SH3LL</title>.*<meta name='author' content='k4
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
-    severity:'ERROR',\
+    severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -107,7 +107,7 @@ SecRule RESPONSE_BODY "@rx <title>Mini Shell</title>.*Developed By LameHacker" \
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
-    severity:'ERROR',\
+    severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -130,7 +130,7 @@ SecRule RESPONSE_BODY "@contains <title>Loader'z WEB shell</title>" \
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
-    severity:'ERROR',\
+    severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -153,7 +153,7 @@ SecRule RESPONSE_BODY "@contains <title>Con7ext Shell V.2</title>" \
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
-    severity:'ERROR',\
+    severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -176,7 +176,7 @@ SecRule RESPONSE_BODY "@contains <title>Yourman.sh Mini Shell</title>" \
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
-    severity:'ERROR',\
+    severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -199,7 +199,7 @@ SecRule RESPONSE_BODY "@contains <title>ZEROSHELL | ZEROSTORE</title>" \
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
-    severity:'ERROR',\
+    severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -222,7 +222,7 @@ SecRule RESPONSE_BODY "@contains <font color=\"red\">USTADCAGE_48</font> <font c
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
-    severity:'ERROR',\
+    severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -245,7 +245,7 @@ SecRule RESPONSE_BODY "@contains <title>0byt3m1n1-V2</title>" \
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
-    severity:'ERROR',\
+    severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -268,7 +268,7 @@ SecRule RESPONSE_BODY "@contains <link rel='SHORTCUT ICON' href='data:image/png;
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
-    severity:'ERROR',\
+    severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -291,7 +291,7 @@ SecRule RESPONSE_BODY "@contains <title>Ani-Shell | India</title>" \
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
-    severity:'ERROR',\
+    severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -314,7 +314,7 @@ SecRule RESPONSE_BODY "@contains <title>IndoXploit</title>" \
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
-    severity:'ERROR',\
+    severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -337,7 +337,7 @@ SecRule RESPONSE_BODY "@contains <title>Dive Shell - Emperor Hacking Team</title
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
-    severity:'ERROR',\
+    severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -360,7 +360,7 @@ SecRule RESPONSE_BODY "@contains <title>=[ 1n73ct10n privat shell ]=</title>" \
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
-    severity:'ERROR',\
+    severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -383,7 +383,7 @@ SecRule RESPONSE_BODY "@contains <font face=Webdings size=6><b>!</b></font>" \
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
-    severity:'ERROR',\
+    severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -406,7 +406,7 @@ SecRule RESPONSE_BODY "@contains ~ ALFA TEaM Shell -" \
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
-    severity:'ERROR',\
+    severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -429,7 +429,7 @@ SecRule RESPONSE_BODY "@rx <title>\.:: .* ~ Ashiyane V [0-9.]+ ::\.</title>" \
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
-    severity:'ERROR',\
+    severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -452,7 +452,7 @@ SecRule RESPONSE_BODY "@contains <font color=lime>./rusuh</font>" \
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
-    severity:'ERROR',\
+    severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -475,7 +475,7 @@ SecRule RESPONSE_BODY "@contains Safe0ver Shell //Safe Mod Bypass  Safe0ver Shel
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
-    severity:'ERROR',\
+    severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -498,7 +498,7 @@ SecRule RESPONSE_BODY "@rx <title>Symlink_Sa [0-9.]+</title>" \
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
-    severity:'ERROR',\
+    severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -521,7 +521,7 @@ SecRule RESPONSE_BODY "@contains <title>SyRiAn Sh3ll ~ " \
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
-    severity:'ERROR',\
+    severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -544,7 +544,7 @@ SecRule RESPONSE_BODY "@contains <h1 style=\"margin-bottom: 0\">webadmin.php</h1
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
-    severity:'ERROR',\
+    severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -567,7 +567,7 @@ SecRule RESPONSE_BODY "@contains <b>--[ x2300 Locus7Shell v. " \
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
-    severity:'ERROR',\
+    severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 

--- a/rules/RESPONSE-955-WEB-SHELLS.conf
+++ b/rules/RESPONSE-955-WEB-SHELLS.conf
@@ -1,0 +1,603 @@
+# ------------------------------------------------------------------------
+# OWASP ModSecurity Core Rule Set ver.3.3.0
+# Copyright (c) 2006-2020 Trustwave and contributors. (not) All rights reserved.
+#
+# The OWASP ModSecurity Core Rule Set is distributed under
+# Apache Software License (ASL) version 2
+# Please see the enclosed LICENSE file for full details.
+# ------------------------------------------------------------------------
+
+#
+# -= Paranoia Level 0 (empty) =- (apply unconditionally)
+#
+
+
+
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:955011,phase:3,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:955012,phase:4,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
+#
+# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+#
+
+# r57 web shell
+SecRule RESPONSE_BODY "@rx (<title>r57 Shell Version [0-9.]+</title>|<title>r57 shell</title>)" \
+    "id:955100,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'r57 web shell',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-iis',\
+    tag:'platform-windows',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+
+# WSO web shell
+SecRule RESPONSE_BODY "@rx <title>.*? - WSO [0-9.]+</title>" \
+    "id:955110,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'WSO web shell',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-iis',\
+    tag:'platform-windows',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+
+# b4tm4n web shell (https://github.com/k4mpr3t/b4tm4n)
+SecRule RESPONSE_BODY "@rx B4TM4N SH3LL</title>.*<meta name='author' content='k4mpr3t'/>" \
+    "id:955120,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'b4tm4n web shell',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-iis',\
+    tag:'platform-windows',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+
+# Mini Shell web shell
+SecRule RESPONSE_BODY "@rx <title>Mini Shell</title>.*Developed By LameHacker" \
+    "id:955130,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'Mini Shell web shell',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-iis',\
+    tag:'platform-windows',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+
+# Loader'z web shell
+SecRule RESPONSE_BODY "@contains <title>Loader'z WEB shell</title>" \
+    "id:955150,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'Loader\'z web shell',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-iis',\
+    tag:'platform-windows',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+
+# Con7ext Shell V.2 web shell
+SecRule RESPONSE_BODY "@contains <title>Con7ext Shell V.2</title>" \
+    "id:955160,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'Con7ext Shell V.2 web shell',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-iis',\
+    tag:'platform-windows',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+
+# Yourman.sh Mini Shell web shell
+SecRule RESPONSE_BODY "@contains <title>Yourman.sh Mini Shell</title>" \
+    "id:955170,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'Yourman.sh Mini Shell web shell',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-iis',\
+    tag:'platform-windows',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+
+# Zerostore web shell
+SecRule RESPONSE_BODY "@contains <title>ZEROSHELL | ZEROSTORE</title>" \
+    "id:955180,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'Zerostore web shell',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-iis',\
+    tag:'platform-windows',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+
+# Ustadcage48 Filemanager
+SecRule RESPONSE_BODY "@contains <font color=\"red\">USTADCAGE_48</font> <font color=\"dodgerblue\">FILE MANAGER</font>" \
+    "id:955190,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'Ustadcage48 Filemanager',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-iis',\
+    tag:'platform-windows',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+
+# Zero Byte Mini Shell V2 web shell
+SecRule RESPONSE_BODY "@contains <title>0byt3m1n1-V2</title>" \
+    "id:955200,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'Zero Byte Mini Shell V2 web shell',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-iis',\
+    tag:'platform-windows',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+
+# B374k web shell
+SecRule RESPONSE_BODY "@contains <link rel='SHORTCUT ICON' href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMy1jMDExIDY2LjE0NTY2MSwgMjAxMi8wMi8wNi0xNDo1NjoyNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoV2luZG93cykiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6MkRFNDY2MDQ4MDgyMTFFM0FDRDdBN0MzOTAxNzZFQUYiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6MkRFNDY2MDU4MDgyMTFFM0FDRDdBN0MzOTAxNzZFQUYiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDoyREU0NjYwMjgwODIxMUUzQUNEN0E3QzM5MDE3NkVBRiIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDoyREU0NjYwMzgwODIxMUUzQUNEN0E3QzM5MDE3NkVBRiIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pu6UWJYAAAKySURBVHjafFNdSJNhFH7e/fhDkrm2i03QphsxhYSgMIUgIeiiK6/SCAKTKNlFoEtBRfEvXYhM+0GQMtMUL7qSgqS0QCNKTDS6cJWGi6n577Zv3/e+b+934ZgxPfDBd3jP85xznnOOzufz4SCr7R7knKOg4eaVd9WPBgsZY/3NZcWJ0TGaaKeuZzgz2ueMgFF+p6WnL0OAjzMK+f8k+wg4xXxN91D5ns8ok8CRH5S2GogS8HBKk1xud+uBBIwpm5zyRvW/+sHAJuM8nsrMIElHi0/aHAmFl/OI2WRyOevrK/YwJFoD0ecFkfWthpDNRH1Cct4ZOzRaglX/DsY+TcNqTUd2phEjo1OiWg5KKUhJTbua6XTT7SKvSlLpGWB6DUjuWQeW/m4iJIWho8DvBT+2tgOwpZsxM/tm/sn9Trsar2OMq6rOV3X19wncJUNSEsnKSsWifx0BKYTgdhDxiENBfjZCuxJejX0W4frZiAZNZUVxVKYfmcyuKTI15ZxKw4IA74aCCIiMeqZDptWIuV8+hAkXOlFo9eaLNyrvOfdp4Gp/FjKlpMSbLMlY2dhCaCcEnUJgt5sF4QqkkIKsDAtGXn9QSThlMmFCg8gUmELpkXg99FoNwgEJ2jBBWpoBP/8sC7AMi/EY/EvLUBQJCpOMT921hDG5JkIglPd8/7EIFpShCQMnrAYsrW0gLERUwTNfv2FyaloddWmvu25NxTzvaG6MELRVXK/SgL8fHZ9AjsMCKUzFqBhSjQZAkrC6viqyy+ILdxU775bH3APVblW3j3POzuc4bGIHNPgyM4dAcFdtslT07OWcvhRVJIvVtg0/9nhJrGMqqWzpFb1eFYuiVfdbACcGOlvzYx0cOewaVStyuiY5U3JFVbahhx3eQ48plr3obDtHqSxTRZ6K9f5PgAEAm/hvADIkGOQAAAAASUVORK5CYII='>" \
+    "id:955210,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'B374k web shell',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-iis',\
+    tag:'platform-windows',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+
+# Ani-Shell web shell (http://ani-shell.sourceforge.net/)
+SecRule RESPONSE_BODY "@contains <title>Ani-Shell | India</title>" \
+    "id:955220,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'Ani-Shell web shell',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-iis',\
+    tag:'platform-windows',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+
+# IndoXploit web shell
+SecRule RESPONSE_BODY "@contains <title>IndoXploit</title>" \
+    "id:955230,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'IndoXploit web shell',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-iis',\
+    tag:'platform-windows',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+
+# Dive Shell web shell
+SecRule RESPONSE_BODY "@contains <title>Dive Shell - Emperor Hacking Team</title>" \
+    "id:955240,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'Dive Shell web shell',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-iis',\
+    tag:'platform-windows',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+
+# 1n73ction web shell
+SecRule RESPONSE_BODY "@contains <title>=[ 1n73ct10n privat shell ]=</title>" \
+    "id:955250,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'1n73ction web shell',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-iis',\
+    tag:'platform-windows',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+
+# C99Shell web shell
+SecRule RESPONSE_BODY "@contains <font face=Webdings size=6><b>!</b></font>" \
+    "id:955260,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'C99Shell web shell',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-iis',\
+    tag:'platform-windows',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+
+# ALFA-SHELL web shell (https://github.com/solevisible)
+SecRule RESPONSE_BODY "@contains ~ ALFA TEaM Shell -" \
+    "id:955270,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'ALFA-SHELL web shell',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-iis',\
+    tag:'platform-windows',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+
+# Ashiyane web shell
+SecRule RESPONSE_BODY "@rx <title>\.:: .* ~ Ashiyane V [0-9.]+ ::\.</title>" \
+    "id:955280,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'Ashiyane web shell',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-iis',\
+    tag:'platform-windows',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+
+# rusuh web shell
+SecRule RESPONSE_BODY "@contains <font color=lime>./rusuh</font>" \
+    "id:955290,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'rusuh web shell',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-iis',\
+    tag:'platform-windows',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+
+# Safe0ver web shell
+SecRule RESPONSE_BODY "@contains Safe0ver Shell //Safe Mod Bypass  Safe0ver Shell" \
+    "id:955300,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'Safe0ver web shell',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-iis',\
+    tag:'platform-windows',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+
+# Symlink_Sa web shell
+SecRule RESPONSE_BODY "@rx <title>Symlink_Sa [0-9.]+</title>" \
+    "id:955310,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'Symlink_Sa web shell',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-iis',\
+    tag:'platform-windows',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+
+# SyRiAn Sh3ll web shell
+SecRule RESPONSE_BODY "@contains <title>SyRiAn Sh3ll ~ " \
+    "id:955320,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'SyRiAn Sh3ll web shell',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-iis',\
+    tag:'platform-windows',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+
+# webadmin.php file manager
+SecRule RESPONSE_BODY "@contains <h1 style=\"margin-bottom: 0\">webadmin.php</h1>" \
+    "id:955330,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'webadmin.php file manager',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-iis',\
+    tag:'platform-windows',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+
+# Locus7Shell web shell
+SecRule RESPONSE_BODY "@contains <b>--[ x2300 Locus7Shell v. " \
+    "id:955340,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'Locus7Shell web shell',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-iis',\
+    tag:'platform-windows',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+
+
+
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:955013,phase:3,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:955014,phase:4,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
+#
+# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
+#
+
+
+
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:955015,phase:3,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:955016,phase:4,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
+#
+# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+#
+
+
+
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:955017,phase:3,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:955018,phase:4,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
+#
+# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+#
+
+
+
+#
+# -= Paranoia Levels Finished =-
+#
+SecMarker "END-RESPONSE-955-WEB-SHELLS"

--- a/rules/RESPONSE-955-WEB-SHELLS.conf
+++ b/rules/RESPONSE-955-WEB-SHELLS.conf
@@ -574,7 +574,7 @@ SecRule RESPONSE_BODY "@contains <h1 style=\"margin-bottom: 0\">webadmin.php</h1
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.outbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:955015,phase:3,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"

--- a/rules/RESPONSE-955-WEB-SHELLS.conf
+++ b/rules/RESPONSE-955-WEB-SHELLS.conf
@@ -334,14 +334,15 @@ SecRule RESPONSE_BODY "@contains <title>=[ 1n73ct10n privat shell ]=</title>" \
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
-# C99Shell web shell
+# C99Shell + N3tShell web shell
+# Shell is able to bypass detection using gzipped output.
 SecRule RESPONSE_BODY "@contains <font face=Webdings size=6><b>!</b></font>" \
     "id:955260,\
     phase:4,\
     block,\
     capture,\
     t:none,\
-    msg:'C99Shell web shell',\
+    msg:'C99Shell + N3tShell web shell',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'language-php',\
     tag:'platform-multi',\
@@ -398,6 +399,7 @@ SecRule RESPONSE_BODY "@rx <title>\.:: .* ~ Ashiyane V [0-9.]+ ::\.</title>" \
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # rusuh web shell
+# Shell is able to bypass detection using gzipped output.
 SecRule RESPONSE_BODY "@contains <font color=lime>./rusuh</font>" \
     "id:955290,\
     phase:4,\
@@ -482,6 +484,7 @@ SecRule RESPONSE_BODY "@contains <title>SyRiAn Sh3ll ~ " \
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Locus7Shell web shell
+# Shell is able to bypass detection using gzipped output.
 SecRule RESPONSE_BODY "@contains <b>--[ x2300 Locus7Shell v. " \
     "id:955330,\
     phase:4,\
@@ -489,6 +492,48 @@ SecRule RESPONSE_BODY "@contains <b>--[ x2300 Locus7Shell v. " \
     capture,\
     t:none,\
     msg:'Locus7Shell web shell',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/225/122/17/650',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'CRITICAL',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# IDBTEAM SHELLS file manager
+SecRule RESPONSE_BODY "@contains <H1><center>-=[+] IDBTEAM SHELLS " \
+    "id:955340,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'IDBTEAM SHELLS file manager',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/225/122/17/650',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'CRITICAL',\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# Small Shell file manager
+SecRule RESPONSE_BODY "@contains <title>Small Shell - Edited By KingDefacer</title>" \
+    "id:955350,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'Small Shell file manager',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'language-php',\
     tag:'platform-multi',\
@@ -513,7 +558,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:955014,phase:4,pass,nolog,skipAf
 # webadmin.php file manager
 # This is placed in PL2 because of too generic pattern.
 SecRule RESPONSE_BODY "@contains <h1 style=\"margin-bottom: 0\">webadmin.php</h1>" \
-    "id:955340,\
+    "id:955360,\
     phase:4,\
     block,\
     capture,\


### PR DESCRIPTION
Adding new type of response body blocking - various web shells. Currently supporting only PHP web shells as i'm not able to host ASP applications (found about 2 ASP web shells). First version is able to block 24 different PHP web shells.

Huge note: This will pevent displaying of web shells only for newbie attackers as it's based on patterns found in response data (which can be changed by modifing the application). Also, gzipping of response data will bypass blocking :( was not able to workaround this. It would be really usefull if modsecurity supports something like 'decompress' transformation function.

**Finally, some help needed: I'm lost with setting of various tags in rules, can anyone help? Current tags are invalid.**