### PR TITLE
test: add tests for 920341

### DIFF
--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920341.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920341.yaml
@@ -1,0 +1,68 @@
+---
+  meta:
+    author: "jptosso"
+    enabled: true
+    name: "920341.yaml"
+    description: "Tests to trigger, or not trigger 920341"
+  tests:
+    -
+      # Standard POST request with length 4 and no content-type
+      test_title: 920341-1
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              method: "POST"
+              port: 80
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Length: 4
+                  # No content-type
+              protocol: "http"
+              uri: "/pineapple"
+              version: "HTTP/1.1"
+              data: test
+              stop_magic: true
+            output:
+              log_contains: id "920341"
+    -
+      # Standard POST request with length and content-type
+      test_title: 920341-2
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              method: "POST"
+              port: 80
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Content-Length: 2
+                  Content-Type: application/json
+              protocol: "http"
+              uri: "/"
+              version: "HTTP/1.1"
+              data: "{}"
+            output:
+              no_log_contains: id "920341"
+    -
+      # Standard GET request (negative test)
+      test_title: 920341-3
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              method: "GET"
+              port: 80
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+              protocol: "http"
+              uri: "/"
+              version: "HTTP/1.1"
+            output:
+              no_log_contains: id "920341"


### PR DESCRIPTION
Add positive and negative tests for 920341, POST request body are required to have content-type if content-length != 0

- Standard POST request with length 4 and no content-type
- Standard POST request with length and content-type
- Standard GET request (negative test)