### PR TITLE
Exclusion list fot RoundCube webmail

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -391,7 +391,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  setvar:tx.crs_exclusions_phpbb=1,\
 #  setvar:tx.crs_exclusions_phpmyadmin=1,\
 #  setvar:tx.crs_exclusions_wordpress=1,\
-#  setvar:tx.crs_exclusions_xenforo=1"
+#  setvar:tx.crs_exclusions_xenforo=1,\
+#  setvar:tx.crs_exclusions_roundcube=1"
 
 #
 # -- [[ HTTP Policy Settings ]] ------------------------------------------------

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -374,6 +374,11 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # the effects of the exclusion to only the path where the excluded webapp
 # resides using a rule similar to the following example:
 # SecRule REQUEST_URI "@beginsWith /wordpress/" setvar:tx.crs_exclusions_wordpress=1
+#
+# If you want to activate RoundCube exclusion set, you can set the
+# 'crs_exclusions_roundcube_hosts', and list the hostnames between pipes where
+# your RoundCube instances run, eg:
+#   setvar:'tx.crs_exclusions_roundcube_hosts=|webmail1.hostname.com| |webmail2.otherhostname.com|'"
 
 #
 # Modify and uncomment this rule to select which application:
@@ -392,7 +397,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  setvar:tx.crs_exclusions_phpmyadmin=1,\
 #  setvar:tx.crs_exclusions_wordpress=1,\
 #  setvar:tx.crs_exclusions_xenforo=1,\
-#  setvar:tx.crs_exclusions_roundcube=1"
+#  setvar:'tx.crs_exclusions_roundcube=||'"
 
 #
 # -- [[ HTTP Policy Settings ]] ------------------------------------------------

--- a/rules/REQUEST-903.9009-ROUNDCUBE-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9009-ROUNDCUBE-EXCLUSION-RULES.conf
@@ -17,23 +17,27 @@
 # we tried to classify the rules from the point of UX function - see the lines before
 # rules.
 
-SecRule &TX:crs_exclusions_roundcube|TX:crs_exclusions_roundcube "@eq 0" \
+SecRule &REQUEST_HEADERS:Host "@eq 1" \
     "id:9009000,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'OWASP_CRS/3.4.0-dev',\
-    skipAfter:END-ROUNDCUBE"
+    skipAfter:END-ROUNDCUBE,\
+    chain"
+    SecRule REQUEST_HEADERS:Host "!@within %{tx.crs_exclusions_roundcube_hosts}"
 
-SecRule &TX:crs_exclusions_roundcube|TX:crs_exclusions_roundcube "@eq 0" \
+SecRule &REQUEST_HEADERS:Host "@eq 1" \
     "id:9009001,\
     phase:2,\
     pass,\
     t:none,\
     nolog,\
     ver:'OWASP_CRS/3.4.0-dev',\
-    skipAfter:END-ROUNDCUBE"
+    skipAfter:END-ROUNDCUBE,\
+    chain"
+    SecRule REQUEST_HEADERS:Host "!@within %{tx.crs_exclusions_roundcube_hosts}"
 
 # Basic exclusions - the next exclusions used for login
 SecAction \
@@ -83,5 +87,23 @@ SecAction \
     ctl:ruleRemoveTargetById=942432;ARGS:_message,\
     ctl:ruleRemoveTargetById=942432;ARGS:_subject,\
     ctl:ruleRemoveTargetById=942460;ARGS:_message"
+
+# Exclusions for re-login
+SecAction \
+    "id:9009104,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetById=942432;ARGS:_url"
+
+# Exclusions for file upload
+SecAction \
+    "id:9009105,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveById=200004"
 
 SecMarker "END-ROUNDCUBE"

