### PR TITLE
Rework and expand 920100

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -41,6 +41,11 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:920012,phase:2,pass,nolog,skipAf
 #
 # It also outlines proper construction for CONNECT, OPTIONS and GET requests.
 #
+# Regexp generated from util/regexp-assemble/920100.data using Regexp::Assemble.
+# To rebuild the regexp:
+#   cd util/regexp-assemble
+#   ./regexp-assemble.py 920100
+#
 # -=[ References ]=-
 # https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.2.1
 # http://capec.mitre.org/data/definitions/272.html

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -45,7 +45,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:920012,phase:2,pass,nolog,skipAf
 # https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.2.1
 # http://capec.mitre.org/data/definitions/272.html
 #
-SecRule REQUEST_LINE "!@rx ^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+)?)?/[^?#]*(?:\?[^#\s]*)?(?:#[\S]*)?|connect (?:\d{1,3}\.){3}\d{1,3}\.?(?::\d+)?|options \*)\s+[\w\./]+|get /[^?#]*(?:\?[^#\s]*)?(?:#[\S]*)?)$" \
+SecRule REQUEST_LINE "!@rx (?i)^(?:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+)?)?\/[^?#]*(?:\?[^#\s]*)?(?:#[\S]*)?|connect (?:(?:\d{1,3}\.){3}\d{1,3}\.?(?::\d+)?|[\w\-\./]+:\d+)|options \*)\s+[\w\./]+|get \/[^?#]*(?:\?[^#\s]*)?(?:#[\S]*)?)$" \
     "id:920100,\
     phase:1,\
     block,\

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920100.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920100.yaml
@@ -107,13 +107,13 @@
               method: "CONNECT"
               port: 80
               headers:
-                  User-Agent: "ModSecurity CRS 3 Tests #FP"
+                  User-Agent: "ModSecurity CRS 3 Tests"
                   Host: "localhost"
               protocol: "http"
               uri: "www.cnn.com:80"
               version: "HTTP/1.1"
             output:
-              log_contains: "id \"920100\""
+              no_log_contains: "id \"920100\""
     -
       # Valid request with query and anchor components
       test_title: 920100-7

--- a/util/regexp-assemble/data/920100.data
+++ b/util/regexp-assemble/data/920100.data
@@ -42,4 +42,3 @@
 ##! Cover other methods of the form METHOD [[scheme]://[host][:port]]/path[?query][#fragment] protocol
 ##!  Method ---|- Scheme:// -|- Host --|-- Port --| Path |--- Query ---| Fragment | Protocol |
 ^[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+)?)?/[^?#]*(?:\?[^#\s]*)?(?:#[\S]*)?\s+[\w\./]+$
-

--- a/util/regexp-assemble/data/920100.data
+++ b/util/regexp-assemble/data/920100.data
@@ -1,0 +1,45 @@
+##! This is a data file used to generate a regular expression for a CRS rule. 
+##! The generation of the regular expression happens with the help of 
+##! util/regexp-assemble/regexp-assemble.py.
+##! The ID of the rule in question is part of the file name of this data file. 
+##! Read more about the format of this data file and the use of the assembly 
+##! script in util/regexp-assemble/README.md.
+##!
+##! Lines starting with `##!` are comments and will be skipped,
+##! empty lines will be ignored completely.
+##! In addition, the quote character `'` at the beginning of a line will
+##! cause the line to be interpreted as literal by the cmdline preprocessor only.
+##! 
+##! Five special comments are at your disposal to influence the assembled expression:
+##! - `##!+`: the flag comment
+##! - `##!^`: the prefix comment
+##! - `##!$`: the suffix comment
+##! - `##!>`: the preprocessor comment
+##! - `##!<`: the block preprocessor end comment
+##!
+##! Currently supported preoprocessors:
+##! - cmdline [windows|unix] (file scope)
+##! - neglook (block scope)
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
+
+##!+ i
+
+##! Cover the GET method
+##!  | Path |--- Query ---| Fragment |
+^get /[^?#]*(?:\?[^#\s]*)?(?:#[\S]*)?$
+
+##! Cover the CONNECT method
+##! Meth |----- IPv4 Address ------|- Port -| Protocol |
+^connect (?:\d{1,3}\.){3}\d{1,3}\.?(?::\d+)?\s+[\w\./]+$
+
+##! Meth |- Host --|Prt| Protocol |
+^connect [\w\-\./]+:\d+\s+[\w\./]+$
+
+##! Cover the OPTIONS method
+##! Meth |*| Protocol |
+^options \*\s+[\w\./]+$
+
+##! Cover other methods of the form METHOD [[scheme]://[host][:port]]/path[?query][#fragment] protocol
+##!  Method ---|- Scheme:// -|- Host --|-- Port --| Path |--- Query ---| Fragment | Protocol |
+^[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+)?)?/[^?#]*(?:\?[^#\s]*)?(?:#[\S]*)?\s+[\w\./]+$
+


### PR DESCRIPTION
This PR addresses the deficiency with covering the `CONNECT` method, as raised in issue #2220.

**In summary**: an HTTP `CONNECT` request typically includes a domain on the request line. Rule 920100, for some reason, was written to only accept `CONNECT` requests featuring an IPv4 address on the request line.

**This PR:**
- disassembles the regular expression for rule 920100;
- adds support for `CONNECT` requests featuring a domain;
- modifies an existing test for the `CONNECT` method which was previously a false positive (the test uses a domain, and is no longer a false positive).

---

### Outstanding

- [x] Test locally ("before and after" tests) using the `cURL` command described in #2220.
- [x] Create a test case for the new style of `CONNECT` request being added here.