### PR TITLE
Update version strings to 3.4.0-dev

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -856,4 +856,4 @@ SecAction \
   nolog,\
   pass,\
   t:none,\
-  setvar:tx.crs_setup_version=330"
+  setvar:tx.crs_setup_version=340"

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -851,9 +851,9 @@ SecCollectionTimeout 600
 # E.g., v3.0.0 is represented as 300.
 #
 SecAction \
- "id:900990,\
-  phase:1,\
-  nolog,\
-  pass,\
-  t:none,\
-  setvar:tx.crs_setup_version=340"
+    "id:900990,\
+    phase:1,\
+    nolog,\
+    pass,\
+    t:none,\
+    setvar:tx.crs_setup_version=340"

--- a/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example
+++ b/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -25,7 +25,7 @@
 #
 # Ref: https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual#wiki-SecComponentSignature
 #
-SecComponentSignature "OWASP_CRS/3.3.0"
+SecComponentSignature "OWASP_CRS/3.4.0-dev"
 
 #
 # -=[ Default setup values ]=-
@@ -58,7 +58,7 @@ SecRule &TX:crs_setup_version "@eq 0" \
     log,\
     auditlog,\
     msg:'ModSecurity Core Rule Set is deployed without configuration! Please copy the crs-setup.conf.example template to crs-setup.conf, and include the crs-setup.conf file in your webserver configuration before including the CRS rules. See the INSTALL file in the CRS directory for detailed instructions',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL'"
 
 
@@ -76,7 +76,7 @@ SecRule &TX:inbound_anomaly_score_threshold "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.inbound_anomaly_score_threshold=5'"
 
 # Default Outbound Anomaly Threshold Level (rule 900110 in setup.conf)
@@ -85,7 +85,7 @@ SecRule &TX:outbound_anomaly_score_threshold "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.outbound_anomaly_score_threshold=4'"
 
 # Default Blocking Early (rule 900120 in setup.conf)
@@ -94,7 +94,7 @@ SecRule &TX:blocking_early "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.blocking_early=0'"
 
 # Default Paranoia Level (rule 900000 in setup.conf)
@@ -103,7 +103,7 @@ SecRule &TX:paranoia_level "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.paranoia_level=1'"
 
 # Default Executing Paranoia Level (rule 900000 in setup.conf)
@@ -112,7 +112,7 @@ SecRule &TX:executing_paranoia_level "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.executing_paranoia_level=%{TX.PARANOIA_LEVEL}'"
 
 # Default Sampling Percentage (rule 900400 in setup.conf)
@@ -121,7 +121,7 @@ SecRule &TX:sampling_percentage "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.sampling_percentage=100'"
 
 # Default Anomaly Scores (rule 900100 in setup.conf)
@@ -130,7 +130,7 @@ SecRule &TX:critical_anomaly_score "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.critical_anomaly_score=5'"
 
 SecRule &TX:error_anomaly_score "@eq 0" \
@@ -138,7 +138,7 @@ SecRule &TX:error_anomaly_score "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.error_anomaly_score=4'"
 
 SecRule &TX:warning_anomaly_score "@eq 0" \
@@ -146,7 +146,7 @@ SecRule &TX:warning_anomaly_score "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.warning_anomaly_score=3'"
 
 SecRule &TX:notice_anomaly_score "@eq 0" \
@@ -154,7 +154,7 @@ SecRule &TX:notice_anomaly_score "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.notice_anomaly_score=2'"
 
 # Default do_reput_block
@@ -163,7 +163,7 @@ SecRule &TX:do_reput_block "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.do_reput_block=0'"
 
 # Default block duration
@@ -172,7 +172,7 @@ SecRule &TX:reput_block_duration "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.reput_block_duration=300'"
 
 # Default HTTP policy: allowed_methods (rule 900200)
@@ -181,7 +181,7 @@ SecRule &TX:allowed_methods "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.allowed_methods=GET HEAD POST OPTIONS'"
 
 # Default HTTP policy: allowed_request_content_type (rule 900220)
@@ -190,7 +190,7 @@ SecRule &TX:allowed_request_content_type "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |multipart/related| |text/xml| |application/xml| |application/soap+xml| |application/x-amf| |application/json| |application/cloudevents+json| |application/cloudevents-batch+json| |application/octet-stream| |application/csp-report| |application/xss-auditor-report| |text/plain|'"
 
 # Default HTTP policy: allowed_request_content_type_charset (rule 900270)
@@ -199,7 +199,7 @@ SecRule &TX:allowed_request_content_type_charset "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.allowed_request_content_type_charset=|utf-8| |iso-8859-1| |iso-8859-15| |windows-1252|'"
 
 # Default HTTP policy: allowed_http_versions (rule 900230)
@@ -208,7 +208,7 @@ SecRule &TX:allowed_http_versions "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.allowed_http_versions=HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0'"
 
 # Default HTTP policy: restricted_extensions (rule 900240)
@@ -217,7 +217,7 @@ SecRule &TX:restricted_extensions "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .rdb/ .resources/ .resx/ .sql/ .swp/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'"
 
 # Default HTTP policy: restricted_headers (rule 900250)
@@ -226,7 +226,7 @@ SecRule &TX:restricted_headers "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.restricted_headers=/proxy/ /lock-token/ /content-range/ /if/ /user-agentt/'"
 
 # Default HTTP policy: static_extensions (rule 900260)
@@ -235,7 +235,7 @@ SecRule &TX:static_extensions "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.static_extensions=/.jpg/ /.jpeg/ /.png/ /.gif/ /.js/ /.css/ /.ico/ /.svg/ /.webp/'"
 
 # Default enforcing of body processor URLENCODED
@@ -244,7 +244,7 @@ SecRule &TX:enforce_bodyproc_urlencoded "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.enforce_bodyproc_urlencoded=0'"
 
 #
@@ -262,7 +262,7 @@ SecAction \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.anomaly_score=0',\
     setvar:'tx.anomaly_score_pl1=0',\
     setvar:'tx.anomaly_score_pl2=0',\
@@ -299,7 +299,7 @@ SecRule REQUEST_HEADERS:User-Agent "@rx ^.*$" \
     pass,\
     t:none,t:sha1,t:hexEncode,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.ua_hash=%{MATCHED_VAR}'"
 
 SecAction \
@@ -308,7 +308,7 @@ SecAction \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     initcol:global=global,\
     initcol:ip=%{remote_addr}_%{tx.ua_hash},\
     setvar:'tx.real_ip=%{remote_addr}'"
@@ -329,7 +329,7 @@ SecRule REQBODY_PROCESSOR "!@rx (?:URLENCODED|MULTIPART|XML|JSON)" \
     msg:'Enabling body inspection',\
     tag:'paranoia-level/1',\
     ctl:forceRequestBodyVariable=On,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Force body processor URLENCODED
 SecRule TX:enforce_bodyproc_urlencoded "@eq 1" \
@@ -340,7 +340,7 @@ SecRule TX:enforce_bodyproc_urlencoded "@eq 1" \
     nolog,\
     noauditlog,\
     msg:'Enabling forced body inspection for ASCII content',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule REQBODY_PROCESSOR "!@rx (?:URLENCODED|MULTIPART|XML|JSON)" \
         "ctl:requestBodyProcessor=URLENCODED"
@@ -379,7 +379,7 @@ SecRule TX:sampling_percentage "@eq 100" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     skipAfter:END-SAMPLING"
 
 SecRule UNIQUE_ID "@rx ^." \
@@ -388,7 +388,7 @@ SecRule UNIQUE_ID "@rx ^." \
     pass,\
     t:sha1,t:hexEncode,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'TX.sampling_rnd100=%{MATCHED_VAR}'"
 
 SecRule DURATION "@rx (..)$" \
@@ -397,7 +397,7 @@ SecRule DURATION "@rx (..)$" \
     pass,\
     capture,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'TX.sampling_rnd100=%{TX.sampling_rnd100}%{TX.1}'"
 
 SecRule TX:sampling_rnd100 "@rx ^[a-f]*([0-9])[a-f]*([0-9])" \
@@ -406,7 +406,7 @@ SecRule TX:sampling_rnd100 "@rx ^[a-f]*([0-9])[a-f]*([0-9])" \
     pass,\
     capture,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'TX.sampling_rnd100=%{TX.1}%{TX.2}'"
 
 SecRule TX:sampling_rnd100 "@rx ^0([0-9])" \
@@ -415,7 +415,7 @@ SecRule TX:sampling_rnd100 "@rx ^0([0-9])" \
     pass,\
     capture,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'TX.sampling_rnd100=%{TX.1}'"
 
 
@@ -440,7 +440,7 @@ SecRule TX:sampling_rnd100 "!@lt %{tx.sampling_percentage}" \
     noauditlog,\
     msg:'Sampling: Disable the rule engine based on sampling_percentage %{TX.sampling_percentage} and random number %{TX.sampling_rnd100}',\
     ctl:ruleEngine=Off,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 SecMarker "END-SAMPLING"
 
@@ -458,4 +458,4 @@ SecRule TX:executing_paranoia_level "@lt %{tx.paranoia_level}" \
     t:none,\
     log,\
     msg:'Executing paranoia level configured is lower than the paranoia level itself. This is illegal. Blocking request. Aborting',\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"

--- a/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -68,7 +68,7 @@ SecRule &TX:crs_exclusions_drupal|TX:crs_exclusions_drupal "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     skipAfter:END-DRUPAL-RULE-EXCLUSIONS"
 
 
@@ -106,7 +106,7 @@ SecAction "id:9001100,\
     nolog,\
     ctl:ruleRemoveTargetById=942450;REQUEST_COOKIES_NAMES,\
     ctl:ruleRemoveTargetById=942450;REQUEST_COOKIES,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 
 #
@@ -121,7 +121,7 @@ SecRule REQUEST_FILENAME "@endsWith /core/install.php" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:account[pass][pass1],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:account[pass][pass2],\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 SecRule REQUEST_FILENAME "@endsWith /user/login" \
     "id:9001112,\
@@ -130,7 +130,7 @@ SecRule REQUEST_FILENAME "@endsWith /user/login" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/people/create" \
     "id:9001114,\
@@ -139,7 +139,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/people/create" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass[pass1],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass[pass2],\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 SecRule REQUEST_FILENAME "@rx /user/[0-9]+/edit$" \
     "id:9001116,\
@@ -149,7 +149,7 @@ SecRule REQUEST_FILENAME "@rx /user/[0-9]+/edit$" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:current_pass,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass[pass1],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass[pass2],\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 
 #
@@ -169,7 +169,7 @@ SecRule REQUEST_FILENAME "@contains /admin/config/" \
     pass,\
     nolog,\
     ctl:ruleRemoveById=942430,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/people/accounts" \
     "id:9001124,\
