### PR TITLE
932200 Linux RCE evasion with (more) uninitialized bash parameters

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -650,7 +650,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #
 # Regex notes: https://regex101.com/r/JgZFRi/7
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:[*?`\\'][^/\n]+/|\$[({\[#@!a-zA-Z0-9]|/[^/]+?[*?`\\'])" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:[*?`\\'][^/\n]+/|\$[({\[#@!?*\-_$a-zA-Z0-9]|/[^/]+?[*?`\\'])" \
     "id:932200,\
     phase:2,\
     block,\


### PR DESCRIPTION
This PR enhances the anti-evasion protection for uninitialized variables provided by rule 932200. Following example payloads will additionally be blocked:

```c$@at /et$@c/pas$@swd```
```c$!at /et$!c/pas$!swd```
```c$*at /et$*c/pas$*swd```
```c$?at /et$?c/pas$?swd```
```c$-at /et$-c/pas$-swd```
```c$_at /et$_c/pas$_swd```
```c$$at /et$$c/pas$$swd```

A full list of special bash parameters can be found in the [bash reference](https://www.gnu.org/software/bash/manual/html_node/Special-Parameters.html)

These parameters might be uninitialized - and as a consequence are translated into empty strings by bash - depending on the system and how RCE was achieved. I was able to find all listed parameters uninitialized, with the exception of ```$#``` (which is already implemented), ```$_``` and ```$$```, but I recommend to add them as precaution. I expect them to produce much less FPs than some of the already implemented variables such as ```$1```.