### PR TITLE
Proposal for a new plugin: Machine Learning on ModSecurity

### DIFF
--- a/rules/REQUEST-949-BLOCKING-EVALUATION.conf
+++ b/rules/REQUEST-949-BLOCKING-EVALUATION.conf
@@ -147,7 +147,9 @@ SecRule TX:ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
     tag:'attack-generic',\
     ver:'OWASP_CRS/3.3.0',\
     severity:'CRITICAL',\
-    setvar:'tx.inbound_anomaly_score=%{tx.anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score=%{tx.anomaly_score}', \
+    chain"
+    SecRuleScript client.lua
 
 SecRule TX:BLOCKING_EARLY "@eq 1" \
     "id:949111,\

--- a/rules/client.lua
+++ b/rules/client.lua
@@ -1,0 +1,54 @@
+-- client.lua
+local ltn12 = require("ltn12")
+local http = require("socket.http")
+
+local url = 'http://ml-server-name:5000/'
+function main()
+  local method = m.getvar("REQUEST_METHOD")
+  local path = m.getvar("REQUEST_FILENAME")
+  local hour = m.getvar("TIME_HOUR")
+  local day = m.getvar("TIME_DAY")
+  local args = m.getvars("ARGS")
+  local args_str = "{}"
+  -- transform the args array into a string following JSON format
+  if args ~= nil then
+    args_str = "{"
+    for k,v in pairs(args) do
+      name = v["name"]
+      value = v["value"]
+      value = value:gsub('"', "$#$")
+      args_str = args_str..'"'..name..'":"'..value..'",'
+    end
+    if #args == 0 then
+      args_str = "{}"
+    else
+      args_str = string.sub(args_str, 1, -2)
+      args_str = args_str.."}"
+    end
+  end
+  -- construct http request for the ml server
+  local body = "method="..method.."&path="..path.."&args="..args_str.."&hour="..hour.."&day="..day
+  local headers = {
+    ["Content-Type"] = "application/x-www-form-urlencoded";
+    ["Content-Length"] = #body
+  }
+  local source = ltn12.source.string(body)
+
+  local client, code, headers, status = http.request{
+    url=url,
+    method='POST',
+    source=source,
+    headers=headers
+  }
+  if client == nil then
+    m.log(4, 'The server is unreachable \n')
+    return
+  end
+  if code == 200 then
+    return nil
+  end
+  if code == 401 then
+    return "Anomaly found"
+  end
+  m.log(4, status, '\n')
+end


### PR DESCRIPTION
This PR is a proposal for a plugin to ease the integration of Machine Learning (ML) in ModSecurity.

### How it works
The core idea is to use ML in combination with the CRS, by having a double-check on suspicious requests. For this reason, ML is triggered only for requests for which the anomaly score exceeds the threshold. This is performed by chaining rule 949110 with a "ML rule".

The "ML rule" is a Lua script calling the ML model running on a server in an external container/pod. This obviously adds latency due to communication overhead but has the advantage of only loading and instantiating the ML model once at server start and not for each incoming request. 

Attached is an example of a server running the ML model that can be reached by the Lua script. It uses the Flask library, definitely not the fastest option. 
[dummy_app.txt](https://github.com/coreruleset/coreruleset/files/6440177/dummy_app.txt)

### What needs to be discussed
I'd be glad to discuss the following (and any other suggestion you may have) with you:

- With this framework, the anomaly score is set but can be ignored if ML decides not to block the request...can bring confusion in the logs
- This framework is for the case where we would like to call ML for suspicious requests only. Maybe we would like something more general?
- Is there a way and would it be interesting to parallelize the ML and CRS execution?
