### PR TITLE
fix(tests): use only valid yaml in tests

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,9 +14,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Lint Yaml
-        uses: ibiqlik/action-yamllint@v1
+        uses: ibiqlik/action-yamllint@v3
         with:
-          file_or_dir: tests/regression/tests/**/*.yaml
+          format: github
+          file_or_dir: tests/regression/tests
           config_file: .yamllint.yml
 
       - name: Linelint

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920100.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920100.yaml
@@ -41,7 +41,7 @@
               uri: "/"
               version: "HTTP/1.1"
             output:
-              status: 400
+              status: [400]
     -
       # Perfectly valid OPTIONS request
       test_title: 920100-3
@@ -95,7 +95,7 @@
               uri: "www.cnn.com"
               version: "HTTP/1.1"
             output:
-              status: 400
+              status: [400]
     -
       # This is an acceptable CONNECT request for SSL tunneling
       test_title: 920100-6
@@ -226,7 +226,7 @@
             uri: /
             version: HTTP/1.1
           output:
-            status: 400
+            status: [400]
     -
       test_title: 920100-13
       desc: Invalid HTTP Request Line (920100) - Test 2 from old modsec regressions

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920120.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920120.yaml
@@ -22,13 +22,13 @@
                   Connection: "close"
                   Referer: "http://localhost/"
                   Content-Type: "multipart/form-data; boundary=--------397236876"
-              data:
-                - "----------397236876"
-                - "Content-Disposition: form-data; name=\"fileRap\"; filename=\"file=.txt\""
-                - "Content-Type: text/plain"
-                - ""
-                - "555-555-0199@example.com"
-                - "----------397236876--"
+              data: |
+                ----------397236876
+                Content-Disposition: form-data; name="fileRap"; filename="file=.txt"
+                Content-Type: text/plain
+
+                555-555-0199@example.com
+                ----------397236876--
               protocol: "http"
             output:
               log_contains: "id \"920120\""
@@ -55,18 +55,18 @@
             port: 80
             uri: /cgi-bin/fup.cgi
             version: HTTP/1.1
-            data:
-            - '-----------------------------627652292512397580456702590'
-            - 'Content-Disposition: form-data; name="fi=le"; filename="test"'
-            - 'Content-Type: text/plain'
-            - ''
-            - 'email: security@modsecurity.org'
-            - ''
-            - '-----------------------------627652292512397580456702590'
-            - 'Content-Disposition: form-data; name="note"'
-            - ''
-            - Contact info.
-            - '-----------------------------627652292512397580456702590--'
+            data: |
+              -----------------------------627652292512397580456702590
+              Content-Disposition: form-data; name="fi=le"; filename="test"
+              Content-Type: text/plain
+
+              email: security@modsecurity.org
+
+              -----------------------------627652292512397580456702590
+              Content-Disposition: form-data; name="note"
+
+              Contact info.
+              -----------------------------627652292512397580456702590--
           output:
             log_contains: id "920120"
     -
@@ -91,22 +91,22 @@
             port: 80
             uri: /
             version: HTTP/1.1
-            data:
-            - '-----------------------------265001916915724'
-            - 'Content-Disposition: form-data; name="fi;le"; filename="test"'
-            - 'Content-Type: application/octet-stream'
-            - ''
-            - Rotem & Ayala
-            - ''
-            - '-----------------------------265001916915724'
-            - 'Content-Disposition: form-data; name="name"'
-            - ''
-            - tt2
-            - '-----------------------------265001916915724'
-            - 'Content-Disposition: form-data; name="B1"'
-            - ''
-            - Submit
-            - '-----------------------------265001916915724--'
+            data: |
+              -----------------------------265001916915724
+              Content-Disposition: form-data; name="fi;le"; filename="test"
+              Content-Type: application/octet-stream
+
+              Rotem & Ayala
+
+              -----------------------------265001916915724
+              Content-Disposition: form-data; name="name"
+
+              tt2
+              -----------------------------265001916915724
+              Content-Disposition: form-data; name="B1"
+
+              Submit
+              -----------------------------265001916915724--
           output:
             log_contains: id "920120"
     -
@@ -124,13 +124,13 @@
             method: POST
             port: 80
             uri: /
-            data:
-            - '-----------------------------265001916915724'
-            - 'Content-Disposition: form-data; name="file"; filename="test"'
-            - 'Content-Type: application/octet-stream'
-            - ''
-            - 'helloworld'
-            - '-----------------------------265001916915724--'
+            data: |
+              -----------------------------265001916915724
+              Content-Disposition: form-data; name="file"; filename="test"
+              Content-Type: application/octet-stream
+
+              helloworld
+              -----------------------------265001916915724--
           output:
             no_log_contains: id "920120"
     -
