### PR TITLE
WordPress exclusion profile improvements

### DIFF
--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -270,7 +270,7 @@ SecRule REQUEST_FILENAME "!@contains /wp-admin/" \
 
 SecRule REQUEST_FILENAME "!@contains /wp-admin/" \
     "id:9002401,\
-    phase:1,\
+    phase:2,\
     pass,\
     t:none,\
     nolog,\
@@ -411,21 +411,23 @@ SecAction \
     nolog,\
     ctl:ruleRemoveTargetById=920230;ARGS:_wp_http_referer,\
     ctl:ruleRemoveTargetById=931130;ARGS:_wp_http_referer,\
-    ctl:ruleRemoveTargetById=932200;ARGS:_wp_http_referer,\
     ctl:ruleRemoveTargetById=932150;ARGS:_wp_http_referer,\
+    ctl:ruleRemoveTargetById=932200;ARGS:_wp_http_referer,\
     ctl:ruleRemoveTargetById=941100;ARGS:_wp_http_referer,\
     ctl:ruleRemoveTargetById=942130;ARGS:_wp_http_referer,\
     ctl:ruleRemoveTargetById=942200;ARGS:_wp_http_referer,\
+    ctl:ruleRemoveTargetById=942230;ARGS:_wp_http_referer,\
     ctl:ruleRemoveTargetById=942260;ARGS:_wp_http_referer,\
     ctl:ruleRemoveTargetById=942431;ARGS:_wp_http_referer,\
     ctl:ruleRemoveTargetById=942440;ARGS:_wp_http_referer,\
     ctl:ruleRemoveTargetById=920230;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=931130;ARGS:wp_http_referer,\
-    ctl:ruleRemoveTargetById=932200;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=932150;ARGS:wp_http_referer,\
+    ctl:ruleRemoveTargetById=932200;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=941100;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=942130;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=942200;ARGS:wp_http_referer,\
+    ctl:ruleRemoveTargetById=942230;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=942260;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=942431;ARGS:wp_http_referer,\
     ver:'OWASP_CRS/3.3.0'"
@@ -491,12 +493,15 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/nav-menus.php" \
     nolog,\
     ver:'OWASP_CRS/3.3.0',\
     chain"
-    SecRule ARGS:action "@streq update" \
+    SecRule ARGS:action "@rx ^(?:update|edit)$" \
         "t:none,\
         chain"
         SecRule &ARGS:action "@eq 1" \
             "t:none,\
+            ctl:ruleRemoveTargetById=932200;ARGS,\
+            ctl:ruleRemoveTargetById=932150;ARGS,\
             ctl:ruleRemoveTargetById=942460;ARGS:menu-name,\
+            ctl:ruleRemoveTargetById=932200;ARGS:nav-menu-data,\
             ctl:ruleRemoveTargetById=941330;ARGS:nav-menu-data,\
             ctl:ruleRemoveTargetById=941340;ARGS:nav-menu-data,\
             ctl:ruleRemoveTargetById=942200;ARGS:nav-menu-data,\


### PR DESCRIPTION
- rule 9002401 should skip over the WP rules in phase:2 when exclusions are deactivated by admin (performance)
- add more wp_http_referer FP exclusions
- nav-menus should also be excluded on edit
- add more exclusions to nav-menus