### PR TITLE
Removing %{MATCHED_VAR} from logging

### DIFF
--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -34,7 +34,7 @@ SecRule RESPONSE_BODY "@rx (?:<(?:TITLE>Index of.*?<H|title>Index of.*?<h)1>Inde
     capture,\
     t:none,\
     msg:'Directory Listing',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -68,7 +68,7 @@ SecRule RESPONSE_BODY "@rx ^#\!\s?/" \
     capture,\
     t:none,\
     msg:'CGI source code leakage',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -100,7 +100,7 @@ SecRule RESPONSE_STATUS "@rx ^5\d{2}$" \
     capture,\
     t:none,\
     msg:'The Application Returned a 500-Level Status Code',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -48,7 +48,7 @@ SecRule TX:sql_error_match "@eq 1" \
     capture,\
     t:none,\
     msg:'Microsoft Access SQL Information Leakage',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-msaccess',\
@@ -73,7 +73,7 @@ SecRule TX:sql_error_match "@eq 1" \
     capture,\
     t:none,\
     msg:'Oracle SQL Information Leakage',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-oracle',\
@@ -98,7 +98,7 @@ SecRule TX:sql_error_match "@eq 1" \
     capture,\
     t:none,\
     msg:'DB2 SQL Information Leakage',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-db2',\
@@ -123,7 +123,7 @@ SecRule TX:sql_error_match "@eq 1" \
     capture,\
     t:none,\
     msg:'EMC SQL Information Leakage',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-emc',\
@@ -148,7 +148,7 @@ SecRule TX:sql_error_match "@eq 1" \
     capture,\
     t:none,\
     msg:'firebird SQL Information Leakage',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-firebird',\
@@ -174,7 +174,7 @@ SecRule TX:sql_error_match "@eq 1" \
     capture,\
     t:none,\
     msg:'Frontbase SQL Information Leakage',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-frontbase',\
@@ -199,7 +199,7 @@ SecRule TX:sql_error_match "@eq 1" \
     capture,\
     t:none,\
     msg:'hsqldb SQL Information Leakage',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-hsqldb',\
@@ -224,7 +224,7 @@ SecRule TX:sql_error_match "@eq 1" \
     capture,\
     t:none,\
     msg:'informix SQL Information Leakage',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-informix',\
@@ -250,7 +250,7 @@ SecRule TX:sql_error_match "@eq 1" \
     capture,\
     t:none,\
     msg:'ingres SQL Information Leakage',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-ingres',\
@@ -276,7 +276,7 @@ SecRule TX:sql_error_match "@eq 1" \
     capture,\
     t:none,\
     msg:'interbase SQL Information Leakage',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-interbase',\
@@ -301,7 +301,7 @@ SecRule TX:sql_error_match "@eq 1" \
     capture,\
     t:none,\
     msg:'maxDB SQL Information Leakage',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-maxdb',\
@@ -326,7 +326,7 @@ SecRule TX:sql_error_match "@eq 1" \
     capture,\
     t:none,\
     msg:'mssql SQL Information Leakage',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-mssql',\
@@ -351,7 +351,7 @@ SecRule TX:sql_error_match "@eq 1" \
     capture,\
     t:none,\
     msg:'mysql SQL Information Leakage',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-mysql',\
@@ -376,7 +376,7 @@ SecRule TX:sql_error_match "@eq 1" \
     capture,\
     t:none,\
     msg:'postgres SQL Information Leakage',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-pgsql',\
@@ -401,7 +401,7 @@ SecRule TX:sql_error_match "@eq 1" \
     capture,\
     t:none,\
     msg:'sqlite SQL Information Leakage',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-sqlite',\
@@ -426,7 +426,7 @@ SecRule TX:sql_error_match "@eq 1" \
     capture,\
     t:none,\
     msg:'Sybase SQL Information Leakage',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-sybase',\

