### PR TITLE
Remove Rule 910110

### DIFF
--- a/rules/REQUEST-910-IP-REPUTATION.conf
+++ b/rules/REQUEST-910-IP-REPUTATION.conf
@@ -86,31 +86,6 @@ SecRule TX:HIGH_RISK_COUNTRY_CODES "!@rx ^$" \
 #
 # -=[ IP Reputation Checks ]=-
 #
-# ModSecurity Rules from Trustwave SpiderLabs: IP Deny List Alert
-# Ref: http://www.modsecurity.org/projects/commercial/rules/
-#
-# This rule checks the client IP address against a list of recent IPs captured
-# from the SpiderLabs web honeypot systems (last 48 hours).
-#
-# SecRule TX:REAL_IP "@ipMatchFromFile ip_blacklist.data" \
-#    "id:910110,\
-#    phase:2,\
-#    block,\
-#    t:none,\
-#    msg:'Client IP in Trustwave SpiderLabs IP Reputation Deny List',\
-#    tag:'application-multi',\
-#    tag:'language-multi',\
-#    tag:'platform-multi',\
-#    tag:'attack-reputation-ip',\
-#    tag:'paranoia-level/1',\
-#    severity:'CRITICAL',\
-#    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-#    setvar:'ip.reput_block_flag=1',\
-#    setvar:'ip.reput_block_reason=%{rule.msg}',\
-#    expirevar:'ip.reput_block_flag=%{tx.reput_block_duration}'"
-
-
-#
 # First check if we have already run an @rbl check for this IP by checking in IP collection.
 # If we have, then skip doing another check.
 #


### PR DESCRIPTION
Remove old rule 910110 which has been commented out a long time.
Spider labs web honeypots thought to be no longer running.
