### PR TITLE
feat(nightly): add nightly latest releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,31 @@
+
+name: Nightly Release
+on:
+  schedule:
+    - cron: '0 2 * * *' # run at 2 AM UTC
+
+jobs:
+  nightly:
+    name: Nightly Release
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout repo"
+        uses: actions/checkout@v2
+
+      - name: Deploy using Release Action
+        uses: ncipollo/release-action@v1
+        with:
+          name: Latest Nightly
+          tag: nightly
+          commit: v3.4/dev
+          allowUpdates: true
+          prerelease: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            Nightly releases are snapshots of the development activity on the Core Rule Set project that may include new features and bug fixes scheduled for upcoming releases. These releases are made available to make it easier for users to test their existing configurations against the Core Rule Set code base for potential issues or to experiment with new features, with a chance to provide feedback on ways to improve the changes before being released.
+
+            As these releases are snapshots of the latest code, you may encounter an issue compared to the latest stable release so users are encouraged to run nightly releases in a non production environment. If you encounter an issue, please check our issue tracker to see if the issue has already been reported; if a report hasn't been made, please report it so we can review the issue and make any needed fixes.
+
+            **Note:** Nightly releases using release action are only available via GitHub.


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

After merging this one we will have nightly pre-releases with latest CRS code.

Fixes #2034.