### PR TITLE
Nextcloud 20 false-positives

### DIFF
--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -598,6 +598,27 @@ SecRule REQUEST_FILENAME "@contains /config/apps/ransomware_protection/extension
     ctl:ruleRemoveTargetById=932130;ARGS:value,\
     ver:'OWASP_CRS/3.4.0'"
 
+# Extension: Text
+
+# Allow characters like /../ in files.
+# Allow all kind of filetypes.
+# Allow source code.
+SecRule REQUEST_FILENAME "@rx /(?:index\.php/)?apps/text/session/(?:sync|push)$" \
+    "id:9003910,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveById=920440,\
+    ctl:ruleRemoveById=920272,\
+    ctl:ruleRemoveById=930100-930110,\
+    ctl:ruleRemoveById=932000-932999,\
+    ctl:ruleRemoveById=933000-933999,\
+    ctl:ruleRemoveById=942000-942999,\
+    ctl:ruleRemoveById=951000-951999,\
+    ctl:ruleRemoveById=953100-953130,\
+    ver:'OWASP_CRS/3.4.0'"
+
 
 SecMarker "END-NEXTCLOUD-ADMIN"
 

--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -496,6 +496,19 @@ SecRule REQUEST_FILENAME "@contains /.well-known/carddav" \
     ver:'OWASP_CRS/3.4.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PROPFIND'"
 
+# Administration: Theming
+
+# Allow update stylesheet and images
+SecRule REQUEST_FILENAME "@rx /(?:index\.php/)?apps/theming/ajax/(?:updateStylesheet|uploadImage)" \
+    "id:9003611,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveById=920272,\
+    ctl:ruleRemoveTargetById=931130;ARGS:value,\
+    ver:'OWASP_CRS/3.4.0'"
+
 
 #
 # [ Notifications ]

--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -451,6 +451,18 @@ SecRule REQUEST_FILENAME "@rx /(?:index\.php/)?settings/users" \
 #
 # This removes checks on multiple settings pages
 
+# Personal: Personal info
+
+# Fix websites with trailing slash
+SecRule REQUEST_FILENAME "@rx /(?:index\.php/)?settings/users/[0-9a-zA-Z-_.@]+/settings$" \
+    "id:9003600,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetById=931130;ARGS:json.website,\
+    ver:'OWASP_CRS/3.4.0'"
+
 # Personal: Security
 
 # Fixes deletion of auth tokens

--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -167,6 +167,16 @@ SecRule REQUEST_METHOD "@streq REPORT" \
         "t:none,\
         ctl:ruleRemoveById=920340"
 
+# Allow outside of printable chars below ascii 127 for files
+SecRule REQUEST_FILENAME "@contains /remote.php/dav/" \
+    "id:9003122,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveById=920272,\
+    ver:'OWASP_CRS/3.4.0'"
+
 
 #
 # [ Searchengine ]

--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -553,6 +553,19 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/files_sharing/api/v1/shares
         "t:none,\
         ctl:ruleRemoveById=200002"
 
+# Allow search providers
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/search/providers" \
+    "id:9003801,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.4.0',\
+    chain"
+    SecRule REQUEST_METHOD "@streq GET" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=932190;ARGS:from"
+
 
 #
 # [ Users ]

--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -173,7 +173,7 @@ SecRule REQUEST_METHOD "@streq REPORT" \
 #
 
 # Nextcloud uses a search field for filename or content queries.
-SecRule REQUEST_FILENAME "@contains /index.php/core/search" \
+SecRule REQUEST_FILENAME "@rx /(?:index\.php)?/core/search" \
     "id:9003125,\
     phase:1,\
     pass,\
@@ -199,7 +199,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/core/search" \
 # Others in the code or js files: PATCH MKCOL MOVE TRACE
 # Others that I added just in case, and they seem related:
 #   CHECKOUT COPY LOCK MERGE MKACTIVITY UNLOCK.
-SecRule REQUEST_FILENAME "@rx /(?:remote|index|public)\.php/" \
+SecRule REQUEST_FILENAME "@rx /(?:remote\.php/|index\.php/|public\.php/)?" \
     "id:9003130,\
     phase:1,\
     pass,\
@@ -226,7 +226,7 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/files_sharing/" \
 #
 
 # Preview
