### PR TITLE
Add support for sec-ch-ua and sec-ch-ua-mobile within Validate Bytes …

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1517,7 +1517,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteRange 38,44-46,48-58,61,65-90
 #
 # This is a stricter sibling of 920270.
 #
-SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!REQUEST_HEADERS:Cookie|!REQUEST_HEADERS:Sec-Fetch-User "@validateByteRange 32,34,38,42-59,61,65-90,95,97-122" \
+SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!REQUEST_HEADERS:Cookie|!REQUEST_HEADERS:Sec-Fetch-User|!REQUEST_HEADERS:sec-ch-ua|!REQUEST_HEADERS:sec-ch-ua-mobile "@validateByteRange 32,34,38,42-59,61,65-90,95,97-122" \
     "id:920274,\
     phase:1,\
     block,\


### PR DESCRIPTION
…rule

Chrome has decided to add new user agent headers, here we add support for ignoring them as we do similarly with the old user-agent header
https://www.chromestatus.com/feature/5995832180473856