### PR TITLE
Introducing generic transformations

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -333,10 +333,10 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # to enable early blocking. The variable tx.blocking_early is set to 0 by
 # default. Early blocking is thus disabled by default.
 #
-# Please note that blocking early will hide potential alerts from you. This 
+# Please note that blocking early will hide potential alerts from you. This
 # means that a payload that would appear in an alert in phase 2 (or phase 4)
-# does not get evaluated if the request is being blocked early. So when you 
-# disabled blocking early again at some point in the future, then new alerts 
+# does not get evaluated if the request is being blocked early. So when you
+# disabled blocking early again at some point in the future, then new alerts
 # from phase 2 might pop up.
 #SecAction \
 #  "id:900120,\
@@ -577,6 +577,69 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  pass,\
 #  t:none,\
 #  setvar:tx.combined_file_sizes=1048576"
+
+
+#
+# -- [[ Generic Transformations of ARGS ]] ------------------------------------------------
+#
+# Generic transformations are a way to catch malicious payloads that have
+# been encoded to bypass the WAF or simply because the backend is known to
+# decode them before handling. This works by decoding the individual payloads
+# of a request with built-in transformation functions in the WAF engine.
+#
+# ModSecurity knows several transformations and the CRS generic transformations
+# feature makes use of these by transforming / decoding every ARGS with
+# the full series of transformations. If the transforming / decoding changed
+# the payload (a hint that it was actually encoded), then (and only then),
+# the transformed / decoded parameter is examined by CRS.
+#
+# E.g.: A transformation is the base64 decoding of a parameter:
+#
+# The base64 string "c3lzdGVtKCdiYXNoJyk=" decodes to "system('bash')".
+#
+# "63336c7a644756744b43646959584e6f4a796b3d" is a double encoded string.
+# It is a hex-encoded version of the aforementioned "c3lzdGVtKCdiYXNoJyk=".
+#
+# So a double decoding (hexDecode + base64Decode) will result in
+# "system('bash')" again.
+#
+# Simple generic transformations happen at paranoia level 3.
+# Double generic transformations happen at paranoia level 4.
+#
+# Generic transformations mean a severe performance impact and should be
+# enabled with caution. The aforementioned base64 encoded parameter will
+# will expand to 1 + 3 parameters (original parameter plus three decoded
+# parameters). The same parameter at PL4 will bring a whopping
+# 1 + 66 parameters. The double encoded parameter will bring 1 + 2
+# parameters at PL3 (but no alert since it's still encoded) and 1 + 44
+# parameters at PL4.
+#
+# Generic transformations are off by default. They were introduced as a
+# new and somewhat experimental feature in CRS 3.4.
+#
+# There are 3 configuration items that need to be set / assured before
+# generic transformations will start the detection.
+#
+# - Enable tx.generic_transformations by enabling rule 900360 in
+#   crs-setup.conf. This will enable the creation of the transformed
+#   parameters in the rules in REQUEST-904-GENERIC-TRANSFORMATIONS.conf.
+# - Add the generic transformations to the target list of those rules that
+#   inspect ARGS by copying / renaming the file
+#   RESPONSE-998-ENABLE-GENERIC-TRANSFORMATIONS.conf.example
+#   to
+#   RESPONSE-998-ENABLE-GENERIC-TRANSFORMATIONS.conf.
+# - Set paranoia level to 3 (or 4).
+#
+# See the file REQUEST-904-GENERIC-TRANSFORMATIONS.conf for a detailed
+# explanation of the mechanics of the decoding process.
+#
+#SecAction \
+# "id:900360,\
+#  phase:1,\
+#  nolog,\
+#  pass,\
+#  t:none,\
+#  setvar:tx.generic_transformations=1"
 
 
 #

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -247,6 +247,16 @@ SecRule &TX:enforce_bodyproc_urlencoded "@eq 0" \
     ver:'OWASP_CRS/3.3.0',\
     setvar:'tx.enforce_bodyproc_urlencoded=0'"
 
+# Default generic_transformations
+SecRule &TX:generic_transformations "@eq 0" \
+    "id:901169,\
+    phase:1,\
+    pass,\
+    nolog,\
+    ver:'OWASP_CRS/3.3.0',\
+    setvar:'tx.generic_transformations=0'"
+
+
 #
 # -=[ Initialize internal variables ]=-
 #

--- a/rules/REQUEST-904-GENERIC-TRANSFORMATIONS.conf
+++ b/rules/REQUEST-904-GENERIC-TRANSFORMATIONS.conf
@@ -88,7 +88,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:904016,phase:2,pass,nolog,skipAf
 #
 
 
-# decode: transform: base64DecodeExt
+# Transformation: base64DecodeExt
 SecRule ARGS "!@streq %{ARGS}" \
     "id:904100,\
     phase:2,\
@@ -97,7 +97,7 @@ SecRule ARGS "!@streq %{ARGS}" \
     nolog,\
     setvar:'tx.tf_1_base64DecodeExt_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: cmdLine
+# Transformation: cmdLine
 SecRule ARGS "!@streq %{ARGS}" \
     "id:904110,\
     phase:2,\
@@ -106,7 +106,7 @@ SecRule ARGS "!@streq %{ARGS}" \
     nolog,\
     setvar:'tx.tf_1_cmdLine_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: compressWhitespace
+# Transformation: compressWhitespace
 SecRule ARGS "!@streq %{ARGS}" \
     "id:904120,\
     phase:2,\
@@ -115,7 +115,7 @@ SecRule ARGS "!@streq %{ARGS}" \
     nolog,\
     setvar:'tx.tf_1_compressWhitespace_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: cssDecode