--- a/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
+++ b/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
@@ -29,7 +29,7 @@ SecRule RESPONSE_BODY "@pmFromFile java-code-leakages.data" \
     capture,\
     t:none,\
     msg:'Java Source Code Leakage',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-java',\
     tag:'platform-multi',\
@@ -56,7 +56,7 @@ SecRule RESPONSE_BODY "@pmFromFile java-errors.data" \
     capture,\
     t:none,\
     msg:'Java Errors',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-java',\
     tag:'platform-multi',\

--- a/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -29,7 +29,7 @@ SecRule RESPONSE_BODY "@pmFromFile php-errors.data" \
     capture,\
     t:none,\
     msg:'PHP Information Leakage',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-php',\
     tag:'platform-multi',\
@@ -56,7 +56,7 @@ SecRule RESPONSE_BODY "@rx (?:\b(?:f(?:tp_(?:nb_)?f?(?:ge|pu)t|get(?:s?s|c)|scan
     capture,\
     t:none,\
     msg:'PHP source code leakage',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-php',\
     tag:'platform-multi',\
@@ -87,7 +87,7 @@ SecRule RESPONSE_BODY "@rx <\?(?!xml)" \
     capture,\
     t:none,\
     msg:'PHP source code leakage',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-php',\
     tag:'platform-multi',\

--- a/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+++ b/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
@@ -27,7 +27,7 @@ SecRule RESPONSE_BODY "@rx [a-z]:\\\\inetpub\b" \
     capture,\
     t:none,t:lowercase,\
     msg:'Disclosure of IIS install location',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-iis',\
@@ -49,7 +49,7 @@ SecRule RESPONSE_BODY "@rx (?:Microsoft OLE DB Provider for SQL Server(?:</font>
     capture,\
     t:none,\
     msg:'Application Availability Error',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-iis',\
@@ -75,7 +75,7 @@ SecRule RESPONSE_BODY "@rx (?:\b(?:A(?:DODB\.Command\b.{0,100}?\b(?:Application 
     capture,\
     t:none,\
     msg:'IIS Information Leakage',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-iis',\
@@ -99,7 +99,7 @@ SecRule RESPONSE_STATUS "!@rx ^404$" \
     capture,\
     t:none,\
     msg:'IIS Information Leakage',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-iis',\

