### PR TITLE
Remove rule 910110 : ModSecurity Rules from Trustwave SpiderLabs: IP Blacklist Alert

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ Please read file ```crs-setup.conf.example``` for an introduction and a more det
 * Matches that cause false positives are limited to use score notice and warning
 * False positive rates increased (even on single string)
 * False negatives should not happen here
-* Check everything against RFC and white listed values for most popular elements
+* Check everything against RFC and allow listed values for most popular elements
 
 
 ## ID Numbering Scheme

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -619,7 +619,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 
 
 #
-# -- [[ Project Honey Pot HTTP Blacklist ]] ------------------------------------
+# -- [[ Project Honey Pot HTTP:BL ]] -------------------------------------------
 #
 # Optionally, you can check the client IP address against the Project Honey Pot
 # HTTPBL (dnsbl.httpbl.org). In order to use this, you need to register to get a

--- a/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example
+++ b/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example
@@ -84,7 +84,7 @@
 # related blog post -
 # http://blog.spiderlabs.com/2010/12/advanced-topic-of-the-week-handling-authorized-scanning-traffic.html
 #
-# White-list ASV network block (no blocking or logging of AVS traffic) Update
+# Allow List ASV network block (no blocking or logging of AVS traffic) Update
 # IP network block as appropriate for your AVS traffic
 #
 # ModSec Rule Exclusion: Disable Rule Engine for known ASV IP
@@ -130,7 +130,7 @@
 # Example Exclusion Rule: Removing a specific ARGS parameter from inspection
 #                         for all CRS rules
 #
-# This rule illustrates that we can use tagging very effectively to whitelist a
+# This rule illustrates that we can use tagging very effectively to allow list a
 # common false positive across an entire ModSecurity instance. This can be done
 # because every rule in OWASP_CRS is tagged with OWASP_CRS. This will NOT
 # affect custom rules.

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -691,7 +691,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/options-permalink.php" \
     ctl:ruleRemoveTargetById=920272;REQUEST_BODY,\
     ver:'OWASP_CRS/3.4.0-dev'"
 
-# Comments blacklist and moderation list
+# Comments deny list and moderation list
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/options.php" \
     "id:9002820,\
     phase:2,\

--- a/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
@@ -272,7 +272,7 @@ SecRule REQUEST_FILENAME "@endsWith /error_report.php" \
         ctl:ruleRemoveTargetById=934100;ARGS,\
         ctl:ruleRemoveTargetById=942100;ARGS"
 
-# Session cookies whitelist
+# Session cookies allow list
 SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
     "id:9008240,\
     phase:1,\

--- a/rules/REQUEST-910-IP-REPUTATION.conf
+++ b/rules/REQUEST-910-IP-REPUTATION.conf
@@ -86,28 +86,6 @@ SecRule TX:HIGH_RISK_COUNTRY_CODES "!@rx ^$" \
 #
 # -=[ IP Reputation Checks ]=-
 #
-# ModSecurity Rules from Trustwave SpiderLabs: IP Deny List Alert
-# Ref: http://www.modsecurity.org/projects/commercial/rules/
-#
-# This rule checks the client IP address against a list of recent IPs captured
-# from the SpiderLabs web honeypot systems (last 48 hours).
-#
-# SecRule TX:REAL_IP "@ipMatchFromFile ip_blacklist.data" \
-#    "id:910110,\
-#    phase:2,\
-#    block,\
-#    t:none,\
-#    msg:'Client IP in Trustwave SpiderLabs IP Reputation Deny List',\
-#    tag:'application-multi',\
-#    tag:'language-multi',\
-#    tag:'platform-multi',\
-#    tag:'attack-reputation-ip',\
-#    tag:'paranoia-level/1',\
-#    severity:'CRITICAL',\
-#    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-#    setvar:'ip.reput_block_flag=1',\
-#    setvar:'ip.reput_block_reason=%{rule.msg}',\
-#    expirevar:'ip.reput_block_flag=%{tx.reput_block_duration}'"
 
 
 #

