### PR TITLE
Fix 933160-21 and 942500-1 tests broken due to invalid URIs

### DIFF
--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933160.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933160.yaml
@@ -338,7 +338,7 @@
             User-Agent: ModSecurity CRS 3 Tests
           method: POST
           port: 80
-          uri: ?x=eval%28chr%28112%29.chr%28104%29.chr%28112%29
+          uri: /?x=eval%28chr%28112%29.chr%28104%29.chr%28112%29
         output:
           log_contains: id "933160"
   -

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942500.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942500.yaml
@@ -17,7 +17,7 @@
             Host: localhost
           method: POST
           port: 80
-          uri: "?id=9999+or+{if+length((/*!5000select+username/*!50000from*/user+where+id=1))>0}"
+          uri: "/?id=9999+or+{if+length((/*!5000select+username/*!50000from*/user+where+id=1))>0}"
           version: HTTP/1.0
         output:
           log_contains: id "942500"


### PR DESCRIPTION
Hi CRS team. Thanks for the great product!
Here is a pull request to fix broken tests on Nginx. Let me know if it's better to open an issue first.

## Issue

The regression test cases, 933160-21 and 942500-1, are failing on Nginx.

## Reason
The `uri` parameters in tests cases `933160-21` and `942500-1` start with `?param=` without the actual path such as `/`. This is an ill-formed path in terms of the HTTP protocol spec, because it lacks the absoluteURI, abs_path nor authority. ([Link to the spec fyi](https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1.2).) 
Thus, the generated requests are rejected by Nginx before WAF sees them, which is not an expected behavior.  
JFYI, this happens on Envoy server as well.

## Logs 
Before my fix, Nginx rejects the requests by the test cases with the following log.
```
2021/07/27 11:47:43 [info] 23#23: *4 client sent invalid request while reading client request line, client: 192.168.208.1, server: localhost, request: "POST ?x=eval%28chr%28112%29.chr%28104%29.chr%28112%29 HTTP/1.1"
```
With my fix, the test cases pass.