### PR TITLE
Fix Python version for tests to 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,8 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          # 3.10 requires pytest 6.2.5+ (currently fixed to 4.6 by tests)
+          python-version: '3.9'
 
       - uses: actions/cache@v2
         id: cache


### PR DESCRIPTION
Tests are failing because of a change in Python 3.10 (requires update of pytest). I've fixed the Python version used for running the tests at 3.9.