### PR TITLE
Fixing docs for Apache

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -98,9 +98,9 @@ Installing on Apache
     ```
     <IfModule security2_module>
           Include modsecurity.d/owasp-modsecurity-crs/crs-setup.conf
-          Include modsecurity.d/owasp-modsecurity-crs/plugins/*-before.conf
+          IncludeOptional modsecurity.d/owasp-modsecurity-crs/plugins/*-before.conf
           Include modsecurity.d/owasp-modsecurity-crs/rules/*.conf
-          Include modsecurity.d/owasp-modsecurity-crs/plugins/*-after.conf
+          IncludeOptional modsecurity.d/owasp-modsecurity-crs/plugins/*-after.conf
     </IfModule>
     ```
     8. Restart web server and ensure it starts without errors


### PR DESCRIPTION
As `plugins` directory, by default, does not contain any file matching `*-(?:before|after).conf`, we need to use `IncludeOptional`, otherwise Apache won't start.