### PR TITLE
fix(test): verify that test encoded works in py2 also

### DIFF
--- a/tests/regression/tests/REQUEST-944-APPLICATION-ATTACK-JAVA/944200.yaml
+++ b/tests/regression/tests/REQUEST-944-APPLICATION-ATTACK-JAVA/944200.yaml
@@ -7,20 +7,6 @@
   tests:
 
     -
-      test_title: 944200-0FP
-      desc: Argument test includes java serialization magic bytes, raw request
-      stages:
-        -
-          stage:
-            input:
-              stop_magic: true
-              dest_addr: "127.0.0.1"
-              port: 80
-              raw_request: "POST / HTTP/1.0\r\nHost: localhost\r\nUser-Agent: ModSecurity CRS 3 Tests\r\nAccept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5\r\nAccept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7\r\nAccept-Encoding: gzip,deflate\r\nAccept-Language: en-us,en;q=0.5\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: 9\r\n\r\ntest=\xac\xed\x00\x05\r\n\r\n"
-            output:
-              no_log_contains: "id \"944200\""
-
-    -
       test_title: 944200-1
       desc: Argument test includes java serialization magic bytes, base64 encoded request
       stages:


### PR DESCRIPTION
Differences in how py2 and py3 handle bytes require we change this test for it to work properly for both

Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

This is only a draft for the purpose of running it in the pipeline in py2.