@@ -186,7 +186,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/people/accounts" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:user_mail_status_activated_body,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:user_mail_status_blocked_body,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:user_mail_status_canceled_body,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/development/configuration/single/import" \
     "id:9001126,\
@@ -195,7 +195,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/development/configuration/sing
     nolog,\
     ctl:ruleRemoveById=920271,\
     ctl:ruleRemoveById=942440,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/development/maintenance" \
     "id:9001128,\
@@ -203,7 +203,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/development/maintenance" \
     pass,\
     nolog,\
     ctl:ruleRemoveById=942440,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 
 #
@@ -220,7 +220,7 @@ SecRule REQUEST_FILENAME "@endsWith /contextual/render" \
     pass,\
     nolog,\
     ctl:ruleRemoveTargetById=942130;ARGS:ids[],\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 
 #
@@ -239,7 +239,7 @@ SecAction "id:9001160,\
     ctl:ruleRemoveTargetById=942440;ARGS:form_build_id,\
     ctl:ruleRemoveTargetById=942450;ARGS:form_token,\
     ctl:ruleRemoveTargetById=942450;ARGS:form_build_id,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 
 #
@@ -256,7 +256,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/content/formats/manage/full_ht
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:editor[settings][toolbar][button_groups],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:filters[filter_html][settings][allowed_html],\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 
 #
@@ -274,7 +274,7 @@ SecRule REQUEST_METHOD "@streq POST" \
     t:none,\
     nolog,\
     noauditlog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule REQUEST_FILENAME "@rx /admin/content/assets/add/[a-z]+$" \
         "chain"
@@ -288,7 +288,7 @@ SecRule REQUEST_METHOD "@streq POST" \
     t:none,\
     nolog,\
     noauditlog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule REQUEST_FILENAME "@rx /admin/content/assets/manage/[0-9]+$" \
         "chain"
@@ -306,7 +306,7 @@ SecRule REQUEST_METHOD "@streq POST" \
     t:none,\
     nolog,\
     noauditlog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule REQUEST_FILENAME "@rx /file/ajax/field_asset_[a-z0-9_]+/[ua]nd/0/form-[a-z0-9A-Z_-]+$" \
         "chain"
@@ -334,7 +334,7 @@ SecRule REQUEST_FILENAME "@endsWith /node/add/article" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body[0][value],\
     ctl:ruleRemoveTargetById=942410;ARGS:uid[0][target_id],\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 SecRule REQUEST_FILENAME "@endsWith /node/add/page" \
     "id:9001202,\
@@ -343,7 +343,7 @@ SecRule REQUEST_FILENAME "@endsWith /node/add/page" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body[0][value],\
     ctl:ruleRemoveTargetById=942410;ARGS:uid[0][target_id],\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 SecRule REQUEST_FILENAME "@rx /node/[0-9]+/edit$" \
     "id:9001204,\
@@ -353,7 +353,7 @@ SecRule REQUEST_FILENAME "@rx /node/[0-9]+/edit$" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body[0][value],\
     ctl:ruleRemoveTargetById=942410;ARGS:uid[0][target_id],\
     ctl:ruleRemoveTargetById=932110;ARGS:destination,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 SecRule REQUEST_FILENAME "@endsWith /block/add" \
     "id:9001206,\
@@ -361,7 +361,7 @@ SecRule REQUEST_FILENAME "@endsWith /block/add" \
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body[0][value],\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/structure/block/block-content/manage/basic" \
     "id:9001208,\
@@ -369,7 +369,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/structure/block/block-content/manage/
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:description,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 SecRule REQUEST_FILENAME "@rx /editor/filter_xss/(?:full|basic)_html$" \
     "id:9001210,\
@@ -377,7 +377,7 @@ SecRule REQUEST_FILENAME "@rx /editor/filter_xss/(?:full|basic)_html$" \
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:value,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 SecRule REQUEST_FILENAME "@rx /user/[0-9]+/contact$" \
     "id:9001212,\
@@ -385,7 +385,7 @@ SecRule REQUEST_FILENAME "@rx /user/[0-9]+/contact$" \
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message[0][value],\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/development/maintenance" \
     "id:9001214,\
@@ -393,7 +393,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/development/maintenance" \
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:maintenance_mode_message,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/services/rss-publishing" \
     "id:9001216,\
@@ -401,7 +401,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/services/rss-publishing" \
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:feed_description,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 
 SecMarker "END-DRUPAL-RULE-EXCLUSIONS"

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -22,7 +22,7 @@ SecRule &TX:crs_exclusions_wordpress|TX:crs_exclusions_wordpress "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     skipAfter:END-WORDPRESS"
 
 SecRule &TX:crs_exclusions_wordpress|TX:crs_exclusions_wordpress "@eq 0" \
@@ -31,7 +31,7 @@ SecRule &TX:crs_exclusions_wordpress|TX:crs_exclusions_wordpress "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     skipAfter:END-WORDPRESS"
 
 
@@ -52,7 +52,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pwd,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Reset password
 SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
@@ -61,7 +61,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:action "@streq resetpass" \
         "t:none,\
@@ -85,7 +85,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-comments-post.php" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=931130;ARGS:url,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 
 #
@@ -102,7 +102,7 @@ SecRule REQUEST_FILENAME "@rx /wp-json/wp/v[0-9]+/(?:posts|pages)" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:content,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.content,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Gutenberg via rest_route for sites without pretty permalinks
 SecRule REQUEST_FILENAME "@endsWith /index.php" \
@@ -111,7 +111,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule &ARGS_GET:rest_route "@eq 1" \
         "t:none,\
@@ -131,7 +131,7 @@ SecRule REQUEST_FILENAME "@rx /wp-json/wp/v[0-9]+/media" \
     nolog,\
     ctl:ruleRemoveById=200002,\
     ctl:ruleRemoveById=200003,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Gutenberg upload image/media via rest_route for sites without pretty permalinks
 SecRule REQUEST_FILENAME "@endsWith /index.php" \
@@ -140,7 +140,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule &ARGS_GET:rest_route "@eq 1" \
         "t:none,\
@@ -169,7 +169,7 @@ SecRule ARGS:wp_customize "@streq on" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule &ARGS:action "@eq 0" \
         "t:none,\
@@ -190,7 +190,7 @@ SecRule ARGS:wp_customize "@streq on" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:action "@rx ^(?:|customize_save|update-widget)$" \
         "t:none,\
@@ -231,7 +231,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-cron.php" \
     nolog,\
     ctl:ruleRemoveById=920180,\
     ctl:ruleRemoveById=920300,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 
 #
@@ -246,7 +246,7 @@ SecRule REQUEST_COOKIES:_wp_session "@rx ^[0-9a-f]+\|\|\d+\|\|\d+$" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule &REQUEST_COOKIES:_wp_session "@eq 1" \
         "t:none,\
@@ -265,7 +265,7 @@ SecRule REQUEST_FILENAME "!@contains /wp-admin/" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     skipAfter:END-WORDPRESS-ADMIN"
 
 SecRule REQUEST_FILENAME "!@contains /wp-admin/" \
@@ -274,7 +274,7 @@ SecRule REQUEST_FILENAME "!@contains /wp-admin/" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     skipAfter:END-WORDPRESS-ADMIN"
 
 
@@ -289,7 +289,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/setup-config.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:step "@streq 2" \
         "t:none,\
@@ -305,7 +305,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/install.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:step "@streq 2" \
         "t:none,\
@@ -328,7 +328,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/profile.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:action "@streq update" \
         "t:none,\
@@ -356,7 +356,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/user-edit.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:action "@streq update" \
         "t:none,\
@@ -385,7 +385,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/user-new.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:action "@streq createuser" \
         "t:none,\
@@ -430,7 +430,7 @@ SecAction \
     ctl:ruleRemoveTargetById=942230;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=942260;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=942431;ARGS:wp_http_referer,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 #
 # [ Content editing ]
@@ -447,7 +447,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/post.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:action "@rx ^(?:edit|editpost)$" \
         "t:none,\
@@ -468,7 +468,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:action "@streq heartbeat" \
         "t:none,\
@@ -491,7 +491,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/nav-menus.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:action "@rx ^(?:update|edit)$" \
         "t:none,\
@@ -519,7 +519,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:action "@rx ^(?:save-widget|update-widget)$" \
         "t:none,\
@@ -574,7 +574,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:action "@streq widgets-order" \
         "t:none,\
@@ -603,7 +603,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:action "@streq sample-permalink" \
         "t:none,\
@@ -620,7 +620,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:action "@streq add-menu-item" \
         "t:none,\
@@ -636,7 +636,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:action "@streq send-attachment-to-editor" \
         "t:none,\
@@ -657,7 +657,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/options.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:option_page "@streq general" \
         "t:none,\
@@ -688,7 +688,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/options-permalink.php" \
     ctl:ruleRemoveTargetById=920272;ARGS:permalink_structure,\
     ctl:ruleRemoveTargetById=942431;ARGS:permalink_structure,\
     ctl:ruleRemoveTargetById=920272;REQUEST_BODY,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Comments blacklist and moderation list
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/options.php" \
@@ -697,7 +697,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/options.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:option_page "@streq discussion" \
         "t:none,\
@@ -721,7 +721,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/edit.php" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:s,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Wordpress Site Health
 # The wordpress site health page makes use of embedded SQL/PHP
@@ -734,7 +734,7 @@ SecRule REQUEST_FILENAME "@rx /wp-admin/site-health.php" \
     nolog,\
     ctl:ruleRemoveById=951220,\
     ctl:ruleRemoveById=953110,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 #
 # [ Helpers ]
@@ -772,7 +772,7 @@ SecRule REQUEST_FILENAME "@rx /wp-admin/load-(?:scripts|styles)\.php$" \
     ctl:ruleRemoveTargetById=942430;ARGS:load[],\
     ctl:ruleRemoveTargetById=942431;ARGS:load[],\
     ctl:ruleRemoveTargetById=942432;ARGS:load[],\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 
 # Site health output can trigger database error rule.
@@ -783,7 +783,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/site-health.php" \
     t:none,\
     nolog,\
     ctl:ruleRemoveById=951220,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 
 #
@@ -797,7 +797,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:action "@rx ^(?:update-plugin|delete-plugin)$" \
         "t:none,\

--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. (not) All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -43,7 +43,7 @@ SecRule &TX:crs_exclusions_nextcloud|TX:crs_exclusions_nextcloud "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     skipAfter:END-NEXTCLOUD"
 
 SecRule &TX:crs_exclusions_nextcloud|TX:crs_exclusions_nextcloud "@eq 0" \
@@ -52,7 +52,7 @@ SecRule &TX:crs_exclusions_nextcloud|TX:crs_exclusions_nextcloud "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     skipAfter:END-NEXTCLOUD"
 
 
@@ -73,7 +73,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/webdav" \
     ctl:ruleRemoveById=953100-953130,\
     ctl:ruleRemoveById=920420,\
     ctl:ruleRemoveById=920440,\
-    ver:'OWASP_CRS/3.4.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Skip PUT parsing for invalid encoding / protocol violations in binary files.
 SecRule REQUEST_METHOD "@streq PUT" \
