### PR TITLE
Updated README.md for nginx

### DIFF
--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -17,7 +17,7 @@ Requirements
 ============
 There are Three requirements for running the OWASP CRS regressions.
 
-1. You must have ModSecurity specify the location of your error.log, this is done in the config.ini file.If you are using nginx you need to change default parameter from modsec2-apache to modsec3-nginx in conftest.py
+1. You must have ModSecurity specify the location of your error.log, this is done in the config.ini file. If you are using nginx you need to change default parameter from modsec2-apache to modsec3-nginx in conftest.py
 2. ModSecurity must be in DetectionOnly (or anomaly scoring) mode
 3. You must disable IP blocking based on previous events
 

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -17,7 +17,7 @@ Requirements
 ============
 There are Three requirements for running the OWASP CRS regressions.
 
-1. You must have ModSecurity specify the location of your error.log, this is done in the config.ini file
+1. You must have ModSecurity specify the location of your error.log, this is done in the config.ini file.If you are using nginx you need to specify ModSecurity to look for [modsec3-nginx] in config.ini, this is done in conftest.py(need to change default parameter from modsec2-apache to modsec3-nginx)
 2. ModSecurity must be in DetectionOnly (or anomaly scoring) mode
 3. You must disable IP blocking based on previous events
 

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -17,7 +17,7 @@ Requirements
 ============
 There are Three requirements for running the OWASP CRS regressions.
 
-1. You must have ModSecurity specify the location of your error.log, this is done in the config.ini file. If you are using nginx you need to change default parameter from modsec2-apache to modsec3-nginx in conftest.py
+1. You must have ModSecurity specify the location of your error.log, this is done in the config.ini file. If you are using nginx you can use the parameter --config=modsec3-nginx (as specified in config.ini)
 2. ModSecurity must be in DetectionOnly (or anomaly scoring) mode
 3. You must disable IP blocking based on previous events
 

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -17,7 +17,7 @@ Requirements
 ============
 There are Three requirements for running the OWASP CRS regressions.
 
-1. You must have ModSecurity specify the location of your error.log, this is done in the config.ini file.If you are using nginx you need to specify ModSecurity to look for [modsec3-nginx] in config.ini, this is done in conftest.py(need to change default parameter from modsec2-apache to modsec3-nginx)
+1. You must have ModSecurity specify the location of your error.log, this is done in the config.ini file.If you are using nginx you need to change default parameter from modsec2-apache to modsec3-nginx in conftest.py
 2. ModSecurity must be in DetectionOnly (or anomaly scoring) mode
 3. You must disable IP blocking based on previous events
 


### PR DESCRIPTION
The default parameter for logs in conftest.py is modsec2-apache, which causes ModSecurity to always look for [modsec2-apache] in config.ini.This causes problem with nginx server as its logging regex are different.This is solved by changing default parameter from modsec2-apache to modsec3-nginx in conftest.py