--- a/rules/REQUEST-910-IP-REPUTATION.conf
+++ b/rules/REQUEST-910-IP-REPUTATION.conf
@@ -23,7 +23,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:910012,phase:2,pass,nolog,skipAf
 # -=[ IP Reputation Block Flag Check ]=-
 #
 # The first check we do is to see if the client IP address has already
-# been blacklisted by rules from previous requests.
+# been deny listed by rules from previous requests.
 #
 # If the rule matches, it will do a skipAfter and pick up processing
 # at the end of the request phase for actual blocking.
@@ -86,7 +86,7 @@ SecRule TX:HIGH_RISK_COUNTRY_CODES "!@rx ^$" \
 #
 # -=[ IP Reputation Checks ]=-
 #
-# ModSecurity Rules from Trustwave SpiderLabs: IP Blacklist Alert
+# ModSecurity Rules from Trustwave SpiderLabs: IP Deny List Alert
 # Ref: http://www.modsecurity.org/projects/commercial/rules/
 #
 # This rule checks the client IP address against a list of recent IPs captured
@@ -97,7 +97,7 @@ SecRule TX:HIGH_RISK_COUNTRY_CODES "!@rx ^$" \
 #    phase:2,\
 #    block,\
 #    t:none,\
-#    msg:'Client IP in Trustwave SpiderLabs IP Reputation Blacklist',\
+#    msg:'Client IP in Trustwave SpiderLabs IP Reputation Deny List',\
 #    tag:'application-multi',\
 #    tag:'language-multi',\
 #    tag:'platform-multi',\
@@ -130,12 +130,12 @@ SecRule IP:PREVIOUS_RBL_CHECK "@eq 1" \
     skipAfter:END-RBL-LOOKUP"
 
 #
-# Check Client IP against ProjectHoneypot's HTTP Blacklist
+# Check Client IP against ProjectHoneypot's HTTP Deny List
 # Ref: http://www.projecthoneypot.org/httpbl_api.php
 #
-# To use the blacklist, you must register for an HttpBL API Key
+# To use the deny list, you must register for an HttpBL API Key
 # and choose the traffic types to block. See section
-# "Project Honey Pot HTTP Blacklist" in crs-setup.conf.
+# "Project Honey Pot HTTP:BL" in crs-setup.conf.
 #
 # Ref: https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual#wiki-SecHttpBlKey
 #
@@ -186,7 +186,7 @@ SecRule TX:block_search_ip "@eq 1" \
     phase:2,\
     block,\
     t:none,\
-    msg:'HTTP Blacklist match for search engine IP',\
+    msg:'HTTP Deny List match for search engine IP',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -210,7 +210,7 @@ SecRule TX:block_spammer_ip "@eq 1" \
     phase:2,\
     block,\
     t:none,\
-    msg:'HTTP Blacklist match for spammer IP',\
+    msg:'HTTP Deny List match for spammer IP',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -234,7 +234,7 @@ SecRule TX:block_suspicious_ip "@eq 1" \
     phase:2,\
     block,\
     t:none,\
-    msg:'HTTP Blacklist match for suspicious IP',\
+    msg:'HTTP Deny List match for suspicious IP',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -258,7 +258,7 @@ SecRule TX:block_harvester_ip "@eq 1" \
     phase:2,\
     block,\
     t:none,\
-    msg:'HTTP Blacklist match for harvester IP',\
+    msg:'HTTP Deny List match for harvester IP',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\

--- a/rules/REQUEST-913-SCANNER-DETECTION.conf
+++ b/rules/REQUEST-913-SCANNER-DETECTION.conf
@@ -31,7 +31,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:913012,phase:2,pass,nolog,skipAf
 # 913101 - scripting/generic HTTP clients (data file scripting-user-agents.data)
 # 913102 - web crawlers/bots (data file crawlers-user-agents.data)
 #
