### PR TITLE
feat(git): ignore docker-compose environment files in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ __pycache__/
 
 # Ignore test logs
 tests/logs/
+
+# ignore .env in tests for docker-compose variables
+tests/.env


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

This is the first of a series of PRs that decouple #1906 in smaller changes.

Just ignore environment files useful for docker-compose.