### PR TITLE
Move 941310 from PL1 to PL2

### DIFF
--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -705,7 +705,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 # Detect tags that are the most common direct HTML injection points.

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -525,33 +525,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #
-# https://www.owasp.org/www-community/xss-filter-evasion-cheatsheet
-# US-ASCII encoding bypass listed on XSS filter evasion
-# Reported by Mazin Ahmed
-#
-
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \xbc[^\xbe>]*[\xbe>]|<[^\xbe]*\xbe" \
-    "id:941310,\
-    phase:2,\
-    block,\
-    capture,\
-    t:none,t:lowercase,t:urlDecode,t:htmlEntityDecode,t:jsDecode,\
-    msg:'US-ASCII Malformed Encoding XSS Filter - Attack Detected',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-tomcat',\
-    tag:'attack-xss',\
-    tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'capec/1000/152/242',\
-    ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
-    severity:'CRITICAL',\
-    setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
-
-#
 # https://nedbatchelder.com/blog/200704/xss_with_utf7.html
 # UTF-7 encoding XSS filter evasion for IE.
 # Reported by Vladimir Ivanov
@@ -704,6 +677,35 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+
+#
+# https://www.owasp.org/www-community/xss-filter-evasion-cheatsheet
+# US-ASCII encoding bypass listed on XSS filter evasion
+# Reported by Mazin Ahmed
+#
+# This rule has been moved to PL2 because of false positives with German Umlaute and Russian letters
+#
+
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \xbc[^\xbe>]*[\xbe>]|<[^\xbe]*\xbe" \
+    "id:941310,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:lowercase,t:urlDecode,t:htmlEntityDecode,t:jsDecode,\
+    msg:'US-ASCII Malformed Encoding XSS Filter - Attack Detected',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-tomcat',\
+    tag:'attack-xss',\
+    tag:'paranoia-level/2',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/242',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'CRITICAL',\
+    setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 # Detect tags that are the most common direct HTML injection points.


### PR DESCRIPTION
This PR is a proposal for issue #1942. We can discuss there if this is the correct solution.
This PR moves rule 941310 from PL1 to PL2, because it has a lot of false positives with Russian letters and German Umlaute.