### PR TITLE
Fix almost all FPs with rule 930120

### DIFF
--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -87,14 +87,16 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-lfi',\
-    tag:'paranoia-level/1',\
+    tag:'paranoia-level/%{tx.paranoia_level}',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/126',\
     tag:'PCI/6.5.4',\
     ver:'OWASP_CRS/3.3.0',\
+    setvar:'tx.paranoia_level=1',\
+    setvar:'tx.matched_patterns=%{tx.0}|!#%{tx.matched_patterns}',\
     severity:'CRITICAL',\
-    setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    chain"
+    SecRuleScript rule_930120.lua
 
 #
 # -=[ Restricted File Access ]=-

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -87,12 +87,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-lfi',\
-    tag:'paranoia-level/%{tx.paranoia_level}',\
+    tag:'paranoia-level/%{tx.rule_paranoia_level}',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/126',\
     tag:'PCI/6.5.4',\
     ver:'OWASP_CRS/3.3.0',\
-    setvar:'tx.paranoia_level=1',\
+    setvar:'tx.rule_paranoia_level=1',\
     setvar:'tx.matched_patterns=%{tx.0}|||%{tx.matched_patterns}',\
     severity:'CRITICAL',\
     chain"

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -87,7 +87,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-lfi',\
-    tag:'paranoia-level/%{tx.rule_paranoia_level}',\
+    tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/126',\
     tag:'PCI/6.5.4',\

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -93,7 +93,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'PCI/6.5.4',\
     ver:'OWASP_CRS/3.3.0',\
     setvar:'tx.paranoia_level=1',\
-    setvar:'tx.matched_patterns=%{tx.0}|!#%{tx.matched_patterns}',\
+    setvar:'tx.matched_patterns=%{tx.0}|||%{tx.matched_patterns}',\
     severity:'CRITICAL',\
     chain"
     SecRuleScript rule_930120.lua

--- a/rules/rule_930120.lua
+++ b/rules/rule_930120.lua
@@ -1,0 +1,51 @@
+require("m")
+
+function main()
+	local matched_vars = m.getvars("MATCHED_VARS", "none")
+	local rule_severity = tonumber(m.getvar("rule.severity", "none"))
+	local rule_severity_name = nil
+	local paranoia_level = tonumber(m.getvar("tx.paranoia_level", "none"))
+	local matched_patterns = m.getvar("tx.matched_patterns", "none")
+	local score = 0
+
+	if rule_severity == 2 then
+		rule_severity_name = "critical"
+	elseif rule_severity == 3 then
+		rule_severity_name = "error"
+	elseif rule_severity == 4 then
+		rule_severity_name = "warning"
+	elseif rule_severity == 5 then
+		rule_severity_name = "notice"
+	end
+
+	local patterns = {}
+	for p in matched_patterns:gmatch("(.-)|!#") do
+		table.insert(patterns, p)
+	end
+
+	for _, variable in pairs(matched_vars) do
+		local add_score = false
+		for _, pattern in pairs(patterns) do
+			if variable["value"] == pattern then
+				add_score = true
+			elseif string.find(variable["value"], string.format("^/%s", pattern)) then
+				add_score = true
+			elseif string.find(variable["value"], string.format("^%s/", pattern)) then
+				add_score = true
+			elseif string.find(variable["value"], string.format("/%s$", pattern)) then
+				add_score = true
+			end
+			if add_score then
+				m.log(2, string.format("Warning. Matched Data: %s found within %s: %s", pattern, variable["name"], variable["value"]))
+				score = score + tonumber(m.getvar(string.format("tx.%s_anomaly_score", rule_severity_name), "none"))
+				break
+			end
+		end
+	end
+	if score > 0 then
+		m.setvar("tx.lfi_score", tonumber(m.getvar("tx.lfi_score", "none")) + score)
+		m.setvar(string.format("tx.anomaly_score_pl%d", paranoia_level), tonumber(m.getvar(string.format("tx.anomaly_score_pl%d", paranoia_level), "none")) + score)
+		return "Matched at least one phrase, see previous messages."
+	end
+	return nil
+end

--- a/rules/rule_930120.lua
+++ b/rules/rule_930120.lua
@@ -19,7 +19,7 @@ function main()
 	end
 
 	local patterns = {}
-	for p in matched_patterns:gmatch("(.-)|!#") do
+	for p in matched_patterns:gmatch("(.-)|||") do
 		table.insert(patterns, p)
 	end
 

--- a/rules/rule_930120.lua
+++ b/rules/rule_930120.lua
@@ -34,6 +34,8 @@ function main()
 				add_score = true
 			elseif string.find(variable["value"], string.format("/%s$", pattern)) then
 				add_score = true
+			elseif string.find(variable["value"], string.format("%s\0", pattern)) then
+				add_score = true
 			end
 			if add_score then
 				m.log(2, string.format("Warning. Matched Data: %s found within %s: %s", pattern, variable["name"], variable["value"]))

--- a/rules/rule_930120.lua
+++ b/rules/rule_930120.lua
@@ -5,7 +5,7 @@ function main()
 	local rule_severity = tonumber(m.getvar("rule.severity", "none"))
 	local rule_severity_name = nil
 	local rule_id = m.getvar("rule.id", "none")
-	local paranoia_level = tonumber(m.getvar("tx.paranoia_level", "none"))
+	local rule_paranoia_level = tonumber(m.getvar("rule_paranoia_level", "none"))
 	local matched_patterns = m.getvar("tx.matched_patterns", "none")
 	local score = 0
 