+# Transformation: cssDecode
 SecRule ARGS "!@streq %{ARGS}" \
     "id:904130,\
     phase:2,\
@@ -124,7 +124,7 @@ SecRule ARGS "!@streq %{ARGS}" \
     nolog,\
     setvar:'tx.tf_1_cssDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: escapeSeqDecode
+# Transformation: escapeSeqDecode
 SecRule ARGS "!@streq %{ARGS}" \
     "id:904140,\
     phase:2,\
@@ -133,7 +133,7 @@ SecRule ARGS "!@streq %{ARGS}" \
     nolog,\
     setvar:'tx.tf_1_escapeSeqDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: hexDecode
+# Transformation: hexDecode
 SecRule ARGS "!@streq %{ARGS}" \
     "id:904150,\
     phase:2,\
@@ -142,7 +142,7 @@ SecRule ARGS "!@streq %{ARGS}" \
     nolog,\
     setvar:'tx.tf_1_hexDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: htmlEntityDecode
+# Transformation: htmlEntityDecode
 SecRule ARGS "!@streq %{ARGS}" \
     "id:904160,\
     phase:2,\
@@ -151,7 +151,7 @@ SecRule ARGS "!@streq %{ARGS}" \
     nolog,\
     setvar:'tx.tf_1_htmlEntityDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: jsDecode
+# Transformation: jsDecode
 SecRule ARGS "!@streq %{ARGS}" \
     "id:904170,\
     phase:2,\
@@ -160,7 +160,7 @@ SecRule ARGS "!@streq %{ARGS}" \
     nolog,\
     setvar:'tx.tf_1_jsDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: normalizePath
+# Transformation: normalizePath
 SecRule ARGS "!@streq %{ARGS}" \
     "id:904180,\
     phase:2,\
@@ -169,7 +169,7 @@ SecRule ARGS "!@streq %{ARGS}" \
     nolog,\
     setvar:'tx.tf_1_normalizePath_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: normalizePathWin
+# Transformation: normalizePathWin
 SecRule ARGS "!@streq %{ARGS}" \
     "id:904190,\
     phase:2,\
@@ -178,7 +178,7 @@ SecRule ARGS "!@streq %{ARGS}" \
     nolog,\
     setvar:'tx.tf_1_normalizePathWin_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: removeComments
+# Transformation: removeComments
 SecRule ARGS "!@streq %{ARGS}" \
     "id:904200,\
     phase:2,\
@@ -187,7 +187,7 @@ SecRule ARGS "!@streq %{ARGS}" \
     nolog,\
     setvar:'tx.tf_1_removeComments_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: removeCommentsChar
+# Transformation: removeCommentsChar
 SecRule ARGS "!@streq %{ARGS}" \
     "id:904210,\
     phase:2,\
@@ -196,7 +196,7 @@ SecRule ARGS "!@streq %{ARGS}" \
     nolog,\
     setvar:'tx.tf_1_removeCommentsChar_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: removeNulls
+# Transformation: removeNulls
 SecRule ARGS "!@streq %{ARGS}" \
     "id:904220,\
     phase:2,\
@@ -205,7 +205,7 @@ SecRule ARGS "!@streq %{ARGS}" \
     nolog,\
     setvar:'tx.tf_1_removeNulls_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: removeWhitespace
+# Transformation: removeWhitespace
 SecRule ARGS "!@streq %{ARGS}" \
     "id:904230,\
     phase:2,\
@@ -214,7 +214,7 @@ SecRule ARGS "!@streq %{ARGS}" \
     nolog,\
     setvar:'tx.tf_1_removeWhitespace_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: replaceComments
+# Transformation: replaceComments
 SecRule ARGS "!@streq %{ARGS}" \
     "id:904240,\
     phase:2,\
@@ -223,7 +223,7 @@ SecRule ARGS "!@streq %{ARGS}" \
     nolog,\
     setvar:'tx.tf_1_replaceComments_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: replaceNulls
+# Transformation: replaceNulls
 SecRule ARGS "!@streq %{ARGS}" \
     "id:904250,\
     phase:2,\
@@ -232,7 +232,7 @@ SecRule ARGS "!@streq %{ARGS}" \
     nolog,\
     setvar:'tx.tf_1_replaceNulls_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: sqlHexDecode
+# Transformation: sqlHexDecode
 SecRule ARGS "!@streq %{ARGS}" \
     "id:904260,\
     phase:2,\
@@ -241,7 +241,7 @@ SecRule ARGS "!@streq %{ARGS}" \
     nolog,\
     setvar:'tx.tf_1_sqlHexDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: trim
+# Transformation: trim
 SecRule ARGS "!@streq %{ARGS}" \
     "id:904270,\
     phase:2,\
@@ -250,7 +250,7 @@ SecRule ARGS "!@streq %{ARGS}" \
     nolog,\
     setvar:'tx.tf_1_trim_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: urlDecode
+# Transformation: urlDecode
 SecRule ARGS "!@streq %{ARGS}" \
     "id:904280,\
     phase:2,\
@@ -259,7 +259,7 @@ SecRule ARGS "!@streq %{ARGS}" \
     nolog,\
     setvar:'tx.tf_1_urlDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: urlDecodeUni
+# Transformation: urlDecodeUni
 SecRule ARGS "!@streq %{ARGS}" \
     "id:904290,\
     phase:2,\
@@ -268,7 +268,7 @@ SecRule ARGS "!@streq %{ARGS}" \
     nolog,\
     setvar:'tx.tf_1_urlDecodeUni_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: utf8toUnicode
+# Transformation: utf8toUnicode
 SecRule ARGS "!@streq %{ARGS}" \
     "id:904300,\
     phase:2,\
@@ -284,7 +284,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:904018,phase:2,pass,nolog,skipAf
 # -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
 #
 
