### PR TITLE
Detect JavaScript prototype pollution injection attempts

### DIFF
--- a/rules/REQUEST-934-APPLICATION-ATTACK-NODEJS.conf
+++ b/rules/REQUEST-934-APPLICATION-ATTACK-NODEJS.conf
@@ -68,6 +68,35 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
+# JavaScript prototype pollution injection attempts
+#
+# Example from https://hackerone.com/reports/869574 critical
+# vulnerability in the TypeORM library:
+# {"text":"a","title":{"__proto__":{"where":{"name":"sqlinjection","where":null}}}}
+
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@contains __proto__" \
+    "id:934110,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:urlDecodeUni,t:base64Decode,\
+    msg:'JavaScript Prototype Pollution',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-javascript',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
+    tag:'attack-injection-nodejs',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/242',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.3.0',\
+    severity:'CRITICAL',\
+    multiMatch,\
+    setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:934013,phase:1,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-NODEJS"
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:934014,phase:2,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-NODEJS"


### PR DESCRIPTION
Block payloads containing `__proto__`, which are used in JavaScript prototype pollution attacks.

Attackers can send specially crafted JSON objects, which have side effects in the application. An example is the TypeORM library https://hackerone.com/reports/869574 where SQL injection is possible using prototype pollution. When cleverly searching for necessary gadgets, it can also lead to RCE.

Therefore the presence of `__proto__` is suspect, and I think we can trigger on it without much risk of false positives.