### PR TITLE
Added missing " from the end of actions list

### DIFF
--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -35,7 +35,7 @@ SecRule &ARGS_GET "@eq 3" \
     t:none,\
     nolog,\
     ver:'OWASP_CRS/3.3.0',\
-    chain
+    chain"
     SecRule REQUEST_METHOD "@streq GET" \
         "chain"
         SecRule &ARGS_GET:state "@eq 1" \
@@ -46,7 +46,7 @@ SecRule &ARGS_GET "@eq 3" \
                     "chain"
                     SecRule ARGS_GET:scope "@rx ^(?:email|profile|openid)(?: email| profile| openid){0,2}(?: https://www\.googleapis\.com/auth/userinfo\.(?:email|profile|openid)){1,3}$" \
                         "t:none,t:urlDecodeUni,t:lowercase,\
-                        setvar:'tx.google_oauth2_callback_detected=1'
+                        setvar:'tx.google_oauth2_callback_detected=1'"
 
 #
 # -=[ Directory Traversal Attacks ]=-


### PR DESCRIPTION
Looks like [eda83298](https://github.com/coreruleset/coreruleset/commit/eda83298c04a4d0d288e7bf57a12467b44a05d4c#diff-6acdf1bc11f3ddaed59cf74b841c45047e63a9515015f2d1d096a01210ddd027) commit misses two `"` from the end of actions list in rule 930050 [here](https://github.com/coreruleset/coreruleset/commit/eda83298c04a4d0d288e7bf57a12467b44a05d4c#diff-6acdf1bc11f3ddaed59cf74b841c45047e63a9515015f2d1d096a01210ddd027R38) and [here](https://github.com/coreruleset/coreruleset/commit/eda83298c04a4d0d288e7bf57a12467b44a05d4c#diff-6acdf1bc11f3ddaed59cf74b841c45047e63a9515015f2d1d096a01210ddd027R49). This PR fixes it.

I'm wondering why mod_security2 allows it...