-SecRule REQUEST_FILENAME "@contains /index.php/core/preview.png" \
+SecRule REQUEST_FILENAME "@rx /(?:index\.php/)?core/preview\.png" \
     "id:9003150,\
     phase:1,\
     pass,\
@@ -236,7 +236,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/core/preview.png" \
     ver:'OWASP_CRS/3.4.0'"
 
 # Filepreview for trashbin
-SecRule REQUEST_FILENAME "@contains /index.php/apps/files_trashbin/ajax/preview.php" \
+SecRule REQUEST_FILENAME "@rx /(?:index\.php/)?apps/files_trashbin/ajax/preview\.php" \
     "id:9003155,\
     phase:1,\
     pass,\
@@ -247,7 +247,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/files_trashbin/ajax/preview.
     ver:'OWASP_CRS/3.4.0'"
 
 # Thumbnails
-SecRule REQUEST_FILENAME "@contains /index.php/apps/gallery/thumbnails" \
+SecRule REQUEST_FILENAME "@rx /(?:index\.php/)?apps/gallery/thumbnails" \
     "id:9003160,\
     phase:1,\
     pass,\
@@ -261,7 +261,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/gallery/thumbnails" \
 # [ Ownnote ]
 #
 
-SecRule REQUEST_FILENAME "@contains /index.php/apps/ownnote/" \
+SecRule REQUEST_FILENAME "@rx /(?:index\.php/)?apps/ownnote/" \
     "id:9003300,\
     phase:1,\
     pass,\
@@ -276,7 +276,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/ownnote/" \
 #
 
 # This file can save anything, and it's name could be lots of things.
-SecRule REQUEST_FILENAME "@contains /index.php/apps/files_texteditor/" \
+SecRule REQUEST_FILENAME "@rx /(?:index\.php/)?apps/files_texteditor/" \
     "id:9003310,\
     phase:1,\
     pass,\
@@ -365,7 +365,7 @@ SecRule REQUEST_METHOD "@streq PROPFIND" \
 
 # We want to allow a lot of things as the user is
 # allowed to note on anything.
-SecRule REQUEST_FILENAME "@contains /index.php/apps/notes/" \
+SecRule REQUEST_FILENAME "@rx /(?:index\.php/)?apps/notes/" \
     "id:9003340,\
     phase:1,\
     pass,\
@@ -380,7 +380,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/notes/" \
 #
 
 # Allow urls in data.
-SecRule REQUEST_FILENAME "@contains /index.php/apps/bookmarks/" \
+SecRule REQUEST_FILENAME "@rx /(index\.php/)?apps/bookmarks/" \
     "id:9003350,\
     phase:1,\
     pass,\
@@ -396,7 +396,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/bookmarks/" \
 # This removes checks on the 'password' and related fields:
 
 # User login password.
-SecRule REQUEST_FILENAME "@contains /index.php/login" \
+SecRule REQUEST_FILENAME "@rx /(?:index\.php/)?login" \
     "id:9003400,\
     phase:1,\
     pass,\
@@ -407,7 +407,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/login" \
     ver:'OWASP_CRS/3.4.0'"
 
 # Reset password.
-SecRule REQUEST_FILENAME "@endsWith /index.php/login" \
+SecRule REQUEST_FILENAME "@rx /(?:index\.php/)?login$" \
     "id:9003410,\
     phase:2,\
     pass,\
@@ -425,7 +425,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/login" \
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass2"
 
 # Logout token
-SecRule REQUEST_FILENAME "@endsWith /index.php/logout" \
+SecRule REQUEST_FILENAME "@rx /(?:index\.php/)?logout$" \
     "id:9003420,\
     phase:1,\
     pass,\
@@ -435,7 +435,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/logout" \
     ver:'OWASP_CRS/3.4.0'"
 
 # Change Password and Setting up a new user/password
-SecRule REQUEST_FILENAME "@endsWith /index.php/settings/users" \
+SecRule REQUEST_FILENAME "@rx /(?:index\.php/)?settings/users" \
     "id:9003500,\
     phase:1,\
     pass,\

