### PR TITLE
Typo in Sampling Mode description pointing to the wrong rule in crs-setup.conf

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -602,7 +602,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # following directive somewhere after the inclusion of the CRS
 # (E.g., RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf).
 #
-# SecRuleUpdateActionById 901150 "nolog"
+# SecRuleUpdateActionById 901450 "nolog"
 #
 # ATTENTION: If this TX.sampling_percentage is below 100, then some of the
 # requests will bypass the Core Rules completely and you lose the ability to


### PR DESCRIPTION
Sampling Mode description indicates, you can silence the log by updating 901150 when it's in fact 901450.

It's always a bit troubling when you encounter bugs several years after you released something.