### PR TITLE
add httpx to scanners-user-agents

### DIFF
--- a/rules/scanners-user-agents.data
+++ b/rules/scanners-user-agents.data
@@ -78,6 +78,9 @@ grabber
 grendel-scan
 # sql injection
 havij
+# vuln scanner
+# https://github.com/projectdiscovery/httpx
+httpx - Open-source project
 # vuln scanner - path disclosure finder
 # http://seclists.org/fulldisclosure/2010/Sep/375
 inspath


### PR DESCRIPTION
Add [`httpx`](https://github.com/projectdiscovery/httpx) detection to scanners-user-agents list.

This is a relatively generic http tool. In practice it is used in conjunction with projectdiscovery/nuclei & subfinder for HTTP server, resource enumeration.

Default user-agent is `httpx - Open-source project (github.com/projectdiscovery/httpx)`:

https://github.com/projectdiscovery/httpx/blob/d7d906150c906a40583a6e9d8812254d50684160/common/httpx/option.go#L47

```
	DefaultUserAgent:         "httpx - Open-source project (github.com/projectdiscovery/httpx)",
```