--- a/rules/REQUEST-903.9009-ROUNDCUBE-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9009-ROUNDCUBE-EXCLUSION-RULES.conf
@@ -1,0 +1,87 @@
+# ------------------------------------------------------------------------
+# OWASP ModSecurity Core Rule Set ver.3.4.0-dev
+# Copyright (c) 2021 Core Rule Set project. All rights reserved.
+#
+# The OWASP ModSecurity Core Rule Set is distributed under
+# Apache Software License (ASL) version 2
+# Please see the enclosed LICENSE file for full details.
+# ------------------------------------------------------------------------
+
+# These exclusions remedy false positives in a default RoundCube Webmail install.
+# The exclusions are only active if crs_exclusions_roundcube=1 (installed instance)
+# or the crs_exclusions_roundcube_installer=1 () is set.
+# See rule 900130 in crs-setup.conf.example for instructions.
+
+# As RoundCube uses only the "/" URI (or /index.php), therefore we do not use any
+# variables in rules. Every exclusion triggered in case of all requests. Nonetheless
+# we tried to classify the rules from the point of UX function - see the lines before
+# rules.
+
+SecRule &TX:crs_exclusions_roundcube|TX:crs_exclusions_roundcube "@eq 0" \
+    "id:9009000,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.4.0-dev',\
+    skipAfter:END-ROUNDCUBE"
+
+SecRule &TX:crs_exclusions_roundcube|TX:crs_exclusions_roundcube "@eq 0" \
+    "id:9009001,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.4.0-dev',\
+    skipAfter:END-ROUNDCUBE"
+
+# Basic exclusions - the next exclusions used for login
+SecAction \
+    "id:9009100,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetById=942421;REQUEST_COOKIES:_hjid,\
+    ctl:ruleRemoveTargetById=920273;ARGS:_timezone,\
+    ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
+    ctl:ruleRemoveTargetById=921170;ARGS_NAMES:_task"
+
+# Exclusions for reading a mail
+SecAction \
+    "id:9009101,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetById=942432;ARGS:_caps,\
+    ctl:ruleRemoveTargetById=920273;ARGS:_email"
+
+# Exclusions for settings
+SecAction \
+    "id:9009102,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetById=920272;ARGS,\
+    ctl:ruleRemoveTargetById=920273;ARGS,\
+    ctl:ruleRemoveTargetById=920272;REQUEST_BODY"
+
+# Exclusions for sending e-mail
+SecAction \
+    "id:9009103,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetById=921170;ARGS_NAMES:_framed,\
+    ctl:ruleRemoveTargetById=942130;ARGS:_message,\
+    ctl:ruleRemoveTargetById=942130;ARGS:_subject,\
+    ctl:ruleRemoveTargetById=942440;ARGS:_message,\
+    ctl:ruleRemoveTargetById=942431;ARGS:_message,\
+    ctl:ruleRemoveTargetById=942432;ARGS:_message,\
+    ctl:ruleRemoveTargetById=942432;ARGS:_subject,\
+    ctl:ruleRemoveTargetById=942460;ARGS:_message"
+
+SecMarker "END-ROUNDCUBE"


### PR DESCRIPTION
This PR is just a draft, please do not merge it.

The patch contains several exclusions for RoundCube webmail.

In case of RoundCube all requests go to URI `/` or `/index.php`, so it's hard to make any condition - that's why I used `SecAction` instead of `SecRule` with any variable. We should check that the affected variable exists (eg. `SecRule @REQUEST_COOKIES:_hjid "@eq 1"...`) but in that case all exception would have a unique rule, which would make a complex and unmanageable set of rules.

The other thing that I deviated from the form we used earlier is the activating of exception list. As you can [see](https://github.com/airween/coreruleset/blob/v3.4/excl_roundcube/crs-setup.conf.example#L400), I use here a list of host names. (Notes are [here](https://github.com/airween/coreruleset/blob/v3.4/excl_roundcube/crs-setup.conf.example#L378-L381)). This is because all exceptions are unconditional, and if somebody applies them for the whole server, that makes a big hole.

I'd like to start a discussion about these solutions - any ideas are welcome.