@@ -148,13 +148,13 @@
             method: POST
             port: 80
             uri: /
-            data:
-            - '-----------------------------265001916915724'
-            - 'Content-Disposition: form-data; name=";zzzz"; filename="test"'
-            - 'Content-Type: application/octet-stream'
-            - ''
-            - 'helloworld'
-            - '-----------------------------265001916915724--'
+            data: |
+              -----------------------------265001916915724
+              Content-Disposition: form-data; name=";zzzz"; filename="test"
+              Content-Type: application/octet-stream
+
+              helloworld
+              -----------------------------265001916915724--
           output:
             log_contains: id "920120"
     -
@@ -172,13 +172,13 @@
             method: POST
             port: 80
             uri: /
-            data:
-            - '-----------------------------265001916915724'
-            - 'Content-Disposition: form-data; name="zzz&amp;zzz"; filename="test"'
-            - 'Content-Type: application/octet-stream'
-            - ''
-            - 'helloworld'
-            - '-----------------------------265001916915724--'
+            data: |
+              -----------------------------265001916915724
+              Content-Disposition: form-data; name="zzz&amp;zzz"; filename="test"
+              Content-Type: application/octet-stream
+
+              helloworld
+              -----------------------------265001916915724--
           output:
             no_log_contains: id "920120"
     -
@@ -196,13 +196,13 @@
             method: POST
             port: 80
             uri: /
-            data:
-            - '-----------------------------265001916915724'
-            - 'Content-Disposition: form-data; name="zzz&Auml;zzz"; filename="test"'
-            - 'Content-Type: application/octet-stream'
-            - ''
-            - 'helloworld'
-            - '-----------------------------265001916915724--'
+            data: |
+              -----------------------------265001916915724
+              Content-Disposition: form-data; name="zzz&Auml;zzz"; filename="test"
+              Content-Type: application/octet-stream
+
+              helloworld
+              -----------------------------265001916915724--
           output:
             no_log_contains: id "920120"
     -
@@ -220,13 +220,13 @@
             method: POST
             port: 80
             uri: /
-            data:
-            - '-----------------------------265001916915724'
-            - 'Content-Disposition: form-data; name="zzz&auml;zzz"; filename="test"'
-            - 'Content-Type: application/octet-stream'
-            - ''
-            - 'helloworld'
-            - '-----------------------------265001916915724--'
+            data: |
+              -----------------------------265001916915724
+              Content-Disposition: form-data; name="zzz&auml;zzz"; filename="test"
+              Content-Type: application/octet-stream
+
+              helloworld
+              -----------------------------265001916915724--
           output:
             no_log_contains: id "920120"
     -
@@ -244,13 +244,13 @@
             method: POST
             port: 80
             uri: /
-            data:
-            - '-----------------------------265001916915724'
-            - 'Content-Disposition: form-data; name="&amp;zzz"; filename="test"'
-            - 'Content-Type: application/octet-stream'
-            - ''
-            - 'helloworld'
-            - '-----------------------------265001916915724--'
+            data: |
+              -----------------------------265001916915724
+              Content-Disposition: form-data; name="&amp;zzz"; filename="test"
+              Content-Type: application/octet-stream
+
+              helloworld
+              -----------------------------265001916915724--
           output:
             no_log_contains: id "920120"
     -
@@ -268,13 +268,13 @@
             method: POST
             port: 80
             uri: /
-            data:
-            - '-----------------------------265001916915724'
-            - 'Content-Disposition: form-data; name="amp;zzz"; filename="test"'
-            - 'Content-Type: application/octet-stream'
-            - ''
-            - 'helloworld'
-            - '-----------------------------265001916915724--'
+            data: |
+              -----------------------------265001916915724
+              Content-Disposition: form-data; name="amp;zzz"; filename="test"
+              Content-Type: application/octet-stream
+
+              helloworld
+              -----------------------------265001916915724--
           output:
             log_contains: id "920120"
     -
@@ -292,13 +292,13 @@
             method: POST
             port: 80
             uri: /
-            data:
-            - '-----------------------------265001916915724'
-            - 'Content-Disposition: form-data; name="mp;zzz"; filename="test"'
-            - 'Content-Type: application/octet-stream'
-            - ''
-            - 'helloworld'
-            - '-----------------------------265001916915724--'
+            data: |
+              -----------------------------265001916915724
+              Content-Disposition: form-data; name="mp;zzz"; filename="test"
+              Content-Type: application/octet-stream
+
+              helloworld
+              -----------------------------265001916915724--
           output:
             log_contains: id "920120"
     -
@@ -316,13 +316,13 @@
             method: POST
             port: 80
             uri: /
