### PR TITLE
fix(ci): remove tag before releasing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ jobs:
       - name: "Checkout repo"
         uses: actions/checkout@v2
 
-      - name: "Remove release before creating new one"
+      - name: "Remove nightly tag before creating new release (ensures that tag is updated)"
         uses: dev-drprasad/delete-tag-and-release@v0.2.0
         with:
           delete_release: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,6 +14,14 @@ jobs:
       - name: "Checkout repo"
         uses: actions/checkout@v2
 
+      - name: "Remove release before creating new one"
+        uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        with:
+          delete_release: false
+          tag_name: nightly
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Deploy using Release Action
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Our new nightly releases are not updating the tag shown (but the zip file is properly generated). Using a previous step removing the tag is the recommended action.