-# decode: transform: base64DecodeExt
+# Transformation: base64DecodeExt
 SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     "id:904400,\
     phase:2,\
@@ -293,7 +293,7 @@ SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     nolog,\
     setvar:'tx.tf_2_base64DecodeExt_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: cmdLine
+# Transformation: cmdLine
 SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     "id:904410,\
     phase:2,\
@@ -302,7 +302,7 @@ SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     nolog,\
     setvar:'tx.tf_2_cmdLine_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: compressWhitespace
+# Transformation: compressWhitespace
 SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     "id:904420,\
     phase:2,\
@@ -311,7 +311,7 @@ SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     nolog,\
     setvar:'tx.tf_2_compressWhitespace_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: cssDecode
+# Transformation: cssDecode
 SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     "id:904430,\
     phase:2,\
@@ -320,7 +320,7 @@ SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     nolog,\
     setvar:'tx.tf_2_cssDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: escapeSeqDecode
+# Transformation: escapeSeqDecode
 SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     "id:904440,\
     phase:2,\
@@ -329,7 +329,7 @@ SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     nolog,\
     setvar:'tx.tf_2_escapeSeqDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: hexDecode
+# Transformation: hexDecode
 SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     "id:904450,\
     phase:2,\
@@ -338,7 +338,7 @@ SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     nolog,\
     setvar:'tx.tf_2_hexDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: htmlEntityDecode
+# Transformation: htmlEntityDecode
 SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     "id:904460,\
     phase:2,\
@@ -347,7 +347,7 @@ SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     nolog,\
     setvar:'tx.tf_2_htmlEntityDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: jsDecode
+# Transformation: jsDecode
 SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     "id:904470,\
     phase:2,\
@@ -356,7 +356,7 @@ SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     nolog,\
     setvar:'tx.tf_2_jsDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: normalizePath
+# Transformation: normalizePath
 SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     "id:904480,\
     phase:2,\
@@ -365,7 +365,7 @@ SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     nolog,\
     setvar:'tx.tf_2_normalizePath_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: normalizePathWin
+# Transformation: normalizePathWin
 SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     "id:904490,\
     phase:2,\
@@ -374,7 +374,7 @@ SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     nolog,\
     setvar:'tx.tf_2_normalizePathWin_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: removeComments
+# Transformation: removeComments
 SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     "id:904500,\
     phase:2,\
@@ -383,7 +383,7 @@ SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     nolog,\
     setvar:'tx.tf_2_removeComments_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: removeCommentsChar
+# Transformation: removeCommentsChar
 SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     "id:904510,\
     phase:2,\
@@ -392,7 +392,7 @@ SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     nolog,\
     setvar:'tx.tf_2_removeCommentsChar_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: removeNulls
+# Transformation: removeNulls
 SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     "id:904520,\
     phase:2,\
@@ -401,7 +401,7 @@ SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     nolog,\
     setvar:'tx.tf_2_removeNulls_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: removeWhitespace
+# Transformation: removeWhitespace
 SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     "id:904530,\
     phase:2,\
@@ -410,7 +410,7 @@ SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     nolog,\
     setvar:'tx.tf_2_removeWhitespace_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: replaceComments
+# Transformation: replaceComments
 SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     "id:904540,\
     phase:2,\
@@ -419,7 +419,7 @@ SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     nolog,\
     setvar:'tx.tf_2_replaceComments_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: replaceNulls
+# Transformation: replaceNulls
 SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     "id:904550,\
     phase:2,\
@@ -428,7 +428,7 @@ SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     nolog,\
     setvar:'tx.tf_2_replaceNulls_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: sqlHexDecode
+# Transformation: sqlHexDecode
 SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     "id:904560,\
     phase:2,\
@@ -437,7 +437,7 @@ SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     nolog,\
     setvar:'tx.tf_2_sqlHexDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: trim
+# Transformation: trim
 SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     "id:904570,\
     phase:2,\
@@ -446,7 +446,7 @@ SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     nolog,\
     setvar:'tx.tf_2_trim_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: urlDecode
+# Transformation: urlDecode
 SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     "id:904580,\
     phase:2,\
@@ -455,7 +455,7 @@ SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     nolog,\
     setvar:'tx.tf_2_urlDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: urlDecodeUni
+# Transformation: urlDecodeUni
 SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     "id:904590,\
     phase:2,\
@@ -464,7 +464,7 @@ SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     nolog,\
     setvar:'tx.tf_2_urlDecodeUni_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
 
-# decode: transform: utf8toUnicode
+# Transformation: utf8toUnicode
 SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
     "id:904600,\
     phase:2,\

