### PR TITLE
Override modsec rule 200001

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -347,6 +347,19 @@ SecRule TX:enforce_bodyproc_urlencoded "@eq 1" \
 
 
 #
+# Set BodyProcessor to JSON
+# override ModSecurity default 200001
+#
+SecRule REQUEST_HEADERS:Content-Type "@rx ^application/(json|[a-z0-9.-]+[+.]json)$" \
+    "id:901360,\
+    phase:1,\
+    t:none,t:lowercase,\
+    pass,\
+    nolog,\
+    ctl:requestBodyProcessor=JSON"
+
+
+#
 # -=[ Easing In / Sampling Percentage ]=-
 #
 # This is used to send only a limited percentage of requests into the Core


### PR DESCRIPTION
referring to #1315 this rule override 200001 and set BodyProcessor to JSON in order to work as expected with the following CT:

https://regex101.com/r/3AvnWp/1
```
application/activity+json
application/alto-costmap+json
application/alto-costmapfilter+json
application/alto-directory+json
application/alto-endpointcost+json
application/alto-endpointcostparams+json
application/alto-endpointprop+json
application/alto-endpointpropparams+json
application/alto-error+json
application/alto-networkmap+json
application/alto-networkmapfilter+json
application/alto-updatestreamcontrol+json
application/alto-updatestreamparams+json
application/atsc-rdt+json
application/calendar+json
application/captive+json
application/coap-group+json
application/csvm+json
application/dicom+json
application/dns+json
application/elm+json
application/expect-ct-report+json
application/fhir+json
application/geo+json
application/jf2feed+json
application/jose+json
application/jrd+json
application/jscalendar+json
application/json
application/json-patch+json
application/jwk+json
application/jwk-set+json
application/ld+json
application/merge-patch+json
application/mud+json
application/ppsp-tracker+json
application/problem+json
application/pvd+json
application/rdap+json
application/reputon+json
application/sarif+json
application/scim+json
application/senml+json
application/senml-etch+json
application/sensml+json
application/stix+json
application/taxii+json
application/td+json
application/tlsrpt+json
application/vcard+json
application/vnd.amadeus+json
application/vnd.apache.thrift.json
application/vnd.api+json
application/vnd.aplextor.warrp+json
application/vnd.apothekende.reservation+json
application/vnd.artisan+json
application/vnd.avalon+json
application/vnd.bbf.usp.msg+json
application/vnd.bekitzur-stech+json
application/vnd.byu.uapi+json
application/vnd.capasystems-pg+json
application/vnd.collection+json
application/vnd.collection.doc+json
application/vnd.collection.next+json
application/vnd.coreos.ignition+json
application/vnd.cryptii.pipe+json
application/vnd.cyclonedx+json
application/vnd.datapackage+json
application/vnd.dataresource+json
application/vnd.document+json
application/vnd.drive+json
application/vnd.futoin+json
application/vnd.gentics.grd+json
application/vnd.geo+json
application/vnd.hal+json
application/vnd.hc+json
application/vnd.heroku+json
application/vnd.hyper+json
application/vnd.hyper-item+json
application/vnd.hyperdrive+json
application/vnd.ims.lis.v2.result+json
application/vnd.ims.lti.v2.toolconsumerprofile+json
application/vnd.ims.lti.v2.toolproxy+json
application/vnd.ims.lti.v2.toolproxy.id+json
application/vnd.ims.lti.v2.toolsettings+json
application/vnd.ims.lti.v2.toolsettings.simple+json
application/vnd.las.las+json
application/vnd.leap+json
application/vnd.mason+json
application/vnd.micro+json
application/vnd.miele+json
application/vnd.nearst.inv+json
application/vnd.oci.image.manifest.v1+json
application/vnd.oftn.l10n+json
application/vnd.oma.lwm2m+json
application/vnd.oracle.resource+json
application/vnd.pagerduty+json
application/vnd.restful+json
application/vnd.seis+json
application/vnd.shootproof+json
application/vnd.shopkick+json
application/vnd.siren+json
application/vnd.tableschema+json
application/vnd.think-cell.ppttc+json
application/vnd.vel+json
application/vnd.xacml+json
application/voucher-cms+json
application/webpush-options+json
application/yang-data+json
application/yang-patch+json
application/hal+json
```