### PR TITLE
Fixing Google OAuth2 detection

### DIFF
--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -28,7 +28,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:930012,phase:2,pass,nolog,skipAf
 # or invalid Google OAuth2 callbacks as this may result in bypass of rules which
 # are using this detection as an allow list.
 # Currently used by rule 930120.
-SecRule &ARGS_GET "@eq 3" \
+SecRule &ARGS_GET:scope "@eq 1" \
     "id:930050,\
     phase:2,\
     pass,\
@@ -42,11 +42,24 @@ SecRule &ARGS_GET "@eq 3" \
             "chain"
             SecRule &ARGS_GET:code "@eq 1" \
                 "chain"
-                SecRule &ARGS_GET:scope "@eq 1" \
-                    "chain"
-                    SecRule ARGS_GET:scope "@rx ^(?:email|profile|openid)(?: email| profile| openid){0,2}(?: https://www\.googleapis\.com/auth/userinfo\.(?:email|profile|openid)){1,3}$" \
-                        "t:none,t:urlDecodeUni,t:lowercase,\
-                        setvar:'tx.google_oauth2_callback_detected=1'"
+                SecRule ARGS_GET:scope "@rx ^(?:email|profile|openid)(?: email| profile| openid| https://www\.googleapis\.com/auth/userinfo\.(?:email|profile|openid))+$" \
+                    "t:none,t:urlDecodeUni,t:lowercase,\
+                    setvar:'tx.google_oauth2_callback_detected=1'"
+
+# This rule is guarding against extra parameters which should not appear in
+# Google OAuth2 callback request (some of the parameters are optional so we
+# can't require them). If extra parameters are found, request is marked as NOT
+# Google OAuth2 callback.
+SecRule tx:google_oauth2_callback_detected "@eq 1" \
+    "id:930051,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'OWASP_CRS/3.3.0',\
+    chain
+    SecRule ARGS_NAMES "!@pm state code scope authuser hd prompt" \
+        "setvar:'tx.google_oauth2_callback_detected=0'"
 
 #
 # -=[ Directory Traversal Attacks ]=-

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -50,7 +50,7 @@ SecRule &ARGS_GET:scope "@eq 1" \
 # Google OAuth2 callback request (some of the parameters are optional so we
 # can't require them). If extra parameters are found, request is marked as NOT
 # Google OAuth2 callback.
-SecRule tx:google_oauth2_callback_detected "@eq 1" \
+SecRule TX:GOOGLE_OAUTH2_CALLBACK_DETECTED "@eq 1" \
     "id:930051,\
     phase:2,\
     pass,\


### PR DESCRIPTION
Our Google OAuth2 detection isn't working correctly, which isn't a suprise for me as we had only two examples of callback URIs.

Changes done by this PR:
 - Fixed and simplified regex for `scope` argument.
 - Added a new rule, ID 930051, for catching extra (non-OAuth2) arguments.

As Google OAuth2 callback can contain also optional arguments, we need to catch requests which are trying to look like an OAuth2 callback but tries to smuggle out additional, non-OAuth2, arguments. Because of this, i wasn't able to find a way to do the whole detection using only one rule.

Anyway, i would consider rewriting this as a plugin.

Fixes #2212.