@@ -82,7 +82,7 @@ SecRule REQUEST_METHOD "@streq PUT" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule REQUEST_FILENAME "@contains /remote.php/webdav" \
         "t:none,\
@@ -99,7 +99,7 @@ SecRule REQUEST_METHOD "@pm PROPFIND PUT" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule REQUEST_FILENAME "@rx /remote\.php/(?:webdav|dav/files)" \
         "t:none,\
@@ -112,7 +112,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/vcard|'"
 
 # Allow the data type 'application/octet-stream'
@@ -122,7 +122,7 @@ SecRule REQUEST_METHOD "@pm PUT MOVE" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule REQUEST_FILENAME "@rx /remote\.php/dav/(?:files|uploads)/" \
         "setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |application/octet-stream|'"
@@ -134,7 +134,7 @@ SecRule REQUEST_METHOD "@streq PUT" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule REQUEST_FILENAME "@rx /(?:public\.php/webdav|remote\.php/dav/uploads)/" \
         "ctl:ruleRemoveById=920340,\
@@ -153,7 +153,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     ctl:ruleRemoveById=951000-951999,\
     ctl:ruleRemoveById=953100-953130,\
     ctl:ruleRemoveById=920440,\
-    ver:'OWASP_CRS/3.4.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Allow REPORT requests without Content-Type header (at least the iOS app does this)
 SecRule REQUEST_METHOD "@streq REPORT" \
@@ -182,7 +182,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/core/search" \
     ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:query,\
     ctl:ruleRemoveTargetById=941000-942999;ARGS:query,\
     ctl:ruleRemoveTargetById=932000-932999;ARGS:query,\
-    ver:'OWASP_CRS/3.4.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 
 #
@@ -205,7 +205,7 @@ SecRule REQUEST_FILENAME "@rx /(?:remote|index|public)\.php/" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT PATCH CHECKOUT COPY DELETE LOCK MERGE MKACTIVITY MKCOL MOVE PROPFIND PROPPATCH SEARCH UNLOCK REPORT TRACE jsonp'"
 
 # We need to allow DAV methods for sharing files, and removing shares
@@ -217,7 +217,7 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/files_sharing/" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT DELETE'"
 
 
@@ -233,7 +233,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/core/preview.png" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=932150;ARGS:file,\
-    ver:'OWASP_CRS/3.4.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Filepreview for trashbin
 SecRule REQUEST_FILENAME "@contains /index.php/apps/files_trashbin/ajax/preview.php" \
@@ -244,7 +244,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/files_trashbin/ajax/preview.
     nolog,\
     ctl:ruleRemoveTargetById=932150;ARGS:file,\
     ctl:ruleRemoveTargetById=942190;ARGS:file,\
-    ver:'OWASP_CRS/3.4.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Thumbnails
 SecRule REQUEST_FILENAME "@contains /index.php/apps/gallery/thumbnails" \
@@ -254,7 +254,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/gallery/thumbnails" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=941120;ARGS:requesttoken,\
-    ver:'OWASP_CRS/3.4.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 
 #
@@ -268,7 +268,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/ownnote/" \
     t:none,\
     nolog,\
     ctl:ruleRemoveById=941150,\
-    ver:'OWASP_CRS/3.4.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 
 #
@@ -287,7 +287,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/files_texteditor/" \
     ctl:ruleRemoveTargetById=932150;ARGS:filename,\
     ctl:ruleRemoveTargetById=920370-920390;ARGS:filecontents,\
     ctl:ruleRemoveTargetById=920370-920390;ARGS_COMBINED_SIZE,\
-    ver:'OWASP_CRS/3.4.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 
 #
@@ -301,7 +301,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/addressbooks/" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/vcard|'"
 
 # Allow modifying contacts via the web interface
@@ -311,7 +311,7 @@ SecRule REQUEST_METHOD "@streq PUT" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule REQUEST_FILENAME "@contains /remote.php/dav/addressbooks/" \
         "t:none,\
@@ -329,7 +329,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/calendars/" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/calendar|'"
 
 # Allow modifying calendar events via the web interface
@@ -339,7 +339,7 @@ SecRule REQUEST_METHOD "@streq PUT" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule REQUEST_FILENAME "@contains /remote.php/dav/calendars/" \
         "t:none,\
@@ -352,7 +352,7 @@ SecRule REQUEST_METHOD "@streq PROPFIND" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule REQUEST_FILENAME "@rx /remote\.php/dav/(?:principals/users|calendars)/" \
         "t:none,\
@@ -372,7 +372,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/notes/" \
     t:none,\
     nolog,\
     ctl:ruleRemoveByTag=attack-injection-php,\
-    ver:'OWASP_CRS/3.4.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 
 #
@@ -387,7 +387,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/bookmarks/" \
     t:none,\
     nolog,\
     ctl:ruleRemoveById=931130,\
-    ver:'OWASP_CRS/3.4.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 
 #
@@ -404,7 +404,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/login" \
     nolog,\
     ctl:ruleRemoveTargetById=941100;ARGS:requesttoken,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password,\
-    ver:'OWASP_CRS/3.4.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Reset password.
 SecRule REQUEST_FILENAME "@endsWith /index.php/login" \
@@ -413,7 +413,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/login" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:action "@streq resetpass" \
         "t:none,\
@@ -432,7 +432,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/logout" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=941120;ARGS:requesttoken,\
-    ver:'OWASP_CRS/3.4.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Change Password and Setting up a new user/password
 SecRule REQUEST_FILENAME "@endsWith /index.php/settings/users" \
@@ -443,7 +443,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/settings/users" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:newuserpassword,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password,\
-    ver:'OWASP_CRS/3.4.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 
 #
@@ -460,7 +460,7 @@ SecRule REQUEST_FILENAME "@contains /settings/personal/authtokens/" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
 
 # Administration: Overview
@@ -472,7 +472,7 @@ SecRule REQUEST_FILENAME "@contains /.well-known/caldav" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PROPFIND'"
 
 SecRule REQUEST_FILENAME "@contains /.well-known/carddav" \
@@ -481,7 +481,7 @@ SecRule REQUEST_FILENAME "@contains /.well-known/carddav" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PROPFIND'"
 
 
@@ -497,7 +497,7 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/notifications/api/v2/notifi
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
 
 
@@ -512,7 +512,7 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/files_sharing/api/v1/shares
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule REQUEST_METHOD "@streq GET" \
         "t:none,\
@@ -530,7 +530,7 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/cloud/users/" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
 
 
@@ -548,7 +548,7 @@ SecRule REQUEST_FILENAME "@contains /config/apps/ransomware_protection/extension
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=932130;ARGS:value,\
-    ver:'OWASP_CRS/3.4.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 
 SecMarker "END-NEXTCLOUD-ADMIN"

--- a/rules/REQUEST-903.9004-DOKUWIKI-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9004-DOKUWIKI-EXCLUSION-RULES.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -26,7 +26,7 @@ SecRule &TX:crs_exclusions_dokuwiki|TX:crs_exclusions_dokuwiki "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     skipAfter:END-DOKUWIKI"
 
 SecRule &TX:crs_exclusions_dokuwiki|TX:crs_exclusions_dokuwiki "@eq 0" \
@@ -35,7 +35,7 @@ SecRule &TX:crs_exclusions_dokuwiki|TX:crs_exclusions_dokuwiki "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     skipAfter:END-DOKUWIKI"
 
 
@@ -80,7 +80,7 @@ SecRule REQUEST_FILENAME "@rx (?:/doku.php|/lib/exe/ajax.php)$" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule REQUEST_METHOD "@streq POST" \
         "t:none,\
@@ -105,7 +105,7 @@ SecRule REQUEST_FILENAME "@endsWith /lib/exe/ajax.php" \
     t:none,\
     nolog,\
     noauditlog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule REQUEST_METHOD "@streq POST" \
         "t:none,\
@@ -124,7 +124,7 @@ SecRule REQUEST_FILENAME "@endsWith /doku.php" \
     t:none,\
     nolog,\
     noauditlog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:do "@streq index" \
         "t:none,\
@@ -148,7 +148,7 @@ SecRule REQUEST_FILENAME "@endsWith /doku.php" \
     t:none,\
     nolog,\
     noauditlog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:do "@streq login" \
         "t:none,\
@@ -169,7 +169,7 @@ SecRule ARGS_GET:do "!@streq admin" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     skipAfter:END-DOKUWIKI-ADMIN"
 
 SecRule ARGS:do "!@streq admin" \
@@ -178,7 +178,7 @@ SecRule ARGS:do "!@streq admin" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     skipAfter:END-DOKUWIKI-ADMIN"
 
 
@@ -193,7 +193,7 @@ SecRule REQUEST_FILENAME "@endsWith /doku.php" \
     t:none,\
     nolog,\
     noauditlog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:do "@streq login" \
         "t:none,\
@@ -219,7 +219,7 @@ SecRule REQUEST_FILENAME "@endsWith /doku.php" \
     t:none,\
     nolog,\
     noauditlog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:page "@streq config" \
         "t:none,\
@@ -251,7 +251,7 @@ SecRule REQUEST_FILENAME "@endsWith /doku.php" \
     t:none,\
     nolog,\
     noauditlog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:page "@streq config" \
         "t:none,\

--- a/rules/REQUEST-903.9005-CPANEL-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9005-CPANEL-EXCLUSION-RULES.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -18,7 +18,7 @@ SecRule &TX:crs_exclusions_cpanel|TX:crs_exclusions_cpanel "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     skipAfter:END-CPANEL"
 
 SecRule &TX:crs_exclusions_cpanel|TX:crs_exclusions_cpanel "@eq 0" \
@@ -27,7 +27,7 @@ SecRule &TX:crs_exclusions_cpanel|TX:crs_exclusions_cpanel "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     skipAfter:END-CPANEL"
 
 
@@ -52,7 +52,7 @@ SecRule REQUEST_LINE "@rx ^GET /whm-server-status(?:/|/\?auto)? HTTP/[12]\.[01]$
     tag:'language-multi',\
     tag:'platform-apache',\
     tag:'attack-generic',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
         "t:none,\

--- a/rules/REQUEST-903.9006-XENFORO-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9006-XENFORO-EXCLUSION-RULES.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -17,7 +17,7 @@ SecRule &TX:crs_exclusions_xenforo|TX:crs_exclusions_xenforo "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     skipAfter:END-XENFORO"
 
 SecRule &TX:crs_exclusions_xenforo|TX:crs_exclusions_xenforo "@eq 0" \