-# Chained rule is doing whitelist for:
+# Chained rule is allow listing:
 # YUM package manager of CentOS / Fedore: User-Agent: urlgrabber/3.10 yum/3.4.3
 # eCairn service: User-Agent: mozilla/5.0 ecairn-grabber/1.0 (+http://ecairn.com/grabber)
 SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scanners-user-agents.data" \

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -954,7 +954,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
 
 # Restrict Content-Type header to established patterns.
 #
-# This provides generic whitelist protection against vulnerabilities like
+# This provides generic allow list protection against vulnerabilities like
 # Apache Struts Content-Type arbitrary command execution (CVE-2017-5638).
 #
 # Examples of allowed patterns:
@@ -1450,10 +1450,10 @@ SecRule &REQUEST_HEADERS:x-up-devcap-post-charset "@ge 1" \
 
 
 #
-# Cache-Control Request Header whitelist
+# Cache-Control Request Header allow list
 #
 # -=[ Rule Logic ]=-
-# This rule aims to strictly whitelist the Cache-Control request header
+# This rule aims to strictly allow list the Cache-Control request header
 # values and to blocks all violations. This should be useful to intercept
 # "bad bot" and tools that impersonate a real browser but with wrong request
 # header setup.
@@ -1490,7 +1490,7 @@ SecRule &REQUEST_HEADERS:Cache-Control "@gt 0" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
-    tag:'header-whitelist',\
+    tag:'header-allowlist',\
     tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -25,8 +25,8 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:930012,phase:2,pass,nolog,skipAf
 #
 # This rule is trying to decide as hard as possible if the request is a callback
 # of Google OAuth2. It is supposed to be tight enough to not activate on bogus
-# or invalid Google OAuth2 callbacks as this may result in bypass of rules with
-# are using this detection to do a whitelist.
+# or invalid Google OAuth2 callbacks as this may result in bypass of rules which
+# are using this detection as an allow list.
 # Currently used by rule 930120.
 SecRule &ARGS_GET "@eq 3" \
     "id:930050,\

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -232,7 +232,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
 
 
 #
-# [Blacklist Keywords from Node-Validator]
+# [Deny List Keywords from Node-Validator]
 # https://raw.github.com/chriso/node-validator/master/validator.js
 # This rule has a stricter sibling 941181 (PL2) that covers the additional payload "-->"
 #
@@ -242,7 +242,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     block,\
     capture,\
     t:none,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,t:removeNulls,\
-    msg:'Node-Validator Blacklist Keywords',\
+    msg:'Node-Validator Deny List Keywords',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
@@ -710,7 +710,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
 
 
 #
-# [Blacklist Keywords from Node-Validator]
+# [Deny List Keywords from Node-Validator]
 # https://raw.github.com/chriso/node-validator/master/validator.js
 # This rule is a stricter sibling of 941180 (PL1)
 #
@@ -720,7 +720,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     block,\
     capture,\
     t:none,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,t:lowercase,t:removeNulls,\
-    msg:'Node-Validator Blacklist Keywords',\
+    msg:'Node-Validator Deny List Keywords',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1229,7 +1229,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'´�
 # DROP sampletable;--
 # admin'--
 # DROP/*comment*/sampletable
-# DR/**/OP/*bypass blacklisting*/sampletable
+# DR/**/OP/*bypass deny listing*/sampletable
 # SELECT/*avoid-spaces*/password/**/FROM/**/Members
 # SELECT /*!32302 1/0, */ 1 FROM tablename
 # ‘ or 1=1#

--- a/tests/regression/tests/REQUEST-913-SCANNER-DETECTION/913100.yaml
+++ b/tests/regression/tests/REQUEST-913-SCANNER-DETECTION/913100.yaml
@@ -94,7 +94,7 @@
           log_contains: id "913100"
   -
    test_title: 913100-5
-   desc: "YUM package manager whitelist"
+   desc: "YUM package manager allow list"
    stages:
    -
      stage:
@@ -126,7 +126,7 @@
          log_contains: id "913100"
   -
    test_title: 913100-7
