### PR TITLE
Amend the regular expression for rule 930110

### DIFF
--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -82,7 +82,7 @@ SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@r
 # - ../
 # - /..
 
-SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@rx (?:(?:^|[\\/])\.\.[\\/]|[\\/]\.\.(?:[\\/]|$))" \
+SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@rx (?:(?:^|[\\\\/])\.\.[\\\\/]|[\\\\/]\.\.(?:[\\\\/]|$))" \
     "id:930110,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930110.yaml
+++ b/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930110.yaml
@@ -113,3 +113,18 @@
               uri: ".."
             output:
               no_log_contains: id "930110"
+    -
+      test_title: 930110-8
+      desc: "Path Traversal Attack (..\) query string"
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "localhost"
+              method: "GET"
+              port: 80
+              headers:
+                  Host: "localhost"
+              uri: '?arg=..\pineapple'
+            output:
+              log_contains: id "930110"

--- a/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930110.yaml
+++ b/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930110.yaml
@@ -115,7 +115,7 @@
               no_log_contains: id "930110"
     -
       test_title: 930110-8
-      desc: "Path Traversal Attack (..\) query string"
+      desc: 'Path Traversal Attack (..\) query string'
       stages:
         -
           stage:

--- a/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930110.yaml
+++ b/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930110.yaml
@@ -125,6 +125,6 @@
               port: 80
               headers:
                   Host: "localhost"
-              uri: '?arg=..\pineapple'
+              uri: '/?arg=..\pineapple'
             output:
               log_contains: id "930110"


### PR DESCRIPTION
This commit amends the regular expression for rule 930110.

The previous representation of the backslash character is replaced with
one which is portable between both Apache and nginx/libmodsecurity.

This commit should resolve the false negative reported in issue #2140