### PR TITLE
Try to fix 933210 bypass at PL1, lowering FPs

### DIFF
--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -480,7 +480,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
 # - [ACME] this is a test (just a test)
 # - Test (with two) rounded (brackets)
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@rx (?:(?:\(|\[)[a-zA-Z0-9_.$\"'\[\](){}*\s]+(?:\)|\])[0-9_.$\"'\[\](){}*\s]*\([a-zA-Z0-9_.$\"'\[\](){}*\s].*\)|\([\s]*string[\s]*\)[\s]*(?:\"|'))" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@rx (?:(?:\(|\[|\")[a-zA-Z0-9_.$\"'\[\](){}*\s\\]+(?:\)|\]|\")[0-9_.$\"'\[\](){}*\s]*\([a-zA-Z0-9_.$\"'\[\](){}*\s].*\)|\([\s]*string[\s]*\)[\s]*(?:\"|'))[;]" \
     "id:933210,\
     phase:2,\
     block,\

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -464,13 +464,13 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
 # Referring to https://www.secjuice.com/php-rce-bypass-filters-sanitization-waf/
 # the rule 933180 could be bypassed by using the following payloads:
 #
-# - (system)('uname')
-# - (sy.(st).em)('uname')
-# - (string)"system"('uname')
-# - define('x', 'sys' . 'tem');(x)/* comment */('uname')
-# - $y = 'sys'.'tem';($y)('uname')
+# - (system)('uname');
+# - (sy.(st).em)('uname');
+# - (string)"system"('uname');
+# - define('x', 'sys' . 'tem');(x)/* comment */('uname');
+# - $y = 'sys'.'tem';($y)('uname');
 # - define('z', [['sys' .'tem']]);(z)[0][0]('uname');
-# - (system)(ls)
+# - (system)(ls);
 # - (/**/system)(ls/**/);
 # - (['system'])[0]('uname');
 # - (++[++system++][++0++])++{/*dsasd*/0}++(++ls++);

--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933210.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933210.yaml
@@ -45,7 +45,7 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=%28system%29%28%27uname%27%29
+          uri: /?x=%28system%29%28%27uname%27%29%3B
         output:
           log_contains: id "933210"
 
@@ -60,7 +60,7 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=%28sy.%28st%29.em%29%28%27uname%27%29
+          uri: /?x=%28sy.%28st%29.em%29%28%27uname%27%29%3B
         output:
           log_contains: id "933210"
 
@@ -75,7 +75,7 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=%28string%29%22system%22%28%27uname%27%29
+          uri: /?x=%28string%29%22system%22%28%27uname%27%29%3B
         output:
           log_contains: id "933210"
 
@@ -90,7 +90,7 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=%28+string+%29+%22sys%22.%22t%22.%22em%22+%28%27uname%27%29
+          uri: /?x=%28+string+%29+%22sys%22.%22t%22.%22em%22+%28%27uname%27%29%3B
         output:
           log_contains: id "933210"
 
@@ -105,7 +105,7 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=%28string%29+%7b%5bsystem%5d%5b0%5d%7d+%28%27uname%27%29
+          uri: /?x=%28string%29+%7b%5bsystem%5d%5b0%5d%7d+%28%27uname%27%29%3B
         output:
           log_contains: id "933210"
 
@@ -120,7 +120,7 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=define%28%27x%27,+%27sys%27+.+%27tem%27%29%3b%28x%29%2f*+comment+*%2f%28%27uname%27%29
+          uri: /?x=define%28%27x%27,+%27sys%27+.+%27tem%27%29%3b%28x%29%2f*+comment+*%2f%28%27uname%27%29%3B
         output:
           log_contains: id "933210"
 
@@ -135,7 +135,7 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=$y+=+%27sys%27.%27tem%27%3b%28$y%29%28%27uname%27%29
+          uri: /?x=$y+=+%27sys%27.%27tem%27%3b%28$y%29%28%27uname%27%29%3B
         output:
           log_contains: id "933210"
 
@@ -150,7 +150,7 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=define%28%27z%27,+%5b%5b%27sys%27+.%27tem%27%5d%5d%29%3b%28z%29%5b0%5d%5b0%5d%28%27uname%27%29
+          uri: /?x=define%28%27z%27,+%5b%5b%27sys%27+.%27tem%27%5d%5d%29%3b%28z%29%5b0%5d%5b0%5d%28%27uname%27%29%3B
         output:
           log_contains: id "933210"
 
@@ -165,7 +165,7 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=%28system%29%28ls%29
+          uri: /?x=%28system%29%28ls%29%3B
         output:
           log_contains: id "933210"
 
@@ -180,7 +180,7 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=%28%2f*+comment+*%2fsystem%29%28ls%2f*+comment+*%2f%29
+          uri: /?x=%28%2f*+comment+*%2fsystem%29%28ls%2f*+comment+*%2f%29%3B
         output:
           log_contains: id "933210"
 
@@ -195,7 +195,7 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=%5bsystem%5d%5b0%5d%28ls%29
+          uri: /?x=%5bsystem%5d%5b0%5d%28ls%29%3B
         output:
           log_contains: id "933210"
 
@@ -210,7 +210,7 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=%5b+system+%5d+%5b+0+%5d+%28+ls+%29
+          uri: /?x=%5b+system+%5d+%5b+0+%5d+%28+ls+%29%3B
         output:
           log_contains: id "933210"
 
@@ -225,7 +225,7 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=%28%5b%27system%27%5d%29%5b0%5d%28%27uname%27%29
+          uri: /?x=%28%5b%27system%27%5d%29%5b0%5d%28%27uname%27%29%3B
         output:
           log_contains: id "933210"
 
@@ -240,7 +240,7 @@
             Host: localhost
             User-Agent: ModSecurity CRS 3 Tests
           port: 80
-          uri: /?x=%28++%5b++system++%5d%5b++0++%5d%29++%7b%2f*+comment+*%2f0%7d++%28++ls++%29
+          uri: /?x=%28++%5b++system++%5d%5b++0++%5d%29++%7b%2f*+comment+*%2f0%7d++%28++ls++%29%3B
         output:
           log_contains: id "933210"
 
@@ -275,3 +275,45 @@
           uri: /
         output:
           no_log_contains: id "933210"
+  -
+    test_title: 933210-19
+    desc: Check FP if text contains quotes and round parenthesis
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+          port: 80
+          uri: /?search=this+is+a+%22dog%22+%28not+a+cat%29
+        output:
+          no_log_contains: id "933210"
+  -
+    test_title: 933210-20
+    desc: Block function call via string
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+          port: 80
+          uri: /?code=%22system%22%28ls%29%3B
+        output:
+          log_contains: id "933210"
+  -
+    test_title: 933210-21
+    desc: Block function call via string using hex escape sequence
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+          port: 80
+          uri: /?code=%22%5Cx73y%5Cx73tem%22%28ls%29%3B
+        output:
+          log_contains: id "933210"


### PR DESCRIPTION
This is the first attempt in order to fix 933210 bypass at PL1. In few words:

- all PHP syntaxes matched by 933210 need a `;` at the end of payload to be a valid PHP syntax. I've added it at the end of regex to be more strict on what it matches or not
- added `"`at the first part of the regex to match a function call using string
- added `\` to match function call using string including escape sequences

I think this way we can reduce the number of FPs, what do you think about it?

![image](https://user-images.githubusercontent.com/4454961/106760354-00a3cf00-6634-11eb-84cc-9e66cf49afc4.png)