-            data:
-            - '-----------------------------265001916915724'
-            - 'Content-Disposition: form-data; name="p;zzz"; filename="test"'
-            - 'Content-Type: application/octet-stream'
-            - ''
-            - 'helloworld'
-            - '-----------------------------265001916915724--'
+            data: |
+              -----------------------------265001916915724
+              Content-Disposition: form-data; name="p;zzz"; filename="test"
+              Content-Type: application/octet-stream
+
+              helloworld
+              -----------------------------265001916915724--
           output:
             log_contains: id "920120"
     -
@@ -340,13 +340,13 @@
             method: POST
             port: 80
             uri: /
-            data:
-            - '-----------------------------265001916915724'
-            - 'Content-Disposition: form-data; name="Zamp;zzz"; filename="test"'
-            - 'Content-Type: application/octet-stream'
-            - ''
-            - 'helloworld'
-            - '-----------------------------265001916915724--'
+            data: |
+              -----------------------------265001916915724
+              Content-Disposition: form-data; name="Zamp;zzz"; filename="test"
+              Content-Type: application/octet-stream
+
+              helloworld
+              -----------------------------265001916915724--
           output:
             log_contains: id "920120"
     -
@@ -364,13 +364,13 @@
             method: POST
             port: 80
             uri: /
-            data:
-            - '-----------------------------265001916915724'
-            - 'Content-Disposition: form-data; name="Zmp;zzz"; filename="test"'
-            - 'Content-Type: application/octet-stream'
-            - ''
-            - 'helloworld'
-            - '-----------------------------265001916915724--'
+            data: |
+              -----------------------------265001916915724
+              Content-Disposition: form-data; name="Zmp;zzz"; filename="test"
+              Content-Type: application/octet-stream
+
+              helloworld
+              -----------------------------265001916915724--
           output:
             log_contains: id "920120"
     -
@@ -388,13 +388,13 @@
             method: POST
             port: 80
             uri: /
-            data:
-            - '-----------------------------265001916915724'
-            - 'Content-Disposition: form-data; name="Zp;zzz"; filename="test"'
-            - 'Content-Type: application/octet-stream'
-            - ''
-            - 'helloworld'
-            - '-----------------------------265001916915724--'
+            data: |
+              -----------------------------265001916915724
+              Content-Disposition: form-data; name="Zp;zzz"; filename="test"
+              Content-Type: application/octet-stream
+
+              helloworld
+              -----------------------------265001916915724--
           output:
             log_contains: id "920120"
     -
@@ -412,13 +412,13 @@
             method: POST
             port: 80
             uri: /
-            data:
-            - '-----------------------------265001916915724'
-            - 'Content-Disposition: form-data; name="Z;zzz"; filename="test"'
-            - 'Content-Type: application/octet-stream'
-            - ''
-            - 'helloworld'
-            - '-----------------------------265001916915724--'
+            data: |
+              -----------------------------265001916915724
+              Content-Disposition: form-data; name="Z;zzz"; filename="test"
+              Content-Type: application/octet-stream
+
+              helloworld
+              -----------------------------265001916915724--
           output:
             log_contains: id "920120"
     -
@@ -436,13 +436,13 @@
             method: POST
             port: 80
             uri: /
-            data:
-            - '-----------------------------265001916915724'
-            - 'Content-Disposition: form-data; name="ZZZamp;zzz"; filename="test"'
-            - 'Content-Type: application/octet-stream'
-            - ''
-            - 'helloworld'
-            - '-----------------------------265001916915724--'
+            data: |
+              -----------------------------265001916915724
+              Content-Disposition: form-data; name="ZZZamp;zzz"; filename="test"
+              Content-Type: application/octet-stream
+
+              helloworld
+              -----------------------------265001916915724--
           output:
             log_contains: id "920120"
     -
@@ -460,13 +460,13 @@
             method: POST
             port: 80
             uri: /
-            data:
-            - '-----------------------------265001916915724'
-            - 'Content-Disposition: form-data; name="ZZZmp;zzz"; filename="test"'
-            - 'Content-Type: application/octet-stream'
-            - ''
-            - 'helloworld'
-            - '-----------------------------265001916915724--'
+            data: |
+              -----------------------------265001916915724
+              Content-Disposition: form-data; name="ZZZmp;zzz"; filename="test"
+              Content-Type: application/octet-stream
+
+              helloworld
+              -----------------------------265001916915724--
           output:
             log_contains: id "920120"
     -
@@ -484,13 +484,13 @@
             method: POST
             port: 80
             uri: /
