### PR TITLE
feat(ci): use latest crs containers for testing

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       MODSEC_AUDIT_LOG_FORMAT: Native
       MODSEC_AUDIT_LOG_TYPE: Serial
       MODSEC_AUDIT_LOG: "/var/log/modsec_audit.log"
+      MODSEC_TMP_DIR: "/tmp"
     volumes:
       - ./logs/modsec2-apache:/var/log:rw
       - ../rules:/opt/owasp-crs/rules:ro

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -6,7 +6,7 @@ version: '3.2'
 services:
   modsec2-apache:
     container_name: modsec2-apache
-    image: owasp/modsecurity-crs:3.3-apache
+    image: owasp/modsecurity-crs:apache
     environment:
       SERVERNAME: modsec2-apache
       BACKEND: http://backend
@@ -30,7 +30,7 @@ services:
 
   modsec3-nginx:
     container_name: modsec3-nginx
-    image: owasp/modsecurity-crs:3.3-nginx
+    image: owasp/modsecurity-crs:nginx
     environment:
       SERVERNAME: modsec3-nginx
       BACKEND: http://backend


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Turns out we were using the old version. We fell in our own trap.