### PR TITLE
Remove statement that is confusing in this context

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -112,8 +112,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # [ Rule Logic ]
 # These rules look for Carriage Return (CR) %0d and Linefeed (LF) %0a characters,
 # on their own or in combination with header field names.
-# These characters may cause problems if the data is returned in a response header
-# and interpreted by the client.
 # The rules are similar to rules defending against the HTTP Request Splitting and
 # Request Smuggling rules.
 #


### PR DESCRIPTION
In this context we seem to talk about requests, not responses. Thus, this statement feels out of place and can be confusing.