@@ -47,7 +47,7 @@ function main()
 	end
 	if score > 0 then
 		m.setvar("tx.lfi_score", tonumber(m.getvar("tx.lfi_score", "none")) + score)
-		m.setvar(string.format("tx.anomaly_score_pl%d", paranoia_level), tonumber(m.getvar(string.format("tx.anomaly_score_pl%d", paranoia_level), "none")) + score)
+		m.setvar(string.format("tx.anomaly_score_pl%d", rule_paranoia_level), tonumber(m.getvar(string.format("tx.anomaly_score_pl%d", rule_paranoia_level), "none")) + score)
 		return "Matched at least one phrase, see previous messages."
 	end
 	return nil

--- a/rules/rule_930120.lua
+++ b/rules/rule_930120.lua
@@ -4,6 +4,7 @@ function main()
 	local matched_vars = m.getvars("MATCHED_VARS", "none")
 	local rule_severity = tonumber(m.getvar("rule.severity", "none"))
 	local rule_severity_name = nil
+	local rule_id = m.getvar("rule.id", "none")
 	local paranoia_level = tonumber(m.getvar("tx.paranoia_level", "none"))
 	local matched_patterns = m.getvar("tx.matched_patterns", "none")
 	local score = 0
@@ -38,7 +39,7 @@ function main()
 				add_score = true
 			end
 			if add_score then
-				m.log(2, string.format("Warning. Matched Data: %s found within %s: %s", pattern, variable["name"], variable["value"]))
+				m.log(2, string.format("Warning. Matched Data: %s found within %s: %s [id \"%s\"]", pattern, variable["name"], variable["value"], rule_id))
 				score = score + tonumber(m.getvar(string.format("tx.%s_anomaly_score", rule_severity_name), "none"))
 				break
 			end

--- a/rules/rule_930120.lua
+++ b/rules/rule_930120.lua
@@ -1,11 +1,10 @@
 require("m")
-
 function main()
 	local matched_vars = m.getvars("MATCHED_VARS", "none")
 	local rule_severity = tonumber(m.getvar("rule.severity", "none"))
 	local rule_severity_name = nil
 	local rule_id = m.getvar("rule.id", "none")
-	local rule_paranoia_level = tonumber(m.getvar("rule_paranoia_level", "none"))
+	local rule_paranoia_level = tonumber(m.getvar("tx.rule_paranoia_level", "none"))
 	local matched_patterns = m.getvar("tx.matched_patterns", "none")
 	local score = 0
 


### PR DESCRIPTION
This is an alternative and more generic fix for issue https://github.com/coreruleset/coreruleset/issues/1922 (original fix is in PR https://github.com/coreruleset/coreruleset/pull/1958). Also, it fixies lots of other FPs, for example issue https://github.com/coreruleset/coreruleset/issues/1864. Both issues are related to rule ID 930120.

This rule is using `@pmFromFile` to search for patterns from file `lfi-os-files.data` - it searches in, for example, whole `ARGS`. As `@pmFromFile` is matching anywhere in the input, this is doing lots of FPs. There is no point to match anywhere in the input as we want to match only strings which looks like file names. I identified 5 file name patterns which we are looking for (are there more?), string %{file} refers to values from `lfi-os-files.data`:
 - ^%{file}$ (exact match)
 - ^/%{file}
 - ^%{file}/
 - /%{file}$
 - %{file}\0 (based on @csanders-git regression tests, searching for NULL byte at the end of the file name, not sure if this rule should support this as NULL byte is already catched by rule 920270)

Everything other is NOT a file name and we don't want to match it. As this cannot be done with `@pmFromFile` itself, but using `@pmFromFile` is very fast and with excellent maintability (so it's good to keep it), i decided to use chained `SecRuleScript` to do the job. First, i'm gathering all matched patterns using `setvar:'tx.matched_patterns=%{tx.0}|||%{tx.matched_patterns}'` in the main rule (this needs to be done as `tx.0` contains only last matched pattern so other matches are not accessible to chained rules, `|||` is a delimiter, we can choose other). Then, in the chained rule, i'm running Lua script which is doing this:
 - first, it parses the `tx.matched_patterns` and saves matched patterns in the array
 - then, it loops throught `MATCHED_VARS` and searches if matches looks like file names
 - finally, it is adding score for the request based on previous step (so it ignores matches which don't looks like file names)

Other noticable features of this Lua script:
 - it is able to correctly choose how much score needs to be added based on rule severity (so script does not need to be updated if severity of the rule changes)
 - it is able to add score to right paranoia level (bud i had to create helper variable as Lua scripts have no access to rule tags)
 - it is able to do MUCH better and correct logs then `@pmFromFile` (in fact, currently generated logs are invalid)

Other things:
 - i suggest to remove `logdata` and do logging for this rule only from Lua script (as i said, current logs are invalid, i can explain way, but it's a little complicated and there's not place for it here)
 - as i stated above, i created a helper variable for setting paranoia level so it also created a new place where paranoia level needs to be set:
```
setvar:'tx.rule_paranoia_level=1',\
```
 - for the performace, i believe it won't be a big deal as Lua script is still running after `@pmFromFile` so it will run only when there's something suspicious, also, script will be run only once no matter how many matches were triggered by `@pmFromFile`