### PR TITLE
Fix Sec-CH-UA and Sec-CH-UA-Mobile request header validation

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1522,7 +1522,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteRange 38,44-46,48-58,61,65-90
 #
 # This is a stricter sibling of 920270.
 #
-SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!REQUEST_HEADERS:Cookie|!REQUEST_HEADERS:Sec-Fetch-User|!REQUEST_HEADERS:Sec-CH-UA|!REQUEST_HEADERS:Sec-CH-UA-Mobile "@validateByteRange 32,34,38,42-59,61,65-90,95,97-122" \
+SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!REQUEST_HEADERS:Cookie|!REQUEST_HEADERS:Sec-Fetch-User|!REQUEST_HEADERS:Sec-CH-UA-Mobile "@validateByteRange 32,34,38,42-59,61,65-90,95,97-122" \
     "id:920274,\
     phase:1,\
     block,\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1542,14 +1542,13 @@ SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!RE
 
 #
 # This is a stricter sibling of 920270.
-# The 'Sec-Fetch-User' header may contain the '?' (63) character.
-# Therefore we exclude this header from rule 920274 which forbids '?'.
-# However, as the header is a structured boolean, only be `?0`, or `?1`
-# are inconspicuous.
-# https://www.w3.org/TR/fetch-metadata/#http-headerdef-sec-fetch-user
-# https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-19#section-3.3.6
+# The headers of this rule are Structured Header booleans, for which only `?0`,
+# and `?1` are inconspicuous.
+# Structured Header boolean: https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-19#section-3.3.6
+# Sec-Fetch-User: https://www.w3.org/TR/fetch-metadata/#http-headerdef-sec-fetch-user
+# Sec-CH-UA-Mobile: https://wicg.github.io/ua-client-hints/#sec-ch-ua-mobile
 #
-SecRule REQUEST_HEADERS:Sec-Fetch-User "!@rx ^(?:\?[01])?$" \
+SecRule REQUEST_HEADERS:Sec-Fetch-User|REQUEST_HEADERS:Sec-CH-UA-Mobile "!@rx ^(?:\?[01])?$" \
     "id:920275,\
     phase:1,\
     block,\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1522,7 +1522,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteRange 38,44-46,48-58,61,65-90
 #
 # This is a stricter sibling of 920270.
 #
-SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!REQUEST_HEADERS:Cookie|!REQUEST_HEADERS:Sec-Fetch-User|!REQUEST_HEADERS:sec-ch-ua|!REQUEST_HEADERS:sec-ch-ua-mobile "@validateByteRange 32,34,38,42-59,61,65-90,95,97-122" \
+SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!REQUEST_HEADERS:Cookie|!REQUEST_HEADERS:Sec-Fetch-User|!REQUEST_HEADERS:Sec-CH-UA|!REQUEST_HEADERS:Sec-CH-UA-Mobile "@validateByteRange 32,34,38,42-59,61,65-90,95,97-122" \
     "id:920274,\
     phase:1,\
     block,\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -488,12 +488,14 @@ SecRule REQUEST_URI|REQUEST_BODY "@rx \%u[fF]{2}[0-9a-fA-F]{2}" \
 #       ASCII 38,44-46,48-58,61,65-90,95,97-122
 #       A-Z a-z 0-9 = - _ . , : &
 #
-# 920274: PL4 : REQUEST_HEADERS without User-Agent, Referer and Cookie
+# 920274: PL4 : REQUEST_HEADERS without User-Agent, Referer, Cookie
+#               and Structured Header booleans
 #       ASCII 32,34,38,42-59,61,65-90,95,97-122
 #       A-Z a-z 0-9 = - _ . , : & " * + / SPACE
 #
 # REQUEST_URI and REQUEST_HEADERS User-Agent, Referer and Cookie are very hard
-# to restrict beyond the limits in 920272.
+# to restrict beyond the limits in 920272. Structured Header booleans are
+# validated separately in 920275.
 #
 # 920274 generally has few positives. However, it would detect rare attacks
 # on Accept request headers and friends.

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920274.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920274.yaml
@@ -83,3 +83,18 @@
                   Cookie: "ThisIsATest%60"
             output:
               no_log_contains: "id \"920274\""
+    -
+      test_title: 920274-6
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              uri: "/"
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Sec-CH-UA: "Test?"
+            output:
+              log_contains: "id \"920274\""

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920275.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920275.yaml
@@ -50,3 +50,48 @@
                   Sec-Fetch-User: "?1"
             output:
               no_log_contains: "id \"920275\""
+    -
+      test_title: 920275-4
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              uri: "/"
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Sec-CH-UA-Mobile: "foo"
+            output:
+                  log_contains: "id \"920275\""
+    -
+      test_title: 920275-5
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              uri: "/"
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Sec-CH-UA-Mobile: "?0"
+            output:
+              no_log_contains: "id \"920275\""
+    -
+      test_title: 920275-6
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              port: 80
+              uri: "/"
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Sec-CH-UA-Mobile: "?1"
+            output:
+              no_log_contains: "id \"920275\""


### PR DESCRIPTION
The `Sec-CH-UA` and `Sec-CH-UA-Mobile` request headers are currently excluded from rule 920274.

`Sec-CH-UA` should not be excluded at all, and `Sec-CH-UA-Mobile` should get validated as Structured Header boolean.

Fixes #2027.