@@ -26,7 +26,7 @@ SecRule &TX:crs_exclusions_xenforo|TX:crs_exclusions_xenforo "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     skipAfter:END-XENFORO"
 
 
@@ -48,7 +48,7 @@ SecRule REQUEST_FILENAME "@endsWith /proxy.php" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:link,\
     ctl:ruleRemoveTargetById=931130;ARGS:referrer,\
     ctl:ruleRemoveTargetById=942230;ARGS:referrer,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Store drafts for private message, forum post, thread reply
 # POST /xf/conversations/draft
@@ -72,7 +72,7 @@ SecRule REQUEST_FILENAME "@rx /(?:conversations|(?:conversations|forums|threads)
     ctl:ruleRemoveTargetById=942260;ARGS:attachment_hash_combined,\
     ctl:ruleRemoveTargetById=942340;ARGS:attachment_hash_combined,\
     ctl:ruleRemoveTargetById=942370;ARGS:attachment_hash_combined,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Send PM, edit post, create thread, reply to thread
 # POST /xf/conversations/add
@@ -105,7 +105,7 @@ SecRule REQUEST_FILENAME "@rx /(?:conversations/add(?:-preview)?|conversations/m
     ctl:ruleRemoveTargetById=942260;ARGS:attachment_hash_combined,\
     ctl:ruleRemoveTargetById=942340;ARGS:attachment_hash_combined,\
     ctl:ruleRemoveTargetById=942370;ARGS:attachment_hash_combined,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Quote
 # POST /xf/posts/12345/quote
@@ -116,7 +116,7 @@ SecRule REQUEST_FILENAME "@rx /posts/\d+/quote$" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:quoteHtml,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Multi quote
 # POST /xf/conversations/convo-title.12345/multi-quote
@@ -139,7 +139,7 @@ SecRule REQUEST_FILENAME "@rx /(?:conversations|threads)/.*\.\d+/multi-quote$" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:insert[7][value],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:insert[8][value],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:insert[9][value],\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Delete thread
 # POST /xf/threads/thread-title.12345/delete
@@ -150,7 +150,7 @@ SecRule REQUEST_FILENAME "@rx /threads/.*\.\d+/delete$" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=942130;ARGS:starter_alert_reason,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Feature thread
 # POST /xf/threads/thread-title.12345/feature-edit
@@ -172,7 +172,7 @@ SecRule REQUEST_FILENAME "@endsWith /inline-mod/" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:author_alert_reason,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Warn member
 # POST /xf/members/name.12345/warn
@@ -185,7 +185,7 @@ SecRule REQUEST_FILENAME "@rx /(?:members/.*\.\d+|posts/\d+)/warn$" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:conversation_message,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:notes,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Editor
 SecRule REQUEST_URI "@endsWith /index.php?editor/to-html" \
@@ -199,7 +199,7 @@ SecRule REQUEST_URI "@endsWith /index.php?editor/to-html" \
     ctl:ruleRemoveTargetById=942260;ARGS:attachment_hash_combined,\
     ctl:ruleRemoveTargetById=942340;ARGS:attachment_hash_combined,\
     ctl:ruleRemoveTargetById=942370;ARGS:attachment_hash_combined,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Editor
 SecRule REQUEST_URI "@endsWith /index.php?editor/to-bb-code" \
@@ -209,7 +209,7 @@ SecRule REQUEST_URI "@endsWith /index.php?editor/to-bb-code" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:html,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Post attachment
 # POST /xf/account/avatar
@@ -225,7 +225,7 @@ SecRule REQUEST_FILENAME "@rx /(?:account/avatar|attachments/upload)$" \
     ctl:ruleRemoveTargetById=942440;ARGS:flowIdentifier,\
     ctl:ruleRemoveTargetById=942440;ARGS:flowFilename,\
     ctl:ruleRemoveTargetById=942440;ARGS:flowRelativePath,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Media
 # POST /xf/index.php?editor/media
@@ -237,7 +237,7 @@ SecRule REQUEST_URI "@endsWith /index.php?editor/media" \
     nolog,\
     ctl:ruleRemoveTargetById=931130;ARGS:url,\
     ctl:ruleRemoveTargetById=942130;ARGS:url,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Emoji
 # GET /xf/index.php?misc/find-emoji&q=(%0A%0A
@@ -248,7 +248,7 @@ SecRule REQUEST_URI "@rx /index\.php\?misc/find-emoji&q=" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=921151;ARGS:q,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Login
 # POST /xf/login/login
@@ -260,7 +260,7 @@ SecRule REQUEST_FILENAME "@endsWith /login/login" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:login,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Register account
 # POST /xf/register/register
@@ -275,7 +275,7 @@ SecRule REQUEST_FILENAME "@endsWith /register/register" \
     nolog,\
     ctl:ruleRemoveTargetById=942130;ARGS,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:reg_key,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Confirm account
 # GET /xf/account-confirmation/name.12345/email?c=foo
@@ -297,7 +297,7 @@ SecRule REQUEST_FILENAME "@endsWith /account/account-details" \
     nolog,\
     ctl:ruleRemoveTargetById=931130;ARGS:custom_fields[picture],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:about_html,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Lost password
 # POST /xf/lost-password/user-name.12345/confirm?c=foo
@@ -308,7 +308,7 @@ SecRule REQUEST_FILENAME "@rx /lost-password/.*\.\d+/confirm$" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:c,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Set forum signature
 # POST /xf/account/signature
@@ -319,7 +319,7 @@ SecRule REQUEST_FILENAME "@endsWith /account/signature" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:signature_html,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Search
 # POST /xf/search/search
@@ -334,7 +334,7 @@ SecRule REQUEST_FILENAME "@endsWith /search/search" \
     ctl:ruleRemoveTargetById=942260;ARGS:constraints,\
     ctl:ruleRemoveTargetById=942340;ARGS:constraints,\
     ctl:ruleRemoveTargetById=942370;ARGS:constraints,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Search within thread
 # GET /xf/threads/foo.12345/page12?highlight=foo
@@ -345,7 +345,7 @@ SecRule REQUEST_FILENAME "@rx /threads/.*\.\d+/(?:page\d+)?$" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:highlight,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Search within search result
 # GET /xf/search/12345/?q=foo
@@ -356,7 +356,7 @@ SecRule REQUEST_FILENAME "@rx /search/\d+/$" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:q,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Contact form
 # POST /xf/misc/contact
@@ -368,7 +368,7 @@ SecRule REQUEST_FILENAME "@endsWith /misc/contact" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:subject,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Report post
 # POST /xf/posts/12345/report
@@ -379,7 +379,7 @@ SecRule REQUEST_FILENAME "@rx /posts/\d+/report$" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Alternate thread view route
 # /xf/index.php?threads/title-having-some-sql.12345/
@@ -394,7 +394,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule REQUEST_METHOD "@streq GET" \
         "t:none,\
@@ -418,7 +418,7 @@ SecRule REQUEST_URI "@endsWith /index.php?dbtech-security/fingerprint" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:components[14][value],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:components[15][value],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:components[16][value],\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Get location info
 SecRule REQUEST_FILENAME "@endsWith /misc/location-info" \
@@ -428,7 +428,7 @@ SecRule REQUEST_FILENAME "@endsWith /misc/location-info" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:location,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 #
 # -=[ XenForo Global Exclusions ]=-
@@ -462,7 +462,7 @@ SecAction \
     ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:xf_session,\
     ctl:ruleRemoveTargetById=942210;REQUEST_COOKIES:xf_session,\
     ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:xf_user,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 #
 # -=[ XenForo Administration Back-End ]=-
@@ -476,7 +476,7 @@ SecRule REQUEST_FILENAME "!@endsWith /admin.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     skipAfter:END-XENFORO-ADMIN"
 
 SecRule REQUEST_FILENAME "!@endsWith /admin.php" \
@@ -485,7 +485,7 @@ SecRule REQUEST_FILENAME "!@endsWith /admin.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     skipAfter:END-XENFORO-ADMIN"
 
 # Admin edit user
@@ -498,7 +498,7 @@ SecRule REQUEST_URI "@rx /admin\.php\?users/.*\.\d+/edit$" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:profile[about],\
     ctl:ruleRemoveTargetById=931130;ARGS:profile[website],\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Admin save user
 # POST /xf/admin.php?users/the-user-name.12345/save
@@ -517,7 +517,7 @@ SecRule REQUEST_URI "@rx /admin\.php\?users/.*\.\d+/save$" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:custom_fields[sexuality],\
     ctl:ruleRemoveTargetById=931130;ARGS:custom_fields[picture],\
     ctl:ruleRemoveTargetById=931130;ARGS:profile[website],\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 
 # Admin edit forum notice
@@ -531,7 +531,7 @@ SecRule REQUEST_URI "@rx /admin\.php\?notices/(?:.*\.)?\d+/save$" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:title,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Admin batch thread update
 # POST /xf/admin.php?threads/batch-update/action
@@ -546,7 +546,7 @@ SecRule REQUEST_URI "@rx /admin\.php\?(?:threads|users)/batch-update/action$" \
     ctl:ruleRemoveTargetById=942330;ARGS:criteria,\
     ctl:ruleRemoveTargetById=942340;ARGS:criteria,\
     ctl:ruleRemoveTargetById=942370;ARGS:criteria,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Edit forum theme
 # POST /xf/admin.php?styles/title.1234/style-properties/group&group=basic
@@ -563,7 +563,7 @@ SecRule REQUEST_URI "@rx /admin\.php\?styles/" \
     ctl:ruleRemoveTargetById=942340;ARGS:json,\
     ctl:ruleRemoveTargetById=942370;ARGS:json,\
     ctl:ruleRemoveTargetById=942440;ARGS:json,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Set forum options
 # POST /xf/admin.php?options/update
@@ -575,7 +575,7 @@ SecRule REQUEST_URI "@rx /admin\.php\?options/update$" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:options[allowedCodeLanguages],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:options[boardInactiveMessage],\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Edit pages/templates
 # POST /xf/admin.php?pages/0/save
@@ -588,7 +588,7 @@ SecRule REQUEST_URI "@rx /admin\.php\?(?:pages|templates)/.*/save$" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:template,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Merge templates
 # POST /xf/admin.php?templates/thread_list_macros.12345/merge-outdated
@@ -599,7 +599,7 @@ SecRule REQUEST_URI "@rx /admin\.php\?templates/.*/merge-outdated$" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:merged[],\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # User groups
 # POST POST /xf/admin.php?user-groups/foo.20/save
@@ -610,7 +610,7 @@ SecRule REQUEST_URI "@rx /admin\.php\?user-groups/.*\.\d+/save$" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=942130;ARGS:user_title,\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 SecMarker "END-XENFORO-ADMIN"
 

--- a/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9007-PHPBB-EXCLUSION-RULES.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.4.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. (not) All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -17,7 +17,7 @@ SecRule &TX:crs_exclusions_phpbb|TX:crs_exclusions_phpbb "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     skipAfter:END-PHPBB"
 
 SecRule &TX:crs_exclusions_phpbb|TX:crs_exclusions_phpbb "@eq 0" \
