### PR TITLE
Fixing a typo in rule ID 9002840

### DIFF
--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -727,9 +727,10 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/edit.php" \
 # Wordpress Site Health
 # The wordpress site health page makes use of embedded SQL/PHP
 # which triggers PHP/SQL leak rules.
+# As we are dealing with response data, rule needs to be run in phase 4.
 SecRule REQUEST_FILENAME "@rx /wp-admin/site-health.php" \
     "id:9002840,\
-    phase:2,\
+    phase:4,\
     pass,\
     t:none,\
     nolog,\


### PR DESCRIPTION
Rule ID 9002840 is excluding match against RESPONSE_BODY, so it needs to be run in phase 4. Typo was introduced here and wasn't catched by tests: https://github.com/coreruleset/coreruleset/pull/1920.

Fixes #2142.