### PR TITLE
Adding WEB-INF into restricted-files.data

### DIFF
--- a/rules/restricted-files.data
+++ b/rules/restricted-files.data
@@ -178,3 +178,5 @@ soapConfig.xml
 # Common names for local PHP error logs
 php_error.log
 php_errors.log
+# Java directory for non-pubic application data
+WEB-INF

--- a/rules/restricted-files.data
+++ b/rules/restricted-files.data
@@ -179,4 +179,4 @@ soapConfig.xml
 php_error.log
 php_errors.log
 # Java directory for non-pubic application data
-WEB-INF
+WEB-INF/


### PR DESCRIPTION
WEB-INF directory is used by Java application to store non-public application data. From the specification:

A special directory exists within the application hierarchy named “WEB-INF”. This directory contains all things related to the application that aren’t in the document root of the application. The WEB-INF node is not part of the public document tree of the application. No file contained in the WEB-INF directory maybe served directly to a client by the container.

This fixes #2089.