-            data:
-            - '-----------------------------265001916915724'
-            - 'Content-Disposition: form-data; name="ZZZp;zzz"; filename="test"'
-            - 'Content-Type: application/octet-stream'
-            - ''
-            - 'helloworld'
-            - '-----------------------------265001916915724--'
+            data: |
+              -----------------------------265001916915724
+              Content-Disposition: form-data; name="ZZZp;zzz"; filename="test"
+              Content-Type: application/octet-stream
+
+              helloworld
+              -----------------------------265001916915724--
           output:
             log_contains: id "920120"
     -
@@ -508,13 +508,13 @@
             method: POST
             port: 80
             uri: /
-            data:
-            - '-----------------------------265001916915724'
-            - 'Content-Disposition: form-data; name="ZZZ;zzz"; filename="test"'
-            - 'Content-Type: application/octet-stream'
-            - ''
-            - 'helloworld'
-            - '-----------------------------265001916915724--'
+            data: |
+              -----------------------------265001916915724
+              Content-Disposition: form-data; name="ZZZ;zzz"; filename="test"
+              Content-Type: application/octet-stream
+
+              helloworld
+              -----------------------------265001916915724--
           output:
             log_contains: id "920120"
     -
@@ -532,12 +532,12 @@
             method: POST
             port: 80
             uri: /
-            data:
-            - '-----------------------------265001916915724'
-            - 'Content-Disposition: form-data; name="mZ;zzz"; filename="test"'
-            - 'Content-Type: application/octet-stream'
-            - ''
-            - 'helloworld'
-            - '-----------------------------265001916915724--'
+            data: |
+              -----------------------------265001916915724
+              Content-Disposition: form-data; name="mZ;zzz"; filename="test"
+              Content-Type: application/octet-stream
+
+              helloworld
+              -----------------------------265001916915724--
           output:
             log_contains: id "920120"

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920160.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920160.yaml
@@ -22,7 +22,7 @@
               protocol: "http"
               uri: "/"
             output:
-              status: 400
+              status: [400]
     -
       # Non digit content-length with content-type
       test_title: 920160-2
@@ -41,7 +41,7 @@
               protocol: "http"
               uri: "/"
             output:
-              status: 400
+              status: [400]
     -
       # Mixed digit and non digit content length
       test_title: 920160-3
@@ -60,7 +60,7 @@
               protocol: "http"
               uri: "/"
             output:
-              status: 400
+              status: [400]
     -
       # Test is based in httpbin.org, so backend returns 405 if you are not posting to /post
       # Apache auto corrects for this error now so the log should not contain anything
@@ -87,7 +87,7 @@
             version: HTTP/1.0
             data: abc
           output:
-            status: 200
+            status: [200]
             no_log_contains: id "920160"
     -
       test_title: 920160-5

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920181.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920181.yaml
@@ -22,12 +22,11 @@
                 Content-Type: "application/x-www-form-urlencoded"
                 Transfer-Encoding: "chunked"
                 User-Agent: "ModSecurity CRS 3 Tests"
-              data:
-                - "7"
-                - "foo=bar"
-                - "0"
-                - ""
-                - ""
+              data: |
+                7
+                foo=bar
+                0
+
               stop_magic: true
             output:
               # Apache unsets the Content-Length header if

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920240.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920240.yaml
@@ -77,15 +77,15 @@
                   Keep-Alive: "300"
                   Proxy-Connection: "keep-alive"
                   Content-Type: "text/xml"
-              data:
-                - "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\">"
-                - " <SOAP-ENV:Body>"
-                - "      <xkms:StatusRequest xmlns:xkms=\"http://www.w3.org/2002/03/xkms#\" Id=\"_6ee48478-fdd6-4d7d-b1bf-e7b4c3254659\" ResponseId=\"_c1c36b3f-f962-4aea-bfbd-07ed58468c9b\" Service=\"http://www.soapclient.com/xml/xkms2\">"
-                - "      <xkms:ResponseMechanism>http://www.w3.org/2002/03/xkms#Pending</xkms:ResponseMechanism>"
-                - "      <xkms:RespondWith>%1Gwww.attack.org</xkms:RespondWith>"
-                - "      </xkms:StatusRequest>"
-                - "  </SOAP-ENV:Body>"
-                - "</SOAP-ENV:Envelope>"
+              data: |
+                <SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\">
+                 <SOAP-ENV:Body>
+                      <xkms:StatusRequest xmlns:xkms=\"http://www.w3.org/2002/03/xkms#\" Id=\"_6ee48478-fdd6-4d7d-b1bf-e7b4c3254659\" ResponseId=\"_c1c36b3f-f962-4aea-bfbd-07ed58468c9b\" Service=\"http://www.soapclient.com/xml/xkms2\">
+                      <xkms:ResponseMechanism>http://www.w3.org/2002/03/xkms#Pending</xkms:ResponseMechanism>
+                      <xkms:RespondWith>%1Gwww.attack.org</xkms:RespondWith>
+                      </xkms:StatusRequest>
+                  </SOAP-ENV:Body>
+                </SOAP-ENV:Envelope>
             output:
               no_log_contains: "id \"920240\""
     -

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920280.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920280.yaml
@@ -44,4 +44,4 @@
                   User-Agent: "ModSecurity CRS 3 Tests"
             output:
               # Technically valid but Apache doesn't allow 0.9 anymore