@@ -26,7 +26,7 @@ SecRule &TX:crs_exclusions_phpbb|TX:crs_exclusions_phpbb "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     skipAfter:END-PHPBB"
 
 # Login
@@ -36,7 +36,7 @@ SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:mode "@streq login" \
         "t:none,\
@@ -55,7 +55,7 @@ SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:mode "@streq register" \
         "t:none,\
@@ -72,7 +72,7 @@ SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:mode "@streq reg_details" \
         "t:none,\
@@ -90,7 +90,7 @@ SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule &ARGS:mode "@eq 0" \
         "t:none,\
@@ -109,7 +109,7 @@ SecRule REQUEST_FILENAME "@endsWith /posting.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:mode "@rx ^(?:post|edit|quote|reply)$" \
         "t:none,\
@@ -139,7 +139,7 @@ SecRule REQUEST_FILENAME "@endsWith /posting.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     ctl:ruleRemoveById=200004"
 
 # Private messages
@@ -149,7 +149,7 @@ SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:mode "@rx ^(?:compose|drafts)$" \
         "t:none,\
@@ -168,7 +168,7 @@ SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS_GET:mode "@streq compose" \
         "t:none,\
@@ -189,7 +189,7 @@ SecRule REQUEST_FILENAME "@endsWith /ucp.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:mode "@streq signature" \
         "t:none,\
@@ -208,7 +208,7 @@ SecRule REQUEST_FILENAME "@endsWith /adm/index.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule ARGS:mode "@streq settings" \
         "t:none,\
@@ -225,7 +225,7 @@ SecRule REQUEST_FILENAME "@endsWith /install/app.php/install" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     ctl:ruleRemoveTargetById=931130;ARGS:server_protocol"
 
 

--- a/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.4.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. (not) All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -17,7 +17,7 @@ SecRule &TX:crs_exclusions_phpmyadmin|TX:crs_exclusions_phpmyadmin "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     skipAfter:END-PHPMYADMIN"
 
 SecRule &TX:crs_exclusions_phpmyadmin|TX:crs_exclusions_phpmyadmin "@eq 0" \
@@ -26,7 +26,7 @@ SecRule &TX:crs_exclusions_phpmyadmin|TX:crs_exclusions_phpmyadmin "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     skipAfter:END-PHPMYADMIN"
 
 # Editing / copying a row - loading row data

--- a/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
+++ b/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -23,7 +23,7 @@ SecRule REQUEST_LINE "@streq GET /" \
     tag:'language-multi',\
     tag:'platform-apache',\
     tag:'attack-generic',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
         "t:none,\
@@ -43,7 +43,7 @@ SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
     tag:'language-multi',\
     tag:'platform-apache',\
     tag:'attack-generic',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule REQUEST_HEADERS:User-Agent "@endsWith (internal dummy connection)" \
         "t:none,\

--- a/rules/REQUEST-910-IP-REPUTATION.conf
+++ b/rules/REQUEST-910-IP-REPUTATION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -40,7 +40,7 @@ SecRule TX:DO_REPUT_BLOCK "@eq 1" \
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain,\
     skipAfter:BEGIN-REQUEST-BLOCKING-EVAL"
@@ -70,7 +70,7 @@ SecRule TX:HIGH_RISK_COUNTRY_CODES "!@rx ^$" \
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule TX:REAL_IP "@geoLookup" \
@@ -125,7 +125,7 @@ SecRule IP:PREVIOUS_RBL_CHECK "@eq 1" \
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     skipAfter:END-RBL-LOOKUP"
 
 #
@@ -149,7 +149,7 @@ SecRule &TX:block_suspicious_ip "@eq 0" \
     nolog,\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain,\
     skipAfter:END-RBL-CHECK"
     SecRule &TX:block_harvester_ip "@eq 0" \
@@ -171,7 +171,7 @@ SecRule TX:REAL_IP "@rbl dnsbl.httpbl.org" \
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.httpbl_msg=%{tx.0}',\
     chain"
     SecRule TX:httpbl_msg "@rx RBL lookup of .*?.dnsbl.httpbl.org succeeded at TX:checkip. (.*?): .*" \
@@ -192,7 +192,7 @@ SecRule TX:block_search_ip "@eq 1" \
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain,\
     skipAfter:END-RBL-CHECK"
@@ -216,7 +216,7 @@ SecRule TX:block_spammer_ip "@eq 1" \
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain,\
     skipAfter:END-RBL-CHECK"
@@ -240,7 +240,7 @@ SecRule TX:block_suspicious_ip "@eq 1" \
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain,\
     skipAfter:END-RBL-CHECK"
@@ -264,7 +264,7 @@ SecRule TX:block_harvester_ip "@eq 1" \
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain,\
     skipAfter:END-RBL-CHECK"
@@ -287,7 +287,7 @@ SecAction \
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'ip.previous_rbl_check=1',\
     expirevar:'ip.previous_rbl_check=86400'"
 

--- a/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
+++ b/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -38,7 +38,7 @@ SecRule REQUEST_METHOD "!@within %{tx.allowed_methods}" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/274',\
     tag:'PCI/12.1',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 

--- a/rules/REQUEST-912-DOS-PROTECTION.conf
+++ b/rules/REQUEST-912-DOS-PROTECTION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -69,7 +69,7 @@ SecRule &TX:dos_burst_time_slice "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain,\
     skipAfter:END-DOS-PROTECTION-CHECKS"
     SecRule &TX:dos_counter_threshold "@eq 0" \
@@ -82,7 +82,7 @@ SecRule &TX:dos_burst_time_slice "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain,\
     skipAfter:END-DOS-PROTECTION-CHECKS"
     SecRule &TX:dos_counter_threshold "@eq 0" \
@@ -115,7 +115,7 @@ SecRule IP:DOS_BLOCK "@eq 1" \
     tag:'attack-dos',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/227/469',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule &IP:DOS_BLOCK_FLAG "@eq 0" \
         "setvar:'ip.dos_block_counter=+1',\
@@ -141,7 +141,7 @@ SecRule IP:DOS_BLOCK "@eq 1" \
     tag:'attack-dos',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/227/469',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'ip.dos_block_counter=+1'"
 
 
@@ -163,7 +163,7 @@ SecRule IP:DOS_BLOCK "@eq 1" \
     tag:'platform-multi',\
     tag:'paranoia-level/1',\
     tag:'attack-dos',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     skipAfter:END-DOS-PROTECTION-CHECKS"
 
 
@@ -184,7 +184,7 @@ SecRule REQUEST_BASENAME "@rx .*?(\.[a-z0-9]{1,10})?$" \
     tag:'attack-dos',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/227/469',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.extension=/%{TX.1}/',\
     chain"
     SecRule TX:EXTENSION "!@within %{tx.static_extensions}" \
@@ -216,7 +216,7 @@ SecRule IP:DOS_COUNTER "@ge %{tx.dos_counter_threshold}" \
     tag:'attack-dos',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/227/469',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule &IP:DOS_BURST_COUNTER "@eq 0" \
         "setvar:'ip.dos_burst_counter=1',\
@@ -237,7 +237,7 @@ SecRule IP:DOS_COUNTER "@ge %{tx.dos_counter_threshold}" \
     tag:'attack-dos',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/227/469',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule &IP:DOS_BURST_COUNTER "@ge 1" \
         "setvar:'ip.dos_burst_counter=2',\
@@ -263,7 +263,7 @@ SecRule IP:DOS_BURST_COUNTER "@ge 2" \
     tag:'attack-dos',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/227/469',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'ip.dos_block=1',\
     expirevar:'ip.dos_block=%{tx.dos_block_timeout}'"
 
@@ -296,7 +296,7 @@ SecRule IP:DOS_BURST_COUNTER "@ge 1" \
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/227/469',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'ip.dos_block=1',\
     expirevar:'ip.dos_block=%{tx.dos_block_timeout}'"
 

