### PR TITLE
Fixing FP in WordPress while updating or deleting a plugin

### DIFF
--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -781,6 +781,28 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/site-health.php" \
     ver:'OWASP_CRS/3.3.0'"
 
 
+#
+# [ Plugins management ]
+#
+
+# Deleting a plugin
+SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
+    "id:9002950,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.3.0',\
+    chain"
+    SecRule ARGS:action "@streq delete-plugin" \
+        "t:none,\
+        chain"
+        SecRule &ARGS:action "@eq 1" \
+            "t:none,\
+            ctl:ruleRemoveTargetById=932120;ARGS:plugin,\
+            ctl:ruleRemoveTargetById=932120;ARGS:slug"
+
+
 SecMarker "END-WORDPRESS-ADMIN"
 
 

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -785,7 +785,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/site-health.php" \
 # [ Plugins management ]
 #
 
-# Deleting a plugin
+# Updating or deleting a plugin
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
     "id:9002950,\
     phase:2,\
@@ -794,7 +794,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
     nolog,\
     ver:'OWASP_CRS/3.3.0',\
     chain"
-    SecRule ARGS:action "@streq delete-plugin" \
+    SecRule ARGS:action "@rx ^(?:update-plugin|delete-plugin)$" \
         "t:none,\
         chain"
         SecRule &ARGS:action "@eq 1" \


### PR DESCRIPTION
Real-world example of FP (some of POST arguments):
```
plugin=easy-remove-item-menu/easy-remove-item-menu.php
slug=easy-remove-item-menu
action=update-plugin
```
```
plugin=easy-remove-item-menu/easy-remove-item-menu.php
slug=easy-remove-item-menu
action=delete-plugin
```