--- a/rules/RESPONSE-955-WEB-SHELLS.conf
+++ b/rules/RESPONSE-955-WEB-SHELLS.conf
@@ -27,7 +27,7 @@ SecRule RESPONSE_BODY "@rx (<title>r57 Shell Version [0-9.]+</title>|<title>r57 
     capture,\
     t:none,\
     msg:'r57 web shell',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -48,7 +48,7 @@ SecRule RESPONSE_BODY "@rx <title>.*? - WSO [0-9.]+</title>" \
     capture,\
     t:none,\
     msg:'WSO web shell',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -69,7 +69,7 @@ SecRule RESPONSE_BODY "@rx B4TM4N SH3LL</title>.*<meta name='author' content='k4
     capture,\
     t:none,\
     msg:'b4tm4n web shell',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -90,7 +90,7 @@ SecRule RESPONSE_BODY "@rx <title>Mini Shell</title>.*Developed By LameHacker" \
     capture,\
     t:none,\
     msg:'Mini Shell web shell',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -111,7 +111,7 @@ SecRule RESPONSE_BODY "@contains <title>Loader'z WEB shell</title>" \
     capture,\
     t:none,\
     msg:'Loader\'z web shell',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -132,7 +132,7 @@ SecRule RESPONSE_BODY "@contains <title>Con7ext Shell V.2</title>" \
     capture,\
     t:none,\
     msg:'Con7ext Shell V.2 web shell',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -153,7 +153,7 @@ SecRule RESPONSE_BODY "@contains <title>Yourman.sh Mini Shell</title>" \
     capture,\
     t:none,\
     msg:'Yourman.sh Mini Shell web shell',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -174,7 +174,7 @@ SecRule RESPONSE_BODY "@contains <title>ZEROSHELL | ZEROSTORE</title>" \
     capture,\
     t:none,\
     msg:'Zerostore web shell',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -195,7 +195,7 @@ SecRule RESPONSE_BODY "@contains <font color=\"red\">USTADCAGE_48</font> <font c
     capture,\
     t:none,\
     msg:'Ustadcage48 Filemanager',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -216,7 +216,7 @@ SecRule RESPONSE_BODY "@contains <title>0byt3m1n1-V2</title>" \
     capture,\
     t:none,\
     msg:'Zero Byte Mini Shell V2 web shell',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -237,7 +237,7 @@ SecRule RESPONSE_BODY "@contains <link rel='SHORTCUT ICON' href='data:image/png;
     capture,\
     t:none,\
     msg:'B374k web shell',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -258,7 +258,7 @@ SecRule RESPONSE_BODY "@contains <title>Ani-Shell | India</title>" \
     capture,\
     t:none,\
     msg:'Ani-Shell web shell',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -279,7 +279,7 @@ SecRule RESPONSE_BODY "@contains <title>IndoXploit</title>" \
     capture,\
     t:none,\
     msg:'IndoXploit web shell',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -300,7 +300,7 @@ SecRule RESPONSE_BODY "@contains <title>Dive Shell - Emperor Hacking Team</title
     capture,\
     t:none,\
     msg:'Dive Shell web shell',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -321,7 +321,7 @@ SecRule RESPONSE_BODY "@contains <title>=[ 1n73ct10n privat shell ]=</title>" \
     capture,\
     t:none,\
     msg:'1n73ction web shell',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -343,7 +343,7 @@ SecRule RESPONSE_BODY "@contains <font face=Webdings size=6><b>!</b></font>" \
     capture,\
     t:none,\
     msg:'C99Shell + N3tShell web shell',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -364,7 +364,7 @@ SecRule RESPONSE_BODY "@contains ~ ALFA TEaM Shell -" \
     capture,\
     t:none,\
     msg:'ALFA-SHELL web shell',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -385,7 +385,7 @@ SecRule RESPONSE_BODY "@rx <title>\.:: .* ~ Ashiyane V [0-9.]+ ::\.</title>" \
     capture,\
     t:none,\
     msg:'Ashiyane web shell',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -407,7 +407,7 @@ SecRule RESPONSE_BODY "@contains <font color=lime>./rusuh</font>" \
     capture,\
     t:none,\
     msg:'rusuh web shell',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -428,7 +428,7 @@ SecRule RESPONSE_BODY "@contains Safe0ver Shell //Safe Mod Bypass  Safe0ver Shel
     capture,\
     t:none,\
     msg:'Safe0ver web shell',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -449,7 +449,7 @@ SecRule RESPONSE_BODY "@rx <title>Symlink_Sa [0-9.]+</title>" \
     capture,\
     t:none,\
     msg:'Symlink_Sa web shell',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -470,7 +470,7 @@ SecRule RESPONSE_BODY "@contains <title>SyRiAn Sh3ll ~ " \
     capture,\
     t:none,\
     msg:'SyRiAn Sh3ll web shell',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -492,7 +492,7 @@ SecRule RESPONSE_BODY "@contains <b>--[ x2300 Locus7Shell v. " \
     capture,\
     t:none,\
     msg:'Locus7Shell web shell',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -513,7 +513,7 @@ SecRule RESPONSE_BODY "@contains <H1><center>-=[+] IDBTEAM SHELLS " \
     capture,\
     t:none,\
     msg:'IDBTEAM SHELLS file manager',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -534,7 +534,7 @@ SecRule RESPONSE_BODY "@contains <title>Small Shell - Edited By KingDefacer</tit
     capture,\
     t:none,\
     msg:'Small Shell file manager',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\
@@ -564,7 +564,7 @@ SecRule RESPONSE_BODY "@contains <h1 style=\"margin-bottom: 0\">webadmin.php</h1
     capture,\
     t:none,\
     msg:'webadmin.php file manager',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-rce',\


### PR DESCRIPTION
As suggested by @theMiddleBlue, logging whole RESPONSE_BODY isn't a good idea.