### PR TITLE
930110: make bare '..' without (back)slashes not trigger

### DIFF
--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -49,7 +49,11 @@ SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@r
 #
 # [ Decoded /../ Payloads ]
 #
-SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@rx (?:^|[\\/])\.\.(?:[\\/]|$)" \
+# To prevent '..' from triggering, the regexp is split into two parts:
+# - ../
+# - /..
+
+SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@rx (?:(?:^|[\\/])\.\.[\\/]|[\\/]\.\.(?:[\\/]|$))" \
     "id:930110,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930110.yaml
+++ b/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930110.yaml
@@ -98,3 +98,18 @@
               uri: "/..foo"
             output:
               no_log_contains: id "930110"
+    -
+      test_title: 930110-7
+      desc: "Path Traversal Attack (/../) query string"
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "localhost"
+              method: "GET"
+              port: 80
+              headers:
+                  Host: "localhost"
+              uri: ".."
+            output:
+              no_log_contains: id "930110"


### PR DESCRIPTION
Fixes a false positive reported in #2005.