--- a/rules/REQUEST-904-GENERIC-TRANSFORMATIONS.conf
+++ b/rules/REQUEST-904-GENERIC-TRANSFORMATIONS.conf
@@ -1,0 +1,480 @@
+# ------------------------------------------------------------------------
+# OWASP ModSecurity Core Rule Set ver.3.3.0
+# Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
+#
+# The OWASP ModSecurity Core Rule Set is distributed under
+# Apache Software License (ASL) version 2
+# Please see the enclosed LICENSE file for full details.
+# ------------------------------------------------------------------------
+
+
+# The rules in this file transform ARGS parameters with a series of 
+# transformations. See documentation in crs-setup.conf.
+#
+# Mechanics of a simple transformation rule
+# -----------------------------------------
+#
+# Consider this rule:
+#
+# SecRule ARGS "!@streq %{ARGS}" \
+#    "id:904100,\
+#    phase:2,\
+#    pass,\
+#    t:base64DecodeExt,\
+#    nolog,\
+#    setvar:'tx.tf_1_base64DecodeExt_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+#
+# The rule transforms any given ARGS with the base64DecodeExt transformation.
+# The SecRule condition will then examine the transformed parameter
+# against the original, non-transformed parameter.
+#
+# If the two strings are not equal (and only then!), a new TX variable is
+# created. The new variable will have the name 
+# "tx.tf_1_base64DecodeExt_ARGS:<varname>".
+#
+# The prefix "tf_1_" indicates that it's a simply transformed parameter.
+#
+# Mechanics of a double transformation rule
+# -----------------------------------------
+#
+# Consider this rule:
+
+# SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
+#    "id:904400,\
+#    phase:2,\
+#    pass,\
+#    t:base64DecodeExt,\
+#    nolog,\
+#    setvar:'tx.tf_2_base64DecodeExt_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+#
+# The rule transforms any given simply transformed parameter (identified)
+# via the prefix "tf_1_") with the base64DecodeExt transformation
+# and the SecRule constraint will then examine the transformed parameter
+# against the original, non-transformed argument.
+#
+# If the two strings are not equal (and only then!), a new TX variable is
+# created. The new variable will have the name 
+# "tx.tf_2_base64DecodeExt_TX:tf_1_<simple-transformation>_ARGS:<varname>".
+#
+# The name of the double transformation is thus a prefixed version of
+# the simple transformation name.
+#
+# The prefix "tf_2_" indicates that it's a double transformed parameter.
+#
+
+SecRule TX:GENERIC_TRANSFORMATIONS "!@eq 1" "id:904010,phase:2,pass,nolog,skipAfter:END-REQUEST-904-GENERIC-TRANSFORMATIONS"
+
+
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:904011,phase:1,pass,nolog,skipAfter:END-REQUEST-904-GENERIC-TRANSFORMATIONS"
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:904012,phase:2,pass,nolog,skipAfter:END-REQUEST-904-GENERIC-TRANSFORMATIONS"
+#
+# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+#
+
+
+
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:904013,phase:1,pass,nolog,skipAfter:END-REQUEST-904-GENERIC-TRANSFORMATIONS"
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:904014,phase:2,pass,nolog,skipAfter:END-REQUEST-904-GENERIC-TRANSFORMATIONS"
+#
+# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
+#
+
+
+
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:904015,phase:1,pass,nolog,skipAfter:END-REQUEST-904-GENERIC-TRANSFORMATIONS"
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:904016,phase:2,pass,nolog,skipAfter:END-REQUEST-904-GENERIC-TRANSFORMATIONS"
+#
+# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+#
+
+
+# decode: transform: base64DecodeExt
+SecRule ARGS "!@streq %{ARGS}" \
+    "id:904100,\
+    phase:2,\
+    pass,\
+    t:base64DecodeExt,\
+    nolog,\
+    setvar:'tx.tf_1_base64DecodeExt_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: cmdLine
+SecRule ARGS "!@streq %{ARGS}" \
+    "id:904110,\
+    phase:2,\
+    pass,\
+    t:cmdLine,\
+    nolog,\
+    setvar:'tx.tf_1_cmdLine_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: compressWhitespace
+SecRule ARGS "!@streq %{ARGS}" \
+    "id:904120,\
+    phase:2,\
+    pass,\
+    t:compressWhitespace,\
+    nolog,\
+    setvar:'tx.tf_1_compressWhitespace_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: cssDecode
+SecRule ARGS "!@streq %{ARGS}" \
+    "id:904130,\
+    phase:2,\
+    pass,\
+    t:cssDecode,\
+    nolog,\
+    setvar:'tx.tf_1_cssDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: escapeSeqDecode
+SecRule ARGS "!@streq %{ARGS}" \
+    "id:904140,\
+    phase:2,\
+    pass,\
+    t:escapeSeqDecode,\
+    nolog,\
+    setvar:'tx.tf_1_escapeSeqDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: hexDecode
+SecRule ARGS "!@streq %{ARGS}" \
+    "id:904150,\
+    phase:2,\
+    pass,\
+    t:hexDecode,\
+    nolog,\
+    setvar:'tx.tf_1_hexDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: htmlEntityDecode
+SecRule ARGS "!@streq %{ARGS}" \
+    "id:904160,\
+    phase:2,\
+    pass,\
+    t:htmlEntityDecode,\
+    nolog,\
+    setvar:'tx.tf_1_htmlEntityDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: jsDecode
+SecRule ARGS "!@streq %{ARGS}" \
+    "id:904170,\
+    phase:2,\
+    pass,\
+    t:jsDecode,\
+    nolog,\
+    setvar:'tx.tf_1_jsDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: normalizePath
+SecRule ARGS "!@streq %{ARGS}" \
+    "id:904180,\
+    phase:2,\
+    pass,\
+    t:normalizePath,\
+    nolog,\
+    setvar:'tx.tf_1_normalizePath_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: normalizePathWin
+SecRule ARGS "!@streq %{ARGS}" \
+    "id:904190,\
+    phase:2,\
+    pass,\
+    t:normalizePathWin,\
+    nolog,\
+    setvar:'tx.tf_1_normalizePathWin_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: removeComments
+SecRule ARGS "!@streq %{ARGS}" \
+    "id:904200,\
+    phase:2,\
+    pass,\
+    t:removeComments,\
+    nolog,\
+    setvar:'tx.tf_1_removeComments_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: removeCommentsChar
+SecRule ARGS "!@streq %{ARGS}" \
+    "id:904210,\
+    phase:2,\
+    pass,\
+    t:removeCommentsChar,\
+    nolog,\
+    setvar:'tx.tf_1_removeCommentsChar_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: removeNulls
+SecRule ARGS "!@streq %{ARGS}" \
+    "id:904220,\
+    phase:2,\
+    pass,\
+    t:removeNulls,\
+    nolog,\
+    setvar:'tx.tf_1_removeNulls_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: removeWhitespace
+SecRule ARGS "!@streq %{ARGS}" \
+    "id:904230,\
+    phase:2,\
+    pass,\
+    t:removeWhitespace,\
+    nolog,\
+    setvar:'tx.tf_1_removeWhitespace_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: replaceComments
+SecRule ARGS "!@streq %{ARGS}" \
+    "id:904240,\
+    phase:2,\
+    pass,\
+    t:replaceComments,\
+    nolog,\
+    setvar:'tx.tf_1_replaceComments_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: replaceNulls
+SecRule ARGS "!@streq %{ARGS}" \
+    "id:904250,\
+    phase:2,\
+    pass,\
+    t:replaceNulls,\
+    nolog,\
+    setvar:'tx.tf_1_replaceNulls_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: sqlHexDecode
+SecRule ARGS "!@streq %{ARGS}" \
+    "id:904260,\
+    phase:2,\
+    pass,\
+    t:sqlHexDecode,\
+    nolog,\
+    setvar:'tx.tf_1_sqlHexDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: trim
+SecRule ARGS "!@streq %{ARGS}" \
+    "id:904270,\
+    phase:2,\
+    pass,\
+    t:trim,\
+    nolog,\
+    setvar:'tx.tf_1_trim_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: urlDecode
+SecRule ARGS "!@streq %{ARGS}" \
+    "id:904280,\
+    phase:2,\
+    pass,\
+    t:urlDecode,\
+    nolog,\
+    setvar:'tx.tf_1_urlDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: urlDecodeUni
+SecRule ARGS "!@streq %{ARGS}" \
+    "id:904290,\
+    phase:2,\
+    pass,\
+    t:urlDecodeUni,\
+    nolog,\
+    setvar:'tx.tf_1_urlDecodeUni_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: utf8toUnicode
+SecRule ARGS "!@streq %{ARGS}" \
+    "id:904300,\
+    phase:2,\
+    pass,\
+    t:utf8toUnicode,\
+    nolog,\
+    setvar:'tx.tf_1_utf8toUnicode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:904017,phase:1,pass,nolog,skipAfter:END-REQUEST-904-GENERIC-TRANSFORMATIONS"
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:904018,phase:2,pass,nolog,skipAfter:END-REQUEST-904-GENERIC-TRANSFORMATIONS"
+#
+# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+#
+
+# decode: transform: base64DecodeExt
+SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
+    "id:904400,\
+    phase:2,\
+    pass,\
+    t:base64DecodeExt,\
+    nolog,\
+    setvar:'tx.tf_2_base64DecodeExt_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: cmdLine
+SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
+    "id:904410,\
+    phase:2,\
+    pass,\
+    t:cmdLine,\
+    nolog,\
+    setvar:'tx.tf_2_cmdLine_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: compressWhitespace
+SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
+    "id:904420,\
+    phase:2,\
+    pass,\
+    t:compressWhitespace,\
+    nolog,\
+    setvar:'tx.tf_2_compressWhitespace_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: cssDecode
+SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
+    "id:904430,\
+    phase:2,\
+    pass,\
+    t:cssDecode,\
+    nolog,\
+    setvar:'tx.tf_2_cssDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: escapeSeqDecode
+SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
+    "id:904440,\
+    phase:2,\
+    pass,\
+    t:escapeSeqDecode,\
+    nolog,\
+    setvar:'tx.tf_2_escapeSeqDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: hexDecode
+SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
+    "id:904450,\
+    phase:2,\
+    pass,\
+    t:hexDecode,\
+    nolog,\
+    setvar:'tx.tf_2_hexDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: htmlEntityDecode
+SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
+    "id:904460,\
+    phase:2,\
+    pass,\
+    t:htmlEntityDecode,\
+    nolog,\
+    setvar:'tx.tf_2_htmlEntityDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: jsDecode
+SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
+    "id:904470,\
+    phase:2,\
+    pass,\
+    t:jsDecode,\
+    nolog,\
+    setvar:'tx.tf_2_jsDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: normalizePath
+SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
+    "id:904480,\
+    phase:2,\
+    pass,\
+    t:normalizePath,\
+    nolog,\
+    setvar:'tx.tf_2_normalizePath_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: normalizePathWin
+SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
+    "id:904490,\
+    phase:2,\
+    pass,\
+    t:normalizePathWin,\
+    nolog,\
+    setvar:'tx.tf_2_normalizePathWin_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: removeComments
+SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
+    "id:904500,\
+    phase:2,\
+    pass,\
+    t:removeComments,\
+    nolog,\
+    setvar:'tx.tf_2_removeComments_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: removeCommentsChar
+SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
+    "id:904510,\
+    phase:2,\
+    pass,\
+    t:removeCommentsChar,\
+    nolog,\
+    setvar:'tx.tf_2_removeCommentsChar_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: removeNulls
+SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
+    "id:904520,\
+    phase:2,\
+    pass,\
+    t:removeNulls,\
+    nolog,\
+    setvar:'tx.tf_2_removeNulls_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: removeWhitespace
+SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
+    "id:904530,\
+    phase:2,\
+    pass,\
+    t:removeWhitespace,\
+    nolog,\
+    setvar:'tx.tf_2_removeWhitespace_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: replaceComments
+SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
+    "id:904540,\
+    phase:2,\
+    pass,\
+    t:replaceComments,\
+    nolog,\
+    setvar:'tx.tf_2_replaceComments_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: replaceNulls
+SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
+    "id:904550,\
+    phase:2,\
+    pass,\
+    t:replaceNulls,\
+    nolog,\
+    setvar:'tx.tf_2_replaceNulls_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: sqlHexDecode
+SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
+    "id:904560,\
+    phase:2,\
+    pass,\
+    t:sqlHexDecode,\
+    nolog,\
+    setvar:'tx.tf_2_sqlHexDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: trim
+SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
+    "id:904570,\
+    phase:2,\
+    pass,\
+    t:trim,\
+    nolog,\
+    setvar:'tx.tf_2_trim_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: urlDecode
+SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
+    "id:904580,\
+    phase:2,\
+    pass,\
+    t:urlDecode,\
+    nolog,\
+    setvar:'tx.tf_2_urlDecode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: urlDecodeUni
+SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
+    "id:904590,\
+    phase:2,\
+    pass,\
+    t:urlDecodeUni,\
+    nolog,\
+    setvar:'tx.tf_2_urlDecodeUni_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+# decode: transform: utf8toUnicode
+SecRule TX:/^tf_1_*/ "!@streq %{MATCHED_VAR_NAME}" \
+    "id:904600,\
+    phase:2,\
+    pass,\
+    t:utf8toUnicode,\
+    nolog,\
+    setvar:'tx.tf_2_utf8toUnicode_%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'"
+
+
+#
+# -= Paranoia Levels Finished =-
+#
+SecMarker "END-REQUEST-904-GENERIC-TRANSFORMATIONS"