-              status: 400
+              status: [400]

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920400.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920400.yaml
@@ -29,22 +29,22 @@
           port: 80
           uri: /
           version: HTTP/1.1
-          data:
-          - '-----------------------------265001916915724'
-          - 'Content-Disposition: form-data; name="file"; filename="test"'
-          - 'Content-Type: application/octet-stream'
-          - ''
-          - Rotem & Ayala
-          - ''
-          - '-----------------------------265001916915724'
-          - 'Content-Disposition: form-data; name="name"'
-          - ''
-          - tt2
-          - '-----------------------------265001916915724'
-          - 'Content-Disposition: form-data; name="B1"'
-          - ''
-          - Submit
-          - '-----------------------------265001916915724--'
+          data: |
+            -----------------------------265001916915724
+            Content-Disposition: form-data; name="file"; filename="test"
+            Content-Type: application/octet-stream
+
+            Rotem & Ayala
+
+            -----------------------------265001916915724
+            Content-Disposition: form-data; name="name"
+
+            tt2
+            -----------------------------265001916915724
+            Content-Disposition: form-data; name="B1"
+
+            Submit
+            -----------------------------265001916915724--
         output:
                 # Most web servers simply won't respond to invalid requests like
                 # like this they'll just time out when we get OR type checks

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920420.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920420.yaml
@@ -91,21 +91,21 @@
             port: 80
             uri: /
             version: HTTP/1.1
-            data:
-            - --0000
-            - 'Content-Disposition: form-data; name="name"'
-            - ''
-            - John Smith
-            - --0000
-            - 'Content-Disposition: form-data; name="email"'
-            - ''
-            - john.smith@example.com
-            - --0000
-            - 'Content-Disposition: form-data; name="image"; filename="image.jpg"'
-            - 'Content-Type: image/jpeg'
-            - ''
-            - BINARYDATA
-            - --0000--
+            data: |
+              --0000
+              Content-Disposition: form-data; name="name"
+
+              John Smith
+              --0000
+              Content-Disposition: form-data; name="email"
+
+              john.smith@example.com
+              --0000
+              Content-Disposition: form-data; name="image"; filename="image.jpg"
+              Content-Type: image/jpeg
+
+              BINARYDATA
+              --0000--
           output:
             log_contains: id "920420"
     -
@@ -130,21 +130,21 @@
             port: 80
             uri: /
             version: HTTP/1.1
-            data:
-            - --0000
-            - 'Content-Disposition: form-data; name="name"'
-            - ''
-            - John Smith
-            - --0000
-            - 'Content-Disposition: form-data; name="email"'
-            - ''
-            - john.smith@example.com
-            - --0000
-            - 'Content-Disposition: form-data; name="image"; filename="image.jpg"'
-            - 'Content-Type: image/jpeg'
-            - ''
-            - BINARYDATA
-            - --0000--
+            data: |
+              --0000
+              Content-Disposition: form-data; name="name"
+
+              John Smith
+              --0000
+              Content-Disposition: form-data; name="email"
+
+              john.smith@example.com
+              --0000
+              Content-Disposition: form-data; name="image"; filename="image.jpg"
+              Content-Type: image/jpeg
+
+              BINARYDATA
+              --0000--
           output:
             log_contains: id "920420"
     -
@@ -169,21 +169,21 @@
             port: 80
             uri: /
             version: HTTP/1.1
-            data:
-            - --0000
-            - 'Content-Disposition: form-data; name="name"'
-            - ''
-            - John Smith
-            - --0000
-            - 'Content-Disposition: form-data; name="email"'
-            - ''
-            - john.smith@example.com
-            - --0000
-            - 'Content-Disposition: form-data; name="image"; filename="image.jpg"'
-            - 'Content-Type: image/jpeg'
-            - ''
-            - BINARYDATA
-            - --0000--
+            data: |
+              --0000
+              Content-Disposition: form-data; name="name"
+
+              John Smith
+              --0000
+              Content-Disposition: form-data; name="email"
+
+              john.smith@example.com
+              --0000
+              Content-Disposition: form-data; name="image"; filename="image.jpg"
+              Content-Type: image/jpeg
+
+              BINARYDATA
+              --0000--
           output:
             log_contains: id "920420"
     -

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921140.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921140.yaml
@@ -20,7 +20,7 @@
                   SomeHeader: "Headerdata\rInjectedHeader: response_splitting_code"
               uri: "/"
             output:
-              status: 400
+              status: [400]
               no_log_contains: "id:921140"
     -
       test_title: 921140-2

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941110.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941110.yaml
@@ -104,8 +104,8 @@
               Accept: "*/*"
               User-Agent: ModSecurity CRS 3 Tests
               Content-Type: application/x-www-form-urlencoded
-            data:
-              - var=%uff1cscript%u0020%uff1ealert%281%29%uff1c/script%uff1e
+            data: |
+              var=%uff1cscript%u0020%uff1ealert%281%29%uff1c/script%uff1e
           output:
             log_contains: id "941110"
     -
@@ -124,8 +124,8 @@
               Accept: "*/*"
               User-Agent: ModSecurity CRS 3 Tests
               Content-Type: application/x-www-form-urlencoded
-            data:
-              - var=%ef%bc%9cscript%20%ef%bc%9ealert%281%29%ef%bc%9c/script%ef%bc%9e
+            data: |
+              var=%ef%bc%9cscript%20%ef%bc%9ealert%281%29%ef%bc%9c/script%ef%bc%9e
           output:
             log_contains: id "941110"
     -

--- a/tests/regression/tests/REQUEST-944-APPLICATION-ATTACK-JAVA/944120.yaml
+++ b/tests/regression/tests/REQUEST-944-APPLICATION-ATTACK-JAVA/944120.yaml
@@ -326,7 +326,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/json\r\n\r\n{\"ProcessBuilder.evil.clonetransformer\": \"test\"}\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/json
+
+                {"ProcessBuilder.evil.clonetransformer": "test"}
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
 
@@ -349,7 +355,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/json\r\n\r\n{\"ProcessBuilder.evil.clonetransformer\": \"test\"}\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/json
+
+                {"ProcessBuilder.evil.clonetransformer": "test"}
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
 
@@ -372,7 +384,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/xml\r\n\r\n<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.clonetransformer</element></xml>\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/xml
+
+                <?xml version="1.0"?><xml><element attribute_name="attribute_value">ProcessBuilder.evil.clonetransformer</element></xml>
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
 
@@ -395,7 +413,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/xml\r\n\r\n<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.clonetransformer</element></xml>\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/xml
+
+                <?xml version="1.0"?><xml><element attribute_name="attribute_value">ProcessBuilder.evil.clonetransformer</element></xml>
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
     -
@@ -719,7 +743,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/json\r\n\r\n{\"ProcessBuilder.evil.forclosure\": \"test\"}\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/json
+
+                {"ProcessBuilder.evil.forclosure": "test"}
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
 
@@ -742,7 +772,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/json\r\n\r\n{\"ProcessBuilder.evil.forclosure\": \"test\"}\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/json
+
+                {"ProcessBuilder.evil.forclosure": "test"}
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
 
@@ -765,7 +801,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/xml\r\n\r\n<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.forclosure</element></xml>\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/xml
+
+                <?xml version="1.0"?><xml><element attribute_name="attribute_value">ProcessBuilder.evil.forclosure</element></xml>
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
 
@@ -788,7 +830,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/xml\r\n\r\n<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.forclosure</element></xml>\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/xml
+
+                <?xml version="1.0"?><xml><element attribute_name="attribute_value">ProcessBuilder.evil.forclosure</element></xml>
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
     -
@@ -1112,7 +1160,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/json\r\n\r\n{\"ProcessBuilder.evil.instantiatefactory\": \"test\"}\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/json
+
+                {"ProcessBuilder.evil.instantiatefactory": "test"}
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
 
@@ -1135,7 +1189,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/json\r\n\r\n{\"ProcessBuilder.evil.instantiatefactory\": \"test\"}\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/json
+
+                {"ProcessBuilder.evil.instantiatefactory": "test"}
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
 
@@ -1158,7 +1218,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/xml\r\n\r\n<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.instantiatefactory</element></xml>\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/xml
+
+                <?xml version="1.0"?><xml><element attribute_name="attribute_value">ProcessBuilder.evil.instantiatefactory</element></xml>
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
 
@@ -1181,7 +1247,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/xml\r\n\r\n<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.instantiatefactory</element></xml>\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/xml
+
+                <?xml version="1.0"?><xml><element attribute_name="attribute_value">ProcessBuilder.evil.instantiatefactory</element></xml>
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
     -
@@ -1505,7 +1577,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/json\r\n\r\n{\"ProcessBuilder.evil.instantiatetransformer\": \"test\"}\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/json
+
+                {"ProcessBuilder.evil.instantiatetransformer": "test"}
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
 
@@ -1528,7 +1606,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/json\r\n\r\n{\"ProcessBuilder.evil.instantiatetransformer\": \"test\"}\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/json
+
+                {"ProcessBuilder.evil.instantiatetransformer": "test"}
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
 
@@ -1551,7 +1635,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/xml\r\n\r\n<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.instantiatetransformer</element></xml>\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/xml
+
+                <?xml version="1.0"?><xml><element attribute_name="attribute_value">ProcessBuilder.evil.instantiatetransformer</element></xml>
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
 
@@ -1574,7 +1664,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/xml\r\n\r\n<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.instantiatetransformer</element></xml>\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/xml
+
+                <?xml version="1.0"?><xml><element attribute_name="attribute_value">ProcessBuilder.evil.instantiatetransformer</element></xml>
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
     -
@@ -1898,7 +1994,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/json\r\n\r\n{\"ProcessBuilder.evil.invokertransformer\": \"test\"}\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/json
+
+                {"ProcessBuilder.evil.invokertransformer": "test"}
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
 
@@ -1921,7 +2023,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/json\r\n\r\n{\"ProcessBuilder.evil.invokertransformer\": \"test\"}\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/json
+
+                {"ProcessBuilder.evil.invokertransformer": "test"}
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
 
@@ -1944,7 +2052,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/xml\r\n\r\n<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.invokertransformer</element></xml>\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/xml
+
+                <?xml version="1.0"?><xml><element attribute_name="attribute_value">ProcessBuilder.evil.invokertransformer</element></xml>
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
 
@@ -1967,7 +2081,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/xml\r\n\r\n<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.invokertransformer</element></xml>\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/xml
+
+                <?xml version="1.0"?><xml><element attribute_name="attribute_value">ProcessBuilder.evil.invokertransformer</element></xml>
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
     -
@@ -2291,7 +2411,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/json\r\n\r\n{\"ProcessBuilder.evil.prototypeclonefactory\": \"test\"}\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/json
+
+                {"ProcessBuilder.evil.prototypeclonefactory": "test"}
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
 
@@ -2314,7 +2440,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/json\r\n\r\n{\"ProcessBuilder.evil.prototypeclonefactory\": \"test\"}\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/json
+
+                {"ProcessBuilder.evil.prototypeclonefactory": "test"}
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
 
@@ -2337,7 +2469,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/xml\r\n\r\n<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.prototypeclonefactory</element></xml>\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/xml
+
+                <?xml version="1.0"?><xml><element attribute_name="attribute_value">ProcessBuilder.evil.prototypeclonefactory</element></xml>
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
 
@@ -2360,7 +2498,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/xml\r\n\r\n<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.prototypeclonefactory</element></xml>\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/xml
+
+                <?xml version="1.0"?><xml><element attribute_name="attribute_value">ProcessBuilder.evil.prototypeclonefactory</element></xml>
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
     -
@@ -2684,7 +2828,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/json\r\n\r\n{\"ProcessBuilder.evil.prototypeserializationfactory\": \"test\"}\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/json
+
+                {"ProcessBuilder.evil.prototypeserializationfactory": "test"}
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
 
@@ -2707,7 +2857,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/json\r\n\r\n{\"ProcessBuilder.evil.prototypeserializationfactory\": \"test\"}\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/json
+
+                {"ProcessBuilder.evil.prototypeserializationfactory": "test"}
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
 
@@ -2730,7 +2886,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/xml\r\n\r\n<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.prototypeserializationfactory</element></xml>\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/xml
+
+                <?xml version="1.0"?><xml><element attribute_name="attribute_value">ProcessBuilder.evil.prototypeserializationfactory</element></xml>
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
 
@@ -2753,7 +2915,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/xml\r\n\r\n<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.prototypeserializationfactory</element></xml>\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/xml
+
+                <?xml version="1.0"?><xml><element attribute_name="attribute_value">ProcessBuilder.evil.prototypeserializationfactory</element></xml>
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
     -
@@ -3031,7 +3199,8 @@
                 Content-Type: "application/json"
               method: "POST"
               version: "HTTP/1.0"
-              data: "{\"test\": \"ProcessBuilder.evil.whileclosure\"}"
+              data: |
+                {"test": "ProcessBuilder.evil.whileclosure"}
             output:
               log_contains: "id \"944120\""
 
@@ -3054,7 +3223,8 @@
                 Content-Type: "application/json"
               method: "POST"
               version: "HTTP/1.0"
-              data: "{\"ProcessBuilder.evil.whileclosure\": \"test\"}"
+              data: |
+                {"ProcessBuilder.evil.whileclosure": "test"}
             output:
               log_contains: "id \"944120\""
 
@@ -3077,7 +3247,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/json\r\n\r\n{\"ProcessBuilder.evil.whileclosure\": \"test\"}\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/json
+
+                {"ProcessBuilder.evil.whileclosure": "test"}
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
 
@@ -3100,7 +3276,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/json\r\n\r\n{\"ProcessBuilder.evil.whileclosure\": \"test\"}\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/json
+
+                {"ProcessBuilder.evil.whileclosure": "test"}
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
 
@@ -3123,7 +3305,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/xml\r\n\r\n<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.whileclosure</element></xml>\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/xml
+
+                <?xml version="1.0"?><xml><element attribute_name="attribute_value">ProcessBuilder.evil.whileclosure</element></xml>
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""
 
@@ -3146,6 +3334,12 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/xml\r\n\r\n<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.whileclosure</element></xml>\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/xml
+
+                <?xml version="1.0"?><xml><element attribute_name="attribute_value">ProcessBuilder.evil.whileclosure</element></xml>
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944120\""

--- a/tests/regression/tests/REQUEST-944-APPLICATION-ATTACK-JAVA/944210.yaml
+++ b/tests/regression/tests/REQUEST-944-APPLICATION-ATTACK-JAVA/944210.yaml
@@ -326,7 +326,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/json\r\n\r\n{\"rO0ABQ\": \"test\"}\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/json
+
+                {"rO0ABQ": "test"}
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944210\""
 
@@ -349,7 +355,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/json\r\n\r\n{\"rO0ABQ\": \"test\"}\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/json
+
+                {"rO0ABQ": "test"}
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944210\""
 
@@ -372,7 +384,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/xml\r\n\r\n<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">rO0ABQ</element></xml>\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/xml
+
+                <?xml version="1.0"?><xml><element attribute_name="attribute_value">rO0ABQ</element></xml>
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944210\""
 
@@ -395,7 +413,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/xml\r\n\r\n<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">rO0ABQ</element></xml>\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/xml
+
+                <?xml version="1.0"?><xml><element attribute_name="attribute_value">rO0ABQ</element></xml>
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944210\""
     -
@@ -719,7 +743,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/json\r\n\r\n{\"KztAAU\": \"test\"}\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/json
+
+                {"KztAAU": "test"}
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944210\""
 
@@ -742,7 +772,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/json\r\n\r\n{\"KztAAU\": \"test\"}\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/json
+
+                {"KztAAU": "test"}
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944210\""
 
@@ -765,7 +801,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/xml\r\n\r\n<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">KztAAU</element></xml>\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/xml
+
+                <?xml version="1.0"?><xml><element attribute_name="attribute_value">KztAAU</element></xml>
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944210\""
 
@@ -788,7 +830,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/xml\r\n\r\n<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">KztAAU</element></xml>\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/xml
+
+                <?xml version="1.0"?><xml><element attribute_name="attribute_value">KztAAU</element></xml>
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944210\""
     -
@@ -1112,7 +1160,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/json\r\n\r\n{\"Cs7QAF\": \"test\"}\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/json
+
+                {"Cs7QAF": "test"}
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944210\""
 
@@ -1135,7 +1189,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/json\r\n\r\n{\"Cs7QAF\": \"test\"}\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/json
+
+                {"Cs7QAF": "test"}
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944210\""
 
@@ -1158,7 +1218,13 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/xml\r\n\r\n<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">Cs7QAF</element></xml>\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/xml
+
+                <?xml version="1.0"?><xml><element attribute_name="attribute_value">Cs7QAF</element></xml>
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944210\""
 
@@ -1181,6 +1247,12 @@
                 Content-Type: "multipart/form-data; boundary=---------------------------thisissparta"
               method: "POST"
               version: "HTTP/1.0"
-              data: "-----------------------------thisissparta\r\nContent-Disposition: form-data; name=\"payload\"\r\nContent-Type: application/xml\r\n\r\n<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">Cs7QAF</element></xml>\r\n-----------------------------thisissparta--"
+              data: |
+                -----------------------------thisissparta
+                Content-Disposition: form-data; name="payload"
+                Content-Type: application/xml
+
+                <?xml version="1.0"?><xml><element attribute_name="attribute_value">Cs7QAF</element></xml>
+                -----------------------------thisissparta--
             output:
               log_contains: "id \"944210\""


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

We admitted tests using list of stings and others in `ftw`. For compatibility, we should use only valid yaml in our tests.

This one fixes this.