-   desc: "eCairn whitelist"
+   desc: "eCairn allow list"
    stages:
    -
      stage:

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920510.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920510.yaml
@@ -3,7 +3,7 @@
     author: "Andrea Menin"
     enabled: true
     name: "920510.yaml"
-    description: "Cache-Control directives whitelist"
+    description: "Cache-Control directives allow list"
   tests:
     - test_title: 920510-1
       desc: "block request with a response cache-control directive in request"

--- a/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930120.yaml
+++ b/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930120.yaml
@@ -97,7 +97,7 @@
          log_contains: id "930120"
   -
    test_title: 930120-5
-   desc: "Google OAuth2 callback whitelist"
+   desc: "Google OAuth2 callback allow list"
    stages:
    -
      stage:

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941180.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941180.yaml
@@ -7,7 +7,7 @@
   tests:
     -
       test_title: 941180-1
-      desc: Node-validator blacklist keywords, ARGS
+      desc: Node-validator deny list keywords, ARGS
       stages:
       -
         stage:
@@ -24,7 +24,7 @@
             log_contains: id "941180"
     -
       test_title: 941180-2
-      desc: Node-validator blacklist keywords, ARGS_NAMES
+      desc: Node-validator deny list keywords, ARGS_NAMES
       stages:
       -
         stage:
@@ -41,7 +41,7 @@
             log_contains: id "941180"
     -
       test_title: 941180-3
-      desc: Node-validator blacklist keywords, ARGS_NAMES
+      desc: Node-validator deny list keywords, ARGS_NAMES
       stages:
       -
         stage:
@@ -58,7 +58,7 @@
             log_contains: id "941180"
     -
       test_title: 941180-4
-      desc: Negative test for Node-validator blacklist keyword -->, present in stricter sibling 941181, ARGS
+      desc: Negative test for Node-validator deny list keyword -->, present in stricter sibling 941181, ARGS
       stages:
       -
         stage:

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941181.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941181.yaml
@@ -7,7 +7,7 @@
   tests:
     -
       test_title: 941181-1
-      desc: Node-validator blacklist keywords, ARGS
+      desc: Node-validator deny list keywords, ARGS
       stages:
       -
         stage:
@@ -24,7 +24,7 @@
             log_contains: id "941181"
     -
       test_title: 941181-2
-      desc: Node-validator blacklist keywords, ARGS
+      desc: Node-validator deny list keywords, ARGS
       stages:
       -
         stage:
@@ -41,7 +41,7 @@
             log_contains: id "941181"
     -
       test_title: 941181-3
-      desc: Node-validator blacklist keywords, ARGS_NAMES
+      desc: Node-validator deny list keywords, ARGS_NAMES
       stages:
       -
         stage:
@@ -58,7 +58,7 @@
             log_contains: id "941181"
     -
       test_title: 941181-4
-      desc: Node-validator blacklist keywords, ARGS_NAMES
+      desc: Node-validator deny list keywords, ARGS_NAMES
       stages:
       -
         stage:

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941190.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941190.yaml
@@ -7,7 +7,7 @@
   tests:
     -
       test_title: 941190-1
-      desc: Node-validator blacklist keywords, ARGS
+      desc: Node-validator deny list keywords, ARGS
       stages:
       -
         stage:
@@ -24,7 +24,7 @@
             log_contains: id "941190"
     -
       test_title: 941190-2
-      desc: Node-validator blacklist keywords, ARGS_NAMES
+      desc: Node-validator deny list keywords, ARGS_NAMES
       stages:
       -
         stage:
@@ -41,7 +41,7 @@
             log_contains: id "941190"
     -
       test_title: 941190-3
-      desc: Node-validator blacklist keywords, COOKIES_NAMES
+      desc: Node-validator deny list keywords, COOKIES_NAMES
       stages:
       -
         stage:


### PR DESCRIPTION
Remove rule 910110 : ModSecurity Rules from Trustwave SpiderLabs: IP Blacklist Alert
Rule has been commented out for a long while
Thought that Spiderlabs web honeypots are no longer running.

Merge after #2137 (to avoid conflicts)