--- a/rules/RESPONSE-998-ENABLE-GENERIC-TRANSFORMATIONS.conf.example
+++ b/rules/RESPONSE-998-ENABLE-GENERIC-TRANSFORMATIONS.conf.example
@@ -14,8 +14,6 @@
 # Please read the documentation about generic transformations of the ARGS
 # parameters in the crs-setup.conf file.
 #
-# FIXME: Make sure file as example-suffix
-#
 
 SecRuleUpdateTargetById 913120 TX:/^tf_/
 SecRuleUpdateTargetById 920230 TX:/^tf_/
@@ -155,8 +153,7 @@ SecRuleUpdateTargetById 944300 TX:/^tf_/
 
 
 # The following rules generally lead to false positives with the decoded files.
-# They are thus excluded automatically when generic transformations are enabled
-# via activating this file.
+# They are thus excluded automatically for the decoded / transformed parameters.
 #
 # Rule Exclusion: 920271 PL2 Invalid character in request (non printable characters)
 # Rule Exclusion: 920272 PL3 Invalid character in request (outside of printable chars below ascii 127)

--- a/rules/RESPONSE-998-ENABLE-GENERIC-TRANSFORMATIONS.conf.example
+++ b/rules/RESPONSE-998-ENABLE-GENERIC-TRANSFORMATIONS.conf.example
@@ -1,0 +1,171 @@
+# ------------------------------------------------------------------------
+# OWASP ModSecurity Core Rule Set ver.3.3.0
+# Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
+#
+# The OWASP ModSecurity Core Rule Set is distributed under
+# Apache Software License (ASL) version 2
+# Please see the enclosed LICENSE file for full details.
+# ------------------------------------------------------------------------
+
+# The directives in this file add the generic transformations of the ARGS
+# parameters to the target list of those rules that inspect the ARGS 
+# parameter.
+#
+# Please read the documentation about generic transformations of the ARGS
+# parameters in the crs-setup.conf file.
+#
+# FIXME: Make sure file as example-suffix
+#
+
+SecRuleUpdateTargetById 913120 TX:/^tf_/
+SecRuleUpdateTargetById 920230 TX:/^tf_/
+SecRuleUpdateTargetById 920250 TX:/^tf_/
+SecRuleUpdateTargetById 920270 TX:/^tf_/
+SecRuleUpdateTargetById 920271 TX:/^tf_/
+SecRuleUpdateTargetById 920272 TX:/^tf_/
+SecRuleUpdateTargetById 920273 TX:/^tf_/
+SecRuleUpdateTargetById 920370 TX:/^tf_/
+SecRuleUpdateTargetById 920460 TX:/^tf_/
+SecRuleUpdateTargetById 921110 TX:/^tf_/
+SecRuleUpdateTargetById 921120 TX:/^tf_/
+SecRuleUpdateTargetById 921130 TX:/^tf_/
+SecRuleUpdateTargetById 921200 TX:/^tf_/
+SecRuleUpdateTargetById 930100 TX:/^tf_/
+SecRuleUpdateTargetById 930110 TX:/^tf_/
+SecRuleUpdateTargetById 930120 TX:/^tf_/
+SecRuleUpdateTargetById 931100 TX:/^tf_/
+SecRuleUpdateTargetById 931120 TX:/^tf_/
+SecRuleUpdateTargetById 931130 TX:/^tf_/
+SecRuleUpdateTargetById 932100 TX:/^tf_/
+SecRuleUpdateTargetById 932101 TX:/^tf_/
+SecRuleUpdateTargetById 932105 TX:/^tf_/
+SecRuleUpdateTargetById 932106 TX:/^tf_/
+SecRuleUpdateTargetById 932106 TX:/^tf_/
+SecRuleUpdateTargetById 932110 TX:/^tf_/
+SecRuleUpdateTargetById 932115 TX:/^tf_/
+SecRuleUpdateTargetById 932120 TX:/^tf_/
+SecRuleUpdateTargetById 932130 TX:/^tf_/
+SecRuleUpdateTargetById 932140 TX:/^tf_/
+SecRuleUpdateTargetById 932150 TX:/^tf_/
+SecRuleUpdateTargetById 932160 TX:/^tf_/
+SecRuleUpdateTargetById 932171 TX:/^tf_/
+SecRuleUpdateTargetById 932190 TX:/^tf_/
+SecRuleUpdateTargetById 932200 TX:/^tf_/
+SecRuleUpdateTargetById 933100 TX:/^tf_/
+SecRuleUpdateTargetById 933120 TX:/^tf_/
+SecRuleUpdateTargetById 933130 TX:/^tf_/
+SecRuleUpdateTargetById 933131 TX:/^tf_/
+SecRuleUpdateTargetById 933140 TX:/^tf_/
+SecRuleUpdateTargetById 933150 TX:/^tf_/
+SecRuleUpdateTargetById 933151 TX:/^tf_/
+SecRuleUpdateTargetById 933160 TX:/^tf_/
+SecRuleUpdateTargetById 933161 TX:/^tf_/
+SecRuleUpdateTargetById 933170 TX:/^tf_/
+SecRuleUpdateTargetById 933180 TX:/^tf_/
+SecRuleUpdateTargetById 933190 TX:/^tf_/
+SecRuleUpdateTargetById 933200 TX:/^tf_/
+SecRuleUpdateTargetById 933210 TX:/^tf_/
+SecRuleUpdateTargetById 934100 TX:/^tf_/
+SecRuleUpdateTargetById 941100 TX:/^tf_/
+SecRuleUpdateTargetById 941110 TX:/^tf_/
+SecRuleUpdateTargetById 941120 TX:/^tf_/
+SecRuleUpdateTargetById 941130 TX:/^tf_/
+SecRuleUpdateTargetById 941140 TX:/^tf_/
+SecRuleUpdateTargetById 941150 TX:/^tf_/
+SecRuleUpdateTargetById 941160 TX:/^tf_/
+SecRuleUpdateTargetById 941170 TX:/^tf_/
+SecRuleUpdateTargetById 941180 TX:/^tf_/
+SecRuleUpdateTargetById 941190 TX:/^tf_/
+SecRuleUpdateTargetById 941200 TX:/^tf_/
+SecRuleUpdateTargetById 941210 TX:/^tf_/
+SecRuleUpdateTargetById 941220 TX:/^tf_/
+SecRuleUpdateTargetById 941230 TX:/^tf_/
+SecRuleUpdateTargetById 941240 TX:/^tf_/
+SecRuleUpdateTargetById 941250 TX:/^tf_/
+SecRuleUpdateTargetById 941260 TX:/^tf_/
+SecRuleUpdateTargetById 941270 TX:/^tf_/
+SecRuleUpdateTargetById 941280 TX:/^tf_/
+SecRuleUpdateTargetById 941290 TX:/^tf_/
+SecRuleUpdateTargetById 941300 TX:/^tf_/
+SecRuleUpdateTargetById 941310 TX:/^tf_/
+SecRuleUpdateTargetById 941320 TX:/^tf_/
+SecRuleUpdateTargetById 941330 TX:/^tf_/
+SecRuleUpdateTargetById 941340 TX:/^tf_/
+SecRuleUpdateTargetById 941350 TX:/^tf_/
+SecRuleUpdateTargetById 941360 TX:/^tf_/
+SecRuleUpdateTargetById 941370 TX:/^tf_/
+SecRuleUpdateTargetById 941380 TX:/^tf_/
+SecRuleUpdateTargetById 942100 TX:/^tf_/
+SecRuleUpdateTargetById 942110 TX:/^tf_/
+SecRuleUpdateTargetById 942120 TX:/^tf_/
+SecRuleUpdateTargetById 942130 TX:/^tf_/
+SecRuleUpdateTargetById 942140 TX:/^tf_/
+SecRuleUpdateTargetById 942150 TX:/^tf_/
+SecRuleUpdateTargetById 942160 TX:/^tf_/
+SecRuleUpdateTargetById 942170 TX:/^tf_/
+SecRuleUpdateTargetById 942180 TX:/^tf_/
+SecRuleUpdateTargetById 942190 TX:/^tf_/
+SecRuleUpdateTargetById 942200 TX:/^tf_/
+SecRuleUpdateTargetById 942210 TX:/^tf_/
+SecRuleUpdateTargetById 942220 TX:/^tf_/
+SecRuleUpdateTargetById 942230 TX:/^tf_/
+SecRuleUpdateTargetById 942240 TX:/^tf_/
+SecRuleUpdateTargetById 942250 TX:/^tf_/
+SecRuleUpdateTargetById 942251 TX:/^tf_/
+SecRuleUpdateTargetById 942260 TX:/^tf_/
+SecRuleUpdateTargetById 942270 TX:/^tf_/
+SecRuleUpdateTargetById 942280 TX:/^tf_/
+SecRuleUpdateTargetById 942290 TX:/^tf_/
+SecRuleUpdateTargetById 942300 TX:/^tf_/
+SecRuleUpdateTargetById 942310 TX:/^tf_/
+SecRuleUpdateTargetById 942320 TX:/^tf_/
+SecRuleUpdateTargetById 942330 TX:/^tf_/
+SecRuleUpdateTargetById 942340 TX:/^tf_/
+SecRuleUpdateTargetById 942350 TX:/^tf_/
+SecRuleUpdateTargetById 942360 TX:/^tf_/
+SecRuleUpdateTargetById 942361 TX:/^tf_/
+SecRuleUpdateTargetById 942362 TX:/^tf_/
+SecRuleUpdateTargetById 942370 TX:/^tf_/
+SecRuleUpdateTargetById 942380 TX:/^tf_/
+SecRuleUpdateTargetById 942390 TX:/^tf_/
+SecRuleUpdateTargetById 942400 TX:/^tf_/
+SecRuleUpdateTargetById 942410 TX:/^tf_/
+SecRuleUpdateTargetById 942430 TX:/^tf_/
+SecRuleUpdateTargetById 942431 TX:/^tf_/
+SecRuleUpdateTargetById 942432 TX:/^tf_/
+SecRuleUpdateTargetById 942440 TX:/^tf_/
+SecRuleUpdateTargetById 942450 TX:/^tf_/
+SecRuleUpdateTargetById 942460 TX:/^tf_/
+SecRuleUpdateTargetById 942470 TX:/^tf_/
+SecRuleUpdateTargetById 942480 TX:/^tf_/
+SecRuleUpdateTargetById 942490 TX:/^tf_/
+SecRuleUpdateTargetById 942500 TX:/^tf_/
+SecRuleUpdateTargetById 942510 TX:/^tf_/
+SecRuleUpdateTargetById 942511 TX:/^tf_/
+SecRuleUpdateTargetById 943100 TX:/^tf_/
+SecRuleUpdateTargetById 944100 TX:/^tf_/
+SecRuleUpdateTargetById 944110 TX:/^tf_/
+SecRuleUpdateTargetById 944120 TX:/^tf_/
+SecRuleUpdateTargetById 944130 TX:/^tf_/
+SecRuleUpdateTargetById 944200 TX:/^tf_/
+SecRuleUpdateTargetById 944210 TX:/^tf_/
+SecRuleUpdateTargetById 944240 TX:/^tf_/
+SecRuleUpdateTargetById 944250 TX:/^tf_/
+SecRuleUpdateTargetById 944300 TX:/^tf_/
+
+
+# The following rules generally lead to false positives with the decoded files.
+# They are thus excluded automatically when generic transformations are enabled
+# via activating this file.
+#
+# Rule Exclusion: 920271 PL2 Invalid character in request (non printable characters)
+# Rule Exclusion: 920272 PL3 Invalid character in request (outside of printable chars below ascii 127)
+# Rule Exclusion: 920273 PL4 Invalid character in request (outside of very strict set)
+# Rule Exclusion: 942432 PL4 Restricted SQL Character Anomaly Detection (args): # of special characters exceeded (2)
+# Rule Exclusion: 942460 PL3 Meta-Character Anomaly Detection Alert - Repetitive Non-Word Characters
+
+SecRuleUpdateTargetById 920271 !TX:/^tf_/
+SecRuleUpdateTargetById 920272 !TX:/^tf_/
+SecRuleUpdateTargetById 920273 !TX:/^tf_/
+SecRuleUpdateTargetById 942432 !TX:/^tf_/
+SecRuleUpdateTargetById 942460 !TX:/^tf_/