--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -619,6 +619,18 @@ SecRule REQUEST_FILENAME "@rx /(?:index\.php/)?apps/text/session/(?:sync|push)$"
     ctl:ruleRemoveById=953100-953130,\
     ver:'OWASP_CRS/3.4.0'"
 
+# Extension: PDF viewwer
+
+# Allow outside of printable chars below ascii 127 for files
+SecRule REQUEST_FILENAME "@rx /(?:index\.php/)?apps/files_pdfviewer/" \
+    "id:9003920,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveById=920272,\
+    ver:'OWASP_CRS/3.4.0'"
+
 
 SecMarker "END-NEXTCLOUD-ADMIN"
 

--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -444,6 +444,22 @@ SecRule REQUEST_FILENAME "@rx /(?:index\.php/)?logout$" \
     ctl:ruleRemoveTargetById=941120;ARGS:requesttoken,\
     ver:'OWASP_CRS/3.4.0'"
 
+# Login with FIDO U2F token
+SecRule REQUEST_FILENAME "@rx /(?:index\.php/)?login/challenge/(?:u2f|twofactor_webauthn)$" \
+    "id:9003430,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetById=942200;ARGS:challenge,\
+    ctl:ruleRemoveTargetById=942260;ARGS:challenge,\
+    ctl:ruleRemoveTargetById=942340;ARGS:challenge,\
+    ctl:ruleRemoveTargetById=942370;ARGS:challenge,\
+    ctl:ruleRemoveTargetById=942430;ARGS:challenge,\
+    ctl:ruleRemoveTargetById=942431;ARGS:challenge,\
+    ctl:ruleRemoveTargetById=942460;ARGS:challenge,\
+    ver:'OWASP_CRS/3.4.0'"
+
 # Change Password and Setting up a new user/password
 SecRule REQUEST_FILENAME "@rx /(?:index\.php/)?settings/users" \
     "id:9003500,\
@@ -629,6 +645,26 @@ SecRule REQUEST_FILENAME "@rx /(?:index\.php/)?apps/files_pdfviewer/" \
     t:none,\
     nolog,\
     ctl:ruleRemoveById=920272,\
+    ver:'OWASP_CRS/3.4.0'"
+
+# Extension: U2F and Webauthn
+
+# Allow registering FIDO U2F keys
+SecRule REQUEST_FILENAME "@rx /(?:index\.php/)?apps/twofactor_(?:u2f|webauthn)/settings/finishregister" \
+    "id:9003931,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetById=942200;ARGS:json.data,\
+    ctl:ruleRemoveTargetById=942260;ARGS:json.data,\
+    ctl:ruleRemoveTargetById=942340;ARGS:json.data,\
+    ctl:ruleRemoveTargetById=942370;ARGS:json.data,\
+    ctl:ruleRemoveTargetById=942430;ARGS:json.data,\
+    ctl:ruleRemoveTargetById=942431;ARGS:json.data,\
+    ctl:ruleRemoveTargetById=942431;ARGS:json.registrationData,\
+    ctl:ruleRemoveTargetById=942460;ARGS:json.data,\
+    ctl:ruleRemoveById=950100,\
     ver:'OWASP_CRS/3.4.0'"
 
 


### PR DESCRIPTION
With Nextcloud 20.0.4 there are multiple false-positives. This PR will fix some of the false-positives.

The following setup is used to reproduce the false-positives:
* Nginx v1.14.1
* ModSecurity v3.0.4
* CRS v3.3.0 with [nextcloud exclusion v.3.4](https://raw.githubusercontent.com/coreruleset/coreruleset/v3.4/dev/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf)
* Paranoia level setting 3
* Operating System: CentOS 8.3.2011
* Backend: Nextcloud 20.0.4 [Container](https://hub.docker.com/layers/nextcloud/library/nextcloud/20.0.4/images/sha256-57c791ec684d5e00c457c69de65633a00a4903ff523d2870f586069858e39853?context=explore)

Fixes:
* #1974
* #1973

Nextcloud Apps:
* PDF viewer (default)
* Theming (default)
* Text (default)
* User status (default)
* First run wizard (default)
* Two-Factor U2F
* Two-Factor Webauthn