### PR TITLE
Fix FP in rule 942190 with keyword UNION

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -178,7 +178,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # to the Regexp::Assemble output:
 #   (?i:ASSEMBLE_OUTPUT)
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:[\"'`](?:;?\s*?(?:union\s*?(?:(?:distin|sele)ct|all)|having|select)\b\s*?[^\s]|\s*?!\s*?[\"'`\w])|(?:c(?:onnection_id|urrent_user)|database)\s*?\([^\)]*?|u(?:nion(?:[\w(\s]*?select| select @)|ser\s*?\([^\)]*?)|s(?:chema\s*?\([^\)]*?|elect.*?\w?user\()|into[\s+]+(?:dump|out)file\s*?[\"'`]|\s*?exec(?:ute)?.*?\Wxp_cmdshell|from\W+information_schema\W|exec(?:ute)?\s+master\.|\wiif\s*?\())" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:[\"'`](?:;?\s*?(?:union\b\s*?(?:(?:distin|sele)ct|all)|having|select)\b\s*?[^\s]|\s*?!\s*?[\"'`\w])|(?:c(?:onnection_id|urrent_user)|database)\s*?\([^\)]*?|u(?:nion(?:[\w(\s]*?select| select @)|ser\s*?\([^\)]*?)|s(?:chema\s*?\([^\)]*?|elect.*?\w?user\()|into[\s+]+(?:dump|out)file\s*?[\"'`]|\s*?exec(?:ute)?.*?\Wxp_cmdshell|from\W+information_schema\W|exec(?:ute)?\s+master\.|\wiif\s*?\())" \
     "id:942190,\
     phase:2,\
     block,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -178,7 +178,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # to the Regexp::Assemble output:
 #   (?i:ASSEMBLE_OUTPUT)
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:[\"'`](?:;?\s*?(?:having|select|union)\b\s*?[^\s]|\s*?!\s*?[\"'`\w])|(?:c(?:onnection_id|urrent_user)|database)\s*?\([^\)]*?|u(?:nion(?:[\w(\s]*?select| select @)|ser\s*?\([^\)]*?)|s(?:chema\s*?\([^\)]*?|elect.*?\w?user\()|into[\s+]+(?:dump|out)file\s*?[\"'`]|\s*?exec(?:ute)?.*?\Wxp_cmdshell|from\W+information_schema\W|exec(?:ute)?\s+master\.|\wiif\s*?\())" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:[\"'`](?:;?\s*?(?:union\s*?(?:(?:distin|sele)ct|all)|having|select)\b\s*?[^\s]|\s*?!\s*?[\"'`\w])|(?:c(?:onnection_id|urrent_user)|database)\s*?\([^\)]*?|u(?:nion(?:[\w(\s]*?select| select @)|ser\s*?\([^\)]*?)|s(?:chema\s*?\([^\)]*?|elect.*?\w?user\()|into[\s+]+(?:dump|out)file\s*?[\"'`]|\s*?exec(?:ute)?.*?\Wxp_cmdshell|from\W+information_schema\W|exec(?:ute)?\s+master\.|\wiif\s*?\())" \
     "id:942190,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942190.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942190.yaml
@@ -670,4 +670,3 @@
           version: HTTP/1.0
         output:
           no_log_contains: id "942190"
-

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942190.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942190.yaml
@@ -1,6 +1,6 @@
 ---
   meta:
-    author: "Christian S.J. Peron, Christoph Hansen"
+    author: "Christian S.J. Peron, Christoph Hansen, Franziska Bühler"
     description: None
     enabled: true
     name: 942190.yaml
@@ -54,7 +54,7 @@
           method: POST
           port: 80
           uri: "/"
-          data: "%22+union+s%0A"
+          data: "%22+union+select%0A"
           version: HTTP/1.0
         output:
           log_contains: id "942190"
@@ -139,7 +139,7 @@
           method: POST
           port: 80
           uri: "/"
-          data: "%27union%2F%0A"
+          data: "%27union%20select%2F%0A"
           version: HTTP/1.0
         output:
           log_contains: id "942190"
@@ -513,7 +513,7 @@
           method: POST
           port: 80
           uri: "/"
-          data: "%22+UNION+A%0A"
+          data: "%22%20UNION%20ALL%20SELECT%0A"
           version: HTTP/1.0
         output:
           log_contains: id "942190"
@@ -653,3 +653,21 @@
           version: HTTP/1.0
         output:
           log_contains: id "942190"
+  -
+    test_title: 942190-39
+    desc: "False positive UNION #2047"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+          method: GET
+          port: 80
+          uri: "/"
+          data: "arg=Die%20%22Union%20von%20Europa%22"
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "942190"
+

--- a/util/regexp-assemble/regexp-942190.data
+++ b/util/regexp-assemble/regexp-942190.data
@@ -1,9 +1,9 @@
 [\"'`]\s*?!\s*?[\"'`\w]
 [\"'`];?\s*?having\b\s*?[^\s]
 [\"'`];?\s*?select\b\s*?[^\s]
-[\"'`];?\s*?union\s*?all\b\s*?[^\s]
-[\"'`];?\s*?union\s*?distinct\b\s*?[^\s]
-[\"'`];?\s*?union\s*?select\b\s*?[^\s]
+[\"'`];?\s*?union\b\s*?all\b\s*?[^\s]
+[\"'`];?\s*?union\b\s*?distinct\b\s*?[^\s]
+[\"'`];?\s*?union\b\s*?select\b\s*?[^\s]
 \s*?exec.*?\Wxp_cmdshell
 \s*?execute.*?\Wxp_cmdshell
 \wiif\s*?\(

--- a/util/regexp-assemble/regexp-942190.data
+++ b/util/regexp-assemble/regexp-942190.data
@@ -1,7 +1,9 @@
 [\"'`]\s*?!\s*?[\"'`\w]
 [\"'`];?\s*?having\b\s*?[^\s]
 [\"'`];?\s*?select\b\s*?[^\s]
-[\"'`];?\s*?union\b\s*?[^\s]
+[\"'`];?\s*?union\s*?all\b\s*?[^\s]
+[\"'`];?\s*?union\s*?distinct\b\s*?[^\s]
+[\"'`];?\s*?union\s*?select\b\s*?[^\s]
 \s*?exec.*?\Wxp_cmdshell
 \s*?execute.*?\Wxp_cmdshell
 \wiif\s*?\(


### PR DESCRIPTION
This PR fixes issue #2047 (False Positive with "Union von" rule id 942190) by extending the keyword `union`.
`Union` alone does not make sense. But it makes sense when a `distinct`, `all` or `select` follows the `union`.

We already fixed a similar FP in rule 942360 in 2018 in this [commit here](https://github.com/coreruleset/coreruleset/commit/6c5f4550f874f66b4b3d9d0222336cfbf4b26a23#diff-ca2e05f6521d61919bf1d74d07d511cd1ccef6bdf553103cac21c0d757979044R132).

I also fixed some tests. They did no longer match, because I extended the regular expression in the rule. 
And I added a new test, that tests if the reported FP is gone.