### PR TITLE
Replace usage of ctl:ruleEngine=Off by ctl:ruleRemoveByTag=OWASP_CRS

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -413,7 +413,7 @@ SecRule TX:sampling_rnd100 "!@lt %{tx.sampling_percentage}" \
     log,\
     noauditlog,\
     msg:'Sampling: Disable the rule engine based on sampling_percentage %{TX.sampling_percentage} and random number %{TX.sampling_rnd100}',\
-    ctl:ruleEngine=Off,\
+    ctl:ruleRemoveByTag=OWASP_CRS,\
     ver:'OWASP_CRS/3.4.0-dev'"
 
 SecMarker "END-SAMPLING"

--- a/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
+++ b/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
@@ -28,7 +28,7 @@ SecRule REQUEST_LINE "@streq GET /" \
     chain"
     SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
         "t:none,\
-        ctl:ruleEngine=Off,\
+        ctl:ruleRemoveByTag=OWASP_CRS,\
         ctl:auditEngine=Off"
 
 #
@@ -51,5 +51,5 @@ SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
         chain"
         SecRule REQUEST_LINE "@rx ^(?:GET /|OPTIONS \*) HTTP/[12]\.[01]$" \
             "t:none,\
-            ctl:ruleEngine=Off,\
+            ctl:ruleRemoveByTag=OWASP_CRS,\
             ctl:auditEngine=Off"


### PR DESCRIPTION
As at least some of our users are using multiple rulesets togather (for example one of our sponzors, Kemp Technologies), we should try to not collide with other rulesets - in this case, do not turn off the whole ModSecurity but only CRS instead.

Btw, is `ctl:ruleRemoveByTag` really unsupported by ModSec3 or it's only outdated documentation?