### PR DESCRIPTION
## Description

This is a PR that implements the automatic and generic transformation / decoding of parameters in PL3 and PL4 with the help of ModSec transformations like `base64DecodeExt`.

This new feature allows to detect the following payloads:

```
Original payload: system('bash')
Base64 encoded payload: c3lzdGVtKCdiYXNoJyk=
Double-Base64 encoded payload: YzNsemRHVnRLQ2RpWVhOb0p5az0
Base64 and then hex-encoded payload: 63336c7a644756744b43646959584e6f4a796b3d
```

The original payload of the simple encoding is detected at PL3, the double encoded payload is detected at PL4. The rules 933160 (PL1) and 942511 (PL3) will trigger.

## Trying this out yourself

Test this at PL4 via: 

```		
$> curl "http://localhost/?test=c3lzdGVtKCdiYXNoJyk="
$> curl "http://localhost/?test=YzNsemRHVnRLQ2RpWVhOb0p5az0="
$> curl "http://localhost/?test=63336c7a644756744b43646959584e6f4a796b3d"
```

This has been tested on ModSec 2.9.3 as well as ModSec 3.0.4 (nginx connector 1.0.1). Both versions exhibit the identical behavior.


## Activation of feature

* Enable via parameter `tx.generic_transformations` in rule 900360 in `crs-setup.conf`
* mv rules/RESPONSE-998-ENABLE-GENERIC-TRANSFORMATIONS.conf.example rules/RESPONSE-998-ENABLE-GENERIC-TRANSFORMATIONS.conf
* Set PL to 3 or 4. (3 brings simple transformations, 4 brings double transformations)