--- a/rules/REQUEST-913-SCANNER-DETECTION.conf
+++ b/rules/REQUEST-913-SCANNER-DETECTION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -49,7 +49,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scanners-user-agents.data" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/224/541/310',\
     tag:'PCI/6.5.10',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VARS "!@rx ^(?:urlgrabber/[0-9\.]+ yum/[0-9\.]+|mozilla/[0-9\.]+ ecairn-grabber/[0-9\.]+ \(\+http://ecairn.com/grabber\))$" \
@@ -74,7 +74,7 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@pmFromFile scanners-headers.data
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/224/541/310',\
     tag:'PCI/6.5.10',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'ip.reput_block_flag=1',\
@@ -99,7 +99,7 @@ SecRule REQUEST_FILENAME|ARGS "@pmFromFile scanners-urls.data" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/224/541/310',\
     tag:'PCI/6.5.10',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'ip.reput_block_flag=1',\
@@ -139,7 +139,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scripting-user-agents.data" \
     tag:'capec/1000/118/224/541/310',\
     tag:'PCI/6.5.10',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
     setvar:'ip.reput_block_flag=1',\
@@ -173,7 +173,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile crawlers-user-agents.data" \
     tag:'capec/1000/118/224/541/310',\
     tag:'PCI/6.5.10',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
     setvar:'ip.reput_block_flag=1',\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -58,7 +58,7 @@ SecRule REQUEST_LINE "!@rx ^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
@@ -129,7 +129,7 @@ SecRule REQUEST_LINE "!@rx ^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+
 # The regex in the following enabled rule is not supported by non-PCRE
 # regular expression engines (?<!re).
 #
- SecRule FILES_NAMES|FILES "@rx (?<!&(?:[aAoOuUyY]uml)|&(?:[aAeEiIoOuU]circ)|&(?:[eEiIoOuUyY]acute)|&(?:[aAeEiIoOuU]grave)|&(?:[cC]cedil)|&(?:[aAnNoO]tilde)|&(?:amp)|&(?:apos));|['\"=]" \
+SecRule FILES_NAMES|FILES "@rx (?<!&(?:[aAoOuUyY]uml)|&(?:[aAeEiIoOuU]circ)|&(?:[eEiIoOuUyY]acute)|&(?:[aAeEiIoOuU]grave)|&(?:[cC]cedil)|&(?:[aAnNoO]tilde)|&(?:amp)|&(?:apos));|['\"=]" \
     "id:920120,\
     phase:2,\
     block,\
@@ -143,7 +143,7 @@ SecRule REQUEST_LINE "!@rx ^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -172,7 +172,7 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^\d+$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -206,7 +206,7 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule REQUEST_HEADERS:Content-Length "!@rx ^0?$" \
@@ -231,7 +231,7 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule &REQUEST_HEADERS:Transfer-Encoding "!@eq 0" \
@@ -267,7 +267,7 @@ SecRule REQUEST_PROTOCOL "!@within HTTP/2 HTTP/2.0" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_METHOD "@streq POST" \
@@ -297,7 +297,7 @@ SecRule &REQUEST_HEADERS:Transfer-Encoding "!@eq 0" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     chain"
     SecRule &REQUEST_HEADERS:Content-Length "!@eq 0" \
@@ -335,7 +335,7 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx (\d+)-(\d+)" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     chain"
     SecRule TX:2 "@lt %{tx.1}" \
@@ -368,7 +368,7 @@ SecRule REQUEST_HEADERS:Connection "@rx \b(?:keep-alive|close),\s?(?:keep-alive|
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
@@ -401,7 +401,7 @@ SecRule REQUEST_URI "@rx \x25" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/267/72',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_URI "@validateUrlEncoding" \
@@ -421,7 +421,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)application/x-www-form-urlencoded
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/267/72',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_BODY "@rx \x25" \
@@ -453,7 +453,7 @@ SecRule TX:CRS_VALIDATE_UTF8_ENCODING "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/267',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_FILENAME|ARGS|ARGS_NAMES "@validateUtf8Encoding" \
@@ -492,7 +492,7 @@ SecRule REQUEST_URI|REQUEST_BODY "@rx \%u[fF]{2}[0-9a-fA-F]{2}" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/267/72',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
@@ -548,7 +548,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 1-255" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -580,7 +580,7 @@ SecRule &REQUEST_HEADERS:Host "@eq 0" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'PCI/6.5.10',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}',\
     skipAfter:END-HOST-CHECK"
@@ -599,7 +599,7 @@ SecRule REQUEST_HEADERS:Host "@rx ^$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
@@ -639,7 +639,7 @@ SecRule REQUEST_HEADERS:Accept "@rx ^$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'NOTICE',\
     chain"
     SecRule REQUEST_METHOD "!@rx ^OPTIONS$" \
@@ -664,7 +664,7 @@ SecRule REQUEST_HEADERS:Accept "@rx ^$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'NOTICE',\
     chain"
     SecRule REQUEST_METHOD "!@rx ^OPTIONS$" \
@@ -697,7 +697,7 @@ SecRule REQUEST_HEADERS:User-Agent "@rx ^$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'NOTICE',\
     setvar:'tx.anomaly_score_pl1=+%{tx.notice_anomaly_score}'"
 
@@ -734,7 +734,7 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'NOTICE',\
     chain"
     SecRule &REQUEST_HEADERS:Content-Type "@eq 0" \
@@ -779,7 +779,7 @@ SecRule REQUEST_HEADERS:Host "@rx (?:^([\d.]+|\[[\da-f:]+\]|[\da-f:]+)(:[\d]+)?$
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'PCI/6.5.10',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
@@ -811,7 +811,7 @@ SecRule &TX:MAX_NUM_ARGS "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule &ARGS "@gt %{tx.max_num_args}" \
@@ -836,7 +836,7 @@ SecRule &TX:ARG_NAME_LENGTH "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule ARGS_NAMES "@gt %{tx.arg_name_length}" \
@@ -863,7 +863,7 @@ SecRule &TX:ARG_LENGTH "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule ARGS "@gt %{tx.arg_length}" \
@@ -887,7 +887,7 @@ SecRule &TX:TOTAL_ARG_LENGTH "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule ARGS_COMBINED_SIZE "@gt %{tx.total_arg_length}" \
@@ -912,7 +912,7 @@ SecRule &TX:MAX_FILE_SIZE "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)multipart/form-data" \
@@ -938,7 +938,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule FILES_COMBINED_SIZE "@gt %{tx.combined_file_sizes}" \
@@ -977,7 +977,7 @@ SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+-]+(?:\s?;\s?(?:action|boundar
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153',\
     tag:'PCI/12.1',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -1000,7 +1000,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153',\
     tag:'PCI/12.1',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.content_type=|%{tx.0}|',\
     chain"
@@ -1028,7 +1028,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx charset\s*=\s*[\"']?([^;\"'\s]+)" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153',\
     tag:'PCI/12.1',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.content_type_charset=|%{tx.1}|',\
     chain"
@@ -1056,7 +1056,7 @@ SecRule REQUEST_PROTOCOL "!@within %{tx.allowed_http_versions}" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'PCI/6.5.10',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -1079,7 +1079,7 @@ SecRule REQUEST_BASENAME "@rx \.([^.]+)$" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'PCI/6.5.10',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.extension=.%{tx.1}/',\
     chain"
@@ -1106,7 +1106,7 @@ SecRule REQUEST_FILENAME "@rx \.[^.~]+~(?:/.*|)$" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'PCI/6.5.10',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -1151,7 +1151,7 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'PCI/12.1',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.header_name_%{tx.0}=/%{tx.0}/',\
     chain"
@@ -1198,7 +1198,7 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_BASENAME "!@endsWith .pdf" \
@@ -1222,7 +1222,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d+)?-(?:\d+)?\s*,?\s*){63}" \
@@ -1243,7 +1243,7 @@ SecRule ARGS "@rx %[0-9a-fA-F]{2}" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/267/120',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl2=+%{tx.warning_anomaly_score}'"
 
@@ -1265,7 +1265,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 9,10,13,
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
@@ -1292,7 +1292,7 @@ SecRule &REQUEST_HEADERS:User-Agent "@eq 0" \
     tag:'capec/1000/210/272',\
     tag:'PCI/6.5.10',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'NOTICE',\
     setvar:'tx.anomaly_score_pl2=+%{tx.notice_anomaly_score}'"
 
@@ -1314,7 +1314,7 @@ SecRule FILES_NAMES|FILES "@rx ['\";=]" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
@@ -1339,7 +1339,7 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule &REQUEST_HEADERS:Content-Type "@eq 0" \
@@ -1373,7 +1373,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteR
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'paranoia-level/3',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
@@ -1407,7 +1407,7 @@ SecRule &REQUEST_HEADERS:Accept "@eq 0" \
     tag:'capec/1000/210/272',\
     tag:'PCI/6.5.10',\
     tag:'paranoia-level/3',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'NOTICE',\
     chain"
     SecRule REQUEST_METHOD "!@rx ^OPTIONS$" \
@@ -1440,7 +1440,7 @@ SecRule &REQUEST_HEADERS:x-up-devcap-post-charset "@ge 1" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'paranoia-level/3',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule REQUEST_HEADERS:User-Agent "@rx ^(?i)up" \
@@ -1493,7 +1493,7 @@ SecRule &REQUEST_HEADERS:Cache-Control "@gt 0" \
     tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule REQUEST_HEADERS:Cache-Control "!@rx ^(?:(?:max-age=[0-9]+|min-fresh=[0-9]+|no-cache|no-store|no-transform|only-if-cached|max-stale(?:=[0-9]+)?)(?:\s*\,\s*|$)){1,7}$" \
@@ -1524,7 +1524,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'paranoia-level/4',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d+)?-(?:\d+)?\s*,?\s*){6}" \
@@ -1551,7 +1551,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteRange 38,44-46,48-58,61,65-90
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'paranoia-level/4',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
 
@@ -1572,7 +1572,7 @@ SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!RE
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'paranoia-level/4',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
 
@@ -1598,7 +1598,7 @@ SecRule REQUEST_HEADERS:Sec-Fetch-User|REQUEST_HEADERS:Sec-CH-UA-Mobile "!@rx ^(
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'paranoia-level/4',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
 
@@ -1643,7 +1643,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@rx (?:^|[^\\\\])\\\\[cdegh
     tag:'OWASP_CRS',\
     tag:'capec/1000/153/267',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl4=+%{tx.critical_anomaly_score}'"

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -46,7 +46,7 @@ SecRule ARGS_NAMES|ARGS|REQUEST_BODY|XML:/* "@rx (?:get|post|head|options|connec
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/33',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -79,7 +79,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/34',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -101,7 +101,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/34',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -136,7 +136,7 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@rx [\n\r]" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/273',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -165,7 +165,7 @@ SecRule ARGS_NAMES "@rx [\n\r]" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/33',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -187,7 +187,7 @@ SecRule ARGS_GET_NAMES|ARGS_GET "@rx [\n\r]+(?:\s|location|refresh|(?:set-)?cook
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/33',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -213,7 +213,7 @@ SecRule REQUEST_FILENAME "@rx [\n\r]" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/34',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -247,7 +247,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/136',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -281,7 +281,7 @@ SecRule ARGS_GET "@rx [\n\r]" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/33',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -324,7 +324,7 @@ SecRule ARGS_NAMES "@rx ." \
     tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/137/15/460',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'TX.paramcounter_%{MATCHED_VAR_NAME}=+1'"
 
 SecRule TX:/paramcounter_.*/ "@gt 1" \
@@ -340,7 +340,7 @@ SecRule TX:/paramcounter_.*/ "@gt 1" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/137/15/460',\
     tag:'paranoia-level/3',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VARS_NAMES "@rx TX:paramcounter_(.*)" \

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -41,7 +41,7 @@ SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@r
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/126',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}'"
@@ -68,7 +68,7 @@ SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@rx (?
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/126',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
@@ -95,7 +95,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/126',\
     tag:'PCI/6.5.4',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -122,7 +122,7 @@ SecRule REQUEST_FILENAME "@pmFromFile restricted-files.data" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/126',\
     tag:'PCI/6.5.4',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"

--- a/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
+++ b/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -49,7 +49,7 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?)://(?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/175/253',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -70,7 +70,7 @@ SecRule QUERY_STRING|REQUEST_BODY "@rx (?i)(?:\binclude\s*\([^)]*|mosConfig_abso
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/175/253',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -91,7 +91,7 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?).*?\?+$" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/175/253',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -120,7 +120,7 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?)://([^/]*).*$" \
     tag:'capec/1000/152/175/253',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_parameter_%{MATCHED_VAR_NAME}=.%{tx.1}',\
     chain"

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -117,7 +117,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -153,7 +153,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -250,7 +250,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -289,7 +289,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -324,7 +324,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -361,7 +361,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -407,7 +407,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -458,7 +458,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -495,7 +495,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -527,7 +527,7 @@ SecRule REQUEST_HEADERS|REQUEST_LINE "@rx ^\(\s*\)\s+{" \
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -549,7 +549,7 @@ SecRule ARGS_NAMES|ARGS|FILES_NAMES "@rx ^\(\s*\)\s+{" \
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -584,7 +584,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -628,7 +628,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -666,7 +666,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VAR "@rx /" "t:none,t:urlDecodeUni,chain"
@@ -708,7 +708,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -755,7 +755,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -787,7 +787,7 @@ SecRule ARGS "@rx (?:/|\\\\)(?:[\?\*]+[a-z/\\\\]+|[a-z/\\\\]+[\?\*]+)" \
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -59,7 +59,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -101,7 +101,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -126,7 +126,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VARS "@pm =" \
@@ -154,7 +154,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -191,7 +191,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -220,7 +220,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -288,7 +288,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -342,7 +342,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -398,7 +398,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -454,7 +454,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -496,7 +496,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -540,7 +540,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'capec/1000/152/242',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VARS "@pm (" \
@@ -594,7 +594,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/242',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -640,7 +640,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'capec/1000/152/242',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -683,7 +683,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'capec/1000/152/242',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -713,7 +713,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/242',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"

