### PR TITLE
Fixing phpMyAdmin FPs

### DIFF
--- a/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
@@ -59,11 +59,6 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_replace.php" \
         ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:where_clause[0],\
         ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
         ctl:ruleRemoveTargetByTag=attack-xss;ARGS,\
-        ctl:ruleRemoveTargetById=932150;ARGS,\
-        ctl:ruleRemoveTargetById=933130;ARGS,\
-        ctl:ruleRemoveTargetById=933160;ARGS,\
-        ctl:ruleRemoveTargetById=942170;ARGS,\
-        ctl:ruleRemoveTargetById=942190;ARGS,\
         ctl:ruleRemoveTargetById=921110;ARGS,\
         ctl:ruleRemoveTargetById=921130;ARGS,\
         ctl:ruleRemoveTargetById=932100;ARGS,\
@@ -72,9 +67,16 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_replace.php" \
         ctl:ruleRemoveTargetById=932115;ARGS,\
         ctl:ruleRemoveTargetById=932130;ARGS,\
         ctl:ruleRemoveTargetById=932140;ARGS,\
+        ctl:ruleRemoveTargetById=932150;ARGS,\
         ctl:ruleRemoveTargetById=933100;ARGS,\
         ctl:ruleRemoveTargetById=933120;ARGS,\
+        ctl:ruleRemoveTargetById=933130;ARGS,\
+        ctl:ruleRemoveTargetById=933160;ARGS,\
         ctl:ruleRemoveTargetById=942100;ARGS,\
+        ctl:ruleRemoveTargetById=942170;ARGS,\
+        ctl:ruleRemoveTargetById=942190;ARGS,\
+        ctl:ruleRemoveTargetById=930100;ARGS:fields[multi_edit][0][],\
+        ctl:ruleRemoveTargetById=930110;ARGS:fields[multi_edit][0][],\
         ctl:ruleRemoveTargetById=933210;ARGS:fields[multi_edit][0][],\
         ctl:ruleRemoveTargetById=934100;ARGS:fields[multi_edit][0][]"
 
@@ -158,7 +160,10 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_sql.php" \
     chain"
     SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
         "t:none,\
-        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query"
+        ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=932100;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=941100;ARGS:sql_query,\
+        ctl:ruleRemoveTargetById=941160;ARGS:sql_query"
 
 # Opening custom SQL editor (databases)
 SecRule REQUEST_FILENAME "@endsWith /db_sql.php" \

--- a/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
@@ -387,4 +387,18 @@ SecRule REQUEST_FILENAME "@endsWith /db_qbe.php" \
         ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:sql_query,\
         ctl:ruleRemoveTargetById=932115;ARGS:sql_query"
 
+
+# Databases -> Check privileges
+SecRule REQUEST_FILENAME "@endsWith /server_privileges.php" \
+    "id:9008320,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    chain"
+    SecRule &REQUEST_COOKIES_NAMES:'/^(?:phpMyAdmin|phpMyAdmin_https)$/' "@eq 1" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=942140;ARGS:db,\
+        ctl:ruleRemoveTargetById=942140;ARGS:checkprivsdb"
+
 SecMarker "END-PHPMYADMIN"


### PR DESCRIPTION
 - fixed 2 real-world FPs
 - fixed `ruleRemoveTargetById` ordering in rule 9008110 (based on removed IDs)
 - adding new rule (was triggering for example for `information_schema` DB)