### PR TITLE
Fix FP 953120 brotli compression

### DIFF
--- a/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -103,8 +103,10 @@ SecRule RESPONSE_BODY "@rx <\?(?!xml)" \
     SecRule RESPONSE_BODY "!@rx (?:\x1f\x8b\x08|\b(?:(?:i(?:nterplay|hdr|d3)|m(?:ovi|thd)|r(?:ar!|iff)|(?:ex|jf)if|f(?:lv|ws)|varg|cws)\b|gif)|B(?:%pdf|\.ra)\b|^wOF[F2])" \
         "capture,\
         t:none,\
-        setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+        chain"
+        SecRule RESPONSE_HEADERS:Content-Encoding "!@streq br" \
+            "setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+            setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:953013,phase:3,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"


### PR DESCRIPTION
This PR solves a false positive with Content-Type: br responses by adding a chained rule as discussed in the related issue #2064.

I didn't test this PR and I would be glad if someone else could review and maybe test the chained rule.