## Performance

This brings a significant performance impact. 

Below is a rough estimate over ab from a local test machine against a local, midsize server. All values in seconds.

The test was carried out with 100 runs for each scenario with 1000 requests each. Then the median time taken to serve the requests was taken for each of the 100 runs and scenarios. Below's numbers are this median value of a run across all runs for a given scenario.

| URI | PL1 | PL3 | PL4 | PL3 with generic transformations | PL4 with generic transformations |
| ---------- | ---------- | ---------- | ---------- | ---------- | ---------- |
| http://server/                                                                                              | 2.6 | 2.7 | 2.6 | 2.9 | 2.8 |
| http://server/?test=system('bash')                                                             | 2.8 | 3.0 | 3.0 | 3.3 | 4.3 |
| http://server/?test=c3lzdGVtKCdiYXNoJyk=                                             | 2.7 | 2.9 | 2.8 | 3.4 | 4.5 |
| http://server/?test=YzNsemRHVnRLQ2RpWVhOb0p5az0=                    | 2.7 | 2.9 | 2.8 | 3.5 | 4.2 |
| http://server/?test=63336c7a644756744b43646959584e6f4a796b3d     | 2.6 | 2.9 | 2.7 | 3.3 | 3.8 |

Enabling the generic transformations adds an overhead of roughly 10% regardless of parameters or not. This is due to the extension of the target list of about half the rules with a regular expression (in order to apply the transformed rules).

With encoded parameters in the request, the overhead can become very steep, namely at PL4, where it can add as much 50%.


## Various

This PR is based on an idea of @spartantri and @dune73 to decode parameters and expand the target lists to include the new parameter. We literally had the same idea in the same week independent of one another. Making this generic is the logical next step.

## Unit testing

Since we need to enable / disable an optional feature including activating a rule file, I am a bit at a loss with regards to unit-testing this.