### PR TITLE
eradicate XMLNS FP in rule 941130

### DIFF
--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -123,7 +123,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
 #   cd util/regexp-assemble
 #   ./regexp-assemble.pl regexp-941130.data
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\S](?:!ENTITY\s+(?:\S+|%\s+\S+)\s+(?:PUBLIC|SYSTEM)|x(?:link:href|html|mlns)|data:text/html|pattern\b.*?=|formaction|\@import|;base64)\b" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\S](?:\b(?:x(?:link:href|html|mlns)|data:text\/html|pattern\b.*?=|formaction)|!ENTITY\s+(?:\S+|%\s+\S+)\s+(?:PUBLIC|SYSTEM)|;base64|@import)\b" \
     "id:941130,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941130.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941130.yaml
@@ -307,3 +307,21 @@
           version: HTTP/1.0
         output:
           log_contains: id "941130"
+  -
+    test_title: 941130-17
+    desc: "FP test for 941130"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          method: POST
+          port: 80
+          headers:
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          uri: "/api/v1/query?q=7XMLNS"
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "941130"

--- a/util/regexp-assemble/regexp-941130.data
+++ b/util/regexp-assemble/regexp-941130.data
@@ -1,10 +1,10 @@
-(?i)[\s\S]xlink:href\b
-(?i)[\s\S]xhtml\b
-(?i)[\s\S]xmlns\b
+(?i)[\s\S]\bxlink:href\b
+(?i)[\s\S]\bxhtml\b
+(?i)[\s\S]\bxmlns\b
 (?i)[\s\S]!ENTITY\s+(?:\S+|%\s+\S+)\s+SYSTEM\b
 (?i)[\s\S]!ENTITY\s+(?:\S+|%\s+\S+)\s+PUBLIC\b
-(?i)[\s\S]data:text/html\b
-(?i)[\s\S]formaction\b
+(?i)[\s\S]\bdata:text/html\b
+(?i)[\s\S]\bformaction\b
 (?i)[\s\S]@import\b
 (?i)[\s\S];base64\b
-(?i)[\s\S]pattern\b.*?=\b
+(?i)[\s\S]\bpattern\b.*?=\b


### PR DESCRIPTION
Get rid of a false positive on string `7XMLNS` by adding word boundaries to our regexps in rule 941130.

This is a quicky so let's see what the tests say.