### PR TITLE
Request header Sec-Fetch-User: Allow only booleans

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1540,9 +1540,12 @@ SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!RE
 # This is a stricter sibling of 920270.
 # The 'Sec-Fetch-User' header may contain the '?' (63) character.
 # Therefore we exclude this header from rule 920274 which forbids '?'.
+# However, as the header is a structured boolean, only be `?0`, or `?1`
+# are inconspicuous.
 # https://www.w3.org/TR/fetch-metadata/#http-headerdef-sec-fetch-user
+# https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-19#section-3.3.6
 #
-SecRule REQUEST_HEADERS:Sec-Fetch-User "@validateByteRange 32,34,38,42-59,61,63,65-90,95,97-122" \
+SecRule REQUEST_HEADERS:Sec-Fetch-User "!@rx ^(?:\?[01])?$" \
     "id:920275,\
     phase:1,\
     block,\


### PR DESCRIPTION
`Sec-Fetch-User` is specified [1] as Structure Header boolean [2] and
hence (if present) should only be `?0` or `?1` [2]. Other values are
suspicious. This also agrees with values seen in real-life traffic.

Hence, the broad `@validateByByteRange` was unnecessarily lenient, and
we make the rule more strict.

Fixes #2019

[1] https://www.w3.org/TR/fetch-metadata/#http-headerdef-sec-fetch-user
[2] https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-19#section-3.3.6