--- a/rules/REQUEST-934-APPLICATION-ATTACK-NODEJS.conf
+++ b/rules/REQUEST-934-APPLICATION-ATTACK-NODEJS.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -62,7 +62,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -49,7 +49,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -76,7 +76,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -108,7 +108,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -138,7 +138,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -164,7 +164,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -199,7 +199,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -224,7 +224,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -251,7 +251,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -278,7 +278,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -300,7 +300,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -322,7 +322,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -344,7 +344,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -366,7 +366,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -388,7 +388,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -410,7 +410,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -432,7 +432,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -454,7 +454,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -476,7 +476,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -498,7 +498,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -520,7 +520,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -547,7 +547,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -574,7 +574,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -616,7 +616,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242/63',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -644,7 +644,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS|XML:
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242/63',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -675,7 +675,7 @@ SecRule REQUEST_HEADERS:Referer "@detectXSS" \
     tag:'capec/1000/152/242',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -701,7 +701,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'capec/1000/152/242',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -729,7 +729,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -816,7 +816,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'capec/1000/152/242/63',\
     tag:'PCI/6.5.1',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -837,7 +837,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'capec/1000/152/242',\
     tag:'PCI/6.5.1',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -861,7 +861,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'capec/1000/152/242',\
     tag:'PCI/6.5.1',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -894,7 +894,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/242/63',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -58,7 +58,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
@@ -93,7 +93,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -136,7 +136,7 @@ SecRule REQUEST_BASENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIE
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -165,7 +165,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -194,7 +194,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -218,7 +218,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -239,7 +239,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -268,7 +268,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -289,7 +289,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -310,7 +310,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -339,7 +339,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -360,7 +360,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -389,7 +389,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -418,7 +418,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -460,7 +460,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -496,7 +496,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -534,7 +534,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?:^\s*[\"'`;]+|[\"'`]+\s*$)" \
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.warning_anomaly_score}'"
@@ -570,7 +570,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:(?:^|\W)in[+\s]*\([\s\d\"]+[^()]*\)|\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -605,7 +605,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i:[\s'\"`()]*?\b([\d\w]+)\b[\s'\"`()]*?(?:
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -644,7 +644,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -673,7 +673,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -705,7 +705,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -737,7 +737,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -766,7 +766,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -795,7 +795,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -824,7 +824,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -861,7 +861,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -892,7 +892,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -917,7 +917,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -950,7 +950,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.4.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -985,7 +985,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1012,7 +1012,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1039,7 +1039,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1069,7 +1069,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1106,7 +1106,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1139,7 +1139,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1172,7 +1172,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1213,7 +1213,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl2=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"
@@ -1257,7 +1257,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -1282,7 +1282,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1331,7 +1331,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1370,7 +1370,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -1394,7 +1394,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -1434,7 +1434,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl3=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"
@@ -1463,7 +1463,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl3=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"
@@ -1493,7 +1493,7 @@ SecRule ARGS "@rx \W{4}" \
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.warning_anomaly_score}'"
@@ -1527,7 +1527,7 @@ SecRule REQUEST_BASENAME "@detectSQLi" \
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -1577,7 +1577,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -1610,7 +1610,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/4',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl4=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"
@@ -1639,7 +1639,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/4',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl4=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"

--- a/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
+++ b/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -43,7 +43,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/21/593/61',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.session_fixation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -65,7 +65,7 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/21/593/61',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule REQUEST_HEADERS:Referer "@rx ^(?:ht|f)tps?://(.*?)/" \
@@ -92,7 +92,7 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/21/593/61',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule &REQUEST_HEADERS:Referer "@eq 0" \

--- a/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -45,7 +45,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'capec/1000/152/137/6',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/1',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -78,7 +78,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/1',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* "@rx (?:unmarshaller|base64data|java\.)" \
@@ -103,7 +103,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/1',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VARS "@rx (?:runtime|processbuilder)" \
@@ -135,7 +135,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/1',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -173,7 +173,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -194,7 +194,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -215,7 +215,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -239,7 +239,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -274,7 +274,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"

--- a/rules/REQUEST-949-BLOCKING-EVALUATION.conf
+++ b/rules/REQUEST-949-BLOCKING-EVALUATION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -126,7 +126,7 @@ SecRule IP:REPUT_BLOCK_FLAG "@eq 1" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule TX:DO_REPUT_BLOCK "@eq 1" \
@@ -145,7 +145,7 @@ SecRule TX:ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-generic',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score=%{tx.anomaly_score}'"
 
@@ -159,7 +159,7 @@ SecRule TX:BLOCKING_EARLY "@eq 1" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-generic',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule TX:ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \

--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -44,7 +44,7 @@ SecRule RESPONSE_BODY "@rx (?:<(?:TITLE>Index of.*?<H|title>Index of.*?<h)1>Inde
     tag:'capec/1000/118/116/54/127',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
@@ -78,7 +78,7 @@ SecRule RESPONSE_BODY "@rx ^#\!\s?/" \
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
@@ -110,7 +110,7 @@ SecRule RESPONSE_STATUS "@rx ^5\d{2}$" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/152',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl2=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.error_anomaly_score}'"

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -38,7 +38,7 @@ SecRule RESPONSE_BODY "@pmFromFile sql-errors.data" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.sql_error_match=1'"
 
 SecRule TX:sql_error_match "@eq 1" \
@@ -57,7 +57,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:JET Database Engine|Access Database Engine|\[Microsoft\]\[ODBC Microsoft Access Driver\])" \
@@ -82,7 +82,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:ORA-[0-9][0-9][0-9][0-9]|java\.sql\.SQLException|Oracle error|Oracle.*Driver|Warning.*oci_.*|Warning.*ora_.*)" \
@@ -107,7 +107,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:DB2 SQL error:|\[IBM\]\[CLI Driver\]\[DB2/6000\]|CLI Driver.*DB2|DB2 SQL error|db2_\w+\()" \
@@ -132,7 +132,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:\[DM_QUERY_E_SYNTAX\]|has occurred in the vicinity of:)" \
@@ -157,7 +157,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)Dynamic SQL Error" \
@@ -183,7 +183,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)Exception (?:condition )?\d+\. Transaction rollback\." \
@@ -208,7 +208,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)org\.hsqldb\.jdbc" \
@@ -233,7 +233,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:An illegal character has been found in the statement|com\.informix\.jdbc|Exception.*Informix)" \
@@ -259,7 +259,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:Warning.*ingres_|Ingres SQLSTATE|Ingres\W.*Driver)" \
@@ -285,7 +285,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:<b>Warning</b>: ibase_|Unexpected end of command in statement)" \
@@ -310,7 +310,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:SQL error.*POS[0-9]+.*|Warning.*maxdb.*)" \
@@ -335,7 +335,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)(?:System\.Data\.OleDb\.OleDbException|\[Microsoft\]\[ODBC SQL Server Driver\]|\[Macromedia\]\[SQLServer JDBC Driver\]|\[SqlException|System\.Data\.SqlClient\.SqlException|Unclosed quotation mark after the character string|'80040e14'|mssql_query\(\)|Microsoft OLE DB Provider for ODBC Drivers|Microsoft OLE DB Provider for SQL Server|Incorrect syntax near|Sintaxis incorrecta cerca de|Syntax error in string in query expression|Procedure or function .* expects parameter|Unclosed quotation mark before the character string|Syntax error .* in query expression|Data type mismatch in criteria expression\.|ADODB\.Field \(0x800A0BCD\)|the used select statements have different number of columns|OLE DB.*SQL Server|Warning.*mssql_.*|Driver.*SQL[ _-]*Server|SQL Server.*Driver|SQL Server.*[0-9a-fA-F]{8}|Exception.*\WSystem\.Data\.SqlClient\.)" \
@@ -360,7 +360,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)(?:supplied argument is not a valid MySQL|Column count doesn't match value count at row|mysql_fetch_array\(\)|on MySQL result index|You have an error in your SQL syntax;|You have an error in your SQL syntax near|MySQL server version for the right syntax to use|\[MySQL\]\[ODBC|Column count doesn't match|Table '[^']+' doesn't exist|SQL syntax.*MySQL|Warning.*mysql_.*|valid MySQL result|MySqlClient\.)" \
@@ -385,7 +385,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:PostgreSQL query failed:|pg_query\(\) \[:|pg_exec\(\) \[:|PostgreSQL.*ERROR|Warning.*\bpg_.*|valid PostgreSQL result|Npgsql\.|PG::[a-zA-Z]*Error|Supplied argument is not a valid PostgreSQL .*? resource|Unable to connect to PostgreSQL server)" \
@@ -410,7 +410,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)(?:Warning.*sqlite_.*|Warning.*SQLite3::|SQLite/JDBCDriver|SQLite\.Exception|System\.Data\.SQLite\.SQLiteException)" \
@@ -435,7 +435,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)(?:Sybase message:|Warning.*sybase.*|Sybase.*Server message.*)" \

--- a/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
+++ b/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -39,7 +39,7 @@ SecRule RESPONSE_BODY "@pmFromFile java-code-leakages.data" \
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
@@ -66,7 +66,7 @@ SecRule RESPONSE_BODY "@pmFromFile java-errors.data" \
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"

--- a/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -39,7 +39,7 @@ SecRule RESPONSE_BODY "@pmFromFile php-errors.data" \
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
@@ -66,7 +66,7 @@ SecRule RESPONSE_BODY "@rx (?:\b(?:f(?:tp_(?:nb_)?f?(?:ge|pu)t|get(?:s?s|c)|scan
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
@@ -97,7 +97,7 @@ SecRule RESPONSE_BODY "@rx <\?(?!xml)" \
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ERROR',\
     chain"
     SecRule RESPONSE_BODY "!@rx (?:\x1f\x8b\x08|\b(?:(?:i(?:nterplay|hdr|d3)|m(?:ovi|thd)|r(?:ar!|iff)|(?:ex|jf)if|f(?:lv|ws)|varg|cws)\b|gif)|B(?:%pdf|\.ra)\b|^wOF[F2])" \

--- a/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+++ b/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -37,7 +37,7 @@ SecRule RESPONSE_BODY "@rx [a-z]:\\\\inetpub\b" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
@@ -60,7 +60,7 @@ SecRule RESPONSE_BODY "@rx (?:Microsoft OLE DB Provider for SQL Server(?:</font>
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
@@ -86,7 +86,7 @@ SecRule RESPONSE_BODY "@rx (?:\b(?:A(?:DODB\.Command\b.{0,100}?\b(?:Application 
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
@@ -110,7 +110,7 @@ SecRule RESPONSE_STATUS "!@rx ^404$" \
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ERROR',\
     chain"
     SecRule RESPONSE_BODY "@rx \bServer Error in.{0,50}?\bApplication\b" \

--- a/rules/RESPONSE-955-WEB-SHELLS.conf
+++ b/rules/RESPONSE-955-WEB-SHELLS.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. (not) All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -35,7 +35,7 @@ SecRule RESPONSE_BODY "@rx (<title>r57 Shell Version [0-9.]+</title>|<title>r57 
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -56,7 +56,7 @@ SecRule RESPONSE_BODY "@rx <title>.*? - WSO [0-9.]+</title>" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -77,7 +77,7 @@ SecRule RESPONSE_BODY "@rx B4TM4N SH3LL</title>.*<meta name='author' content='k4
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -98,7 +98,7 @@ SecRule RESPONSE_BODY "@rx <title>Mini Shell</title>.*Developed By LameHacker" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -119,7 +119,7 @@ SecRule RESPONSE_BODY "@contains <title>Loader'z WEB shell</title>" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -140,7 +140,7 @@ SecRule RESPONSE_BODY "@contains <title>Con7ext Shell V.2</title>" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -161,7 +161,7 @@ SecRule RESPONSE_BODY "@contains <title>Yourman.sh Mini Shell</title>" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -182,7 +182,7 @@ SecRule RESPONSE_BODY "@contains <title>ZEROSHELL | ZEROSTORE</title>" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -203,7 +203,7 @@ SecRule RESPONSE_BODY "@contains <font color=\"red\">USTADCAGE_48</font> <font c
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -224,7 +224,7 @@ SecRule RESPONSE_BODY "@contains <title>0byt3m1n1-V2</title>" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -245,7 +245,7 @@ SecRule RESPONSE_BODY "@contains <link rel='SHORTCUT ICON' href='data:image/png;
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -266,7 +266,7 @@ SecRule RESPONSE_BODY "@contains <title>Ani-Shell | India</title>" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -287,7 +287,7 @@ SecRule RESPONSE_BODY "@contains <title>IndoXploit</title>" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -308,7 +308,7 @@ SecRule RESPONSE_BODY "@contains <title>Dive Shell - Emperor Hacking Team</title
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -329,7 +329,7 @@ SecRule RESPONSE_BODY "@contains <title>=[ 1n73ct10n privat shell ]=</title>" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -351,7 +351,7 @@ SecRule RESPONSE_BODY "@contains <font face=Webdings size=6><b>!</b></font>" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -372,7 +372,7 @@ SecRule RESPONSE_BODY "@contains ~ ALFA TEaM Shell -" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -393,7 +393,7 @@ SecRule RESPONSE_BODY "@rx <title>\.:: .* ~ Ashiyane V [0-9.]+ ::\.</title>" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -415,7 +415,7 @@ SecRule RESPONSE_BODY "@contains <font color=lime>./rusuh</font>" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -436,7 +436,7 @@ SecRule RESPONSE_BODY "@contains Safe0ver Shell //Safe Mod Bypass  Safe0ver Shel
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -457,7 +457,7 @@ SecRule RESPONSE_BODY "@rx <title>Symlink_Sa [0-9.]+</title>" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -478,7 +478,7 @@ SecRule RESPONSE_BODY "@contains <title>SyRiAn Sh3ll ~ " \
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -500,7 +500,7 @@ SecRule RESPONSE_BODY "@contains <b>--[ x2300 Locus7Shell v. " \
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -521,7 +521,7 @@ SecRule RESPONSE_BODY "@contains <H1><center>-=[+] IDBTEAM SHELLS " \
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -542,7 +542,7 @@ SecRule RESPONSE_BODY "@contains <title>Small Shell - Edited By KingDefacer</tit
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -564,7 +564,7 @@ SecRule RESPONSE_BODY "@contains <input type='submit' value='file' /></form>Anon
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -593,7 +593,7 @@ SecRule RESPONSE_BODY "@contains <h1 style=\"margin-bottom: 0\">webadmin.php</h1
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/122/17/650',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"

--- a/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
+++ b/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -132,7 +132,7 @@ SecRule TX:OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
     t:none,\
     msg:'Outbound Anomaly Score Exceeded (Total Score: %{TX.OUTBOUND_ANOMALY_SCORE})',\
     tag:'anomaly-evaluation',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.anomaly_score=+%{tx.outbound_anomaly_score}'"
 
 SecRule TX:BLOCKING_EARLY "@eq 1" \
@@ -145,7 +145,7 @@ SecRule TX:BLOCKING_EARLY "@eq 1" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-generic',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
     SecRule TX:OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under
@@ -28,7 +28,7 @@ SecRule &TX:'/LEAKAGE\\\/ERRORS/' "@ge 1" \
     t:none,\
     msg:'Correlated Successful Attack Identified: (Total Score: %{tx.anomaly_score}) Inbound Attack (Inbound Anomaly Score: %{TX.INBOUND_ANOMALY_SCORE}) + Outbound Data Leakage (Outbound Anomaly Score: %{TX.OUTBOUND_ANOMALY_SCORE})',\
     tag:'event-correlation',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'EMERGENCY',\
     chain,\
     skipAfter:END-CORRELATION"
@@ -44,7 +44,7 @@ SecRule &TX:'/AVAILABILITY\\\/APP_NOT_AVAIL/' "@ge 1" \
     t:none,\
     msg:'Correlated Attack Attempt Identified: (Total Score: %{tx.anomaly_score}) Inbound Attack (Inbound Anomaly Score: %{TX.INBOUND_ANOMALY_SCORE}) + Outbound Application Error (Outbound Anomaly Score: %{TX.OUTBOUND_ANOMALY_SCORE})',\
     tag:'event-correlation',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ALERT',\
     chain,\
     skipAfter:END-CORRELATION"
@@ -58,7 +58,7 @@ SecAction \
     t:none,\
     nolog,\
     noauditlog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.executing_anomaly_score=%{tx.anomaly_score_pl1}',\
     setvar:'tx.executing_anomaly_score=+%{tx.anomaly_score_pl2}',\
     setvar:'tx.executing_anomaly_score=+%{tx.anomaly_score_pl3}',\
@@ -72,7 +72,7 @@ SecRule TX:INBOUND_ANOMALY_SCORE "@lt %{tx.inbound_anomaly_score_threshold}" \
     noauditlog,\
     msg:'Inbound Anomaly Score (Total Inbound Score: %{TX.INBOUND_ANOMALY_SCORE} - SQLI=%{tx.sql_injection_score},XSS=%{tx.xss_score},RFI=%{tx.rfi_score},LFI=%{tx.lfi_score},RCE=%{tx.rce_score},PHPI=%{tx.php_injection_score},HTTP=%{tx.http_violation_score},SESS=%{tx.session_fixation_score}): individual paranoia level scores: %{TX.ANOMALY_SCORE_PL1}, %{TX.ANOMALY_SCORE_PL2}, %{TX.ANOMALY_SCORE_PL3}, %{TX.ANOMALY_SCORE_PL4}',\
     tag:'event-correlation',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule TX:EXECUTING_ANOMALY_SCORE "@gt 1"
 
@@ -84,7 +84,7 @@ SecRule TX:INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
     noauditlog,\
     msg:'Inbound Anomaly Score Exceeded (Total Inbound Score: %{TX.INBOUND_ANOMALY_SCORE} - SQLI=%{tx.sql_injection_score},XSS=%{tx.xss_score},RFI=%{tx.rfi_score},LFI=%{tx.lfi_score},RCE=%{tx.rce_score},PHPI=%{tx.php_injection_score},HTTP=%{tx.http_violation_score},SESS=%{tx.session_fixation_score}): individual paranoia level scores: %{TX.ANOMALY_SCORE_PL1}, %{TX.ANOMALY_SCORE_PL2}, %{TX.ANOMALY_SCORE_PL3}, %{TX.ANOMALY_SCORE_PL4}',\
     tag:'event-correlation',\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 SecRule TX:OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
     "id:980140,\
@@ -94,7 +94,7 @@ SecRule TX:OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
     noauditlog,\
     msg:'Outbound Anomaly Score Exceeded (score %{TX.OUTBOUND_ANOMALY_SCORE}): individual paranoia level scores: %{TX.OUTBOUND_ANOMALY_SCORE_PL1}, %{TX.OUTBOUND_ANOMALY_SCORE_PL2}, %{TX.OUTBOUND_ANOMALY_SCORE_PL3}, %{TX.OUTBOUND_ANOMALY_SCORE_PL4}',\
     tag:'event-correlation',\
-    ver:'OWASP_CRS/3.3.0'"
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Creating a total sum of all triggered outbound rules, including the ones only being monitored
 SecAction \
@@ -104,7 +104,7 @@ SecAction \
     t:none,\
     nolog,\
     noauditlog,\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.executing_anomaly_score=%{tx.outbound_anomaly_score_pl1}',\
     setvar:'tx.executing_anomaly_score=+%{tx.outbound_anomaly_score_pl2}',\
     setvar:'tx.executing_anomaly_score=+%{tx.outbound_anomaly_score_pl3}',\
@@ -118,7 +118,7 @@ SecRule TX:OUTBOUND_ANOMALY_SCORE "@lt %{tx.outbound_anomaly_score_threshold}" \
     noauditlog,\
     msg:'Outbound Anomaly Score (Total Outbound Score: %{TX.OUTBOUND_ANOMALY_SCORE}): individual paranoia level scores: %{TX.OUTBOUND_ANOMALY_SCORE_PL1}, %{TX.OUTBOUND_ANOMALY_SCORE_PL2}, %{TX.OUTBOUND_ANOMALY_SCORE_PL3}, %{TX.OUTBOUND_ANOMALY_SCORE_PL4}',\
     tag:'event-correlation',\
-    ver:'OWASP_CRS/3.3.0',\
+    ver:'OWASP_CRS/3.4.0-dev',\
     chain"
     SecRule TX:EXECUTING_ANOMALY_SCORE "@gt 1"
 

--- a/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf.example
+++ b/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf.example
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.0
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 #
 # The OWASP ModSecurity Core Rule Set is distributed under


### PR DESCRIPTION
For the development branch, use "x.y.z-dev" notation.
Change made automatically in all rule files using Airween's cool tool from #2085:

```
python3 -m pip install --user --upgrade msc_pyparser
cd util/change-version
./change-version.py "../../rules/*.conf" ../../rules/ "OWASP_CRS/3.4.0-dev" "3.4.0-dev"
```

Also, the version number in crs-setup.conf.example (rule 900990) was updated manually.