### PR TITLE
Amend 920300 to exclude CONNECT requests

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1376,8 +1376,8 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteR
 # It is just typical browser behavior to send and it can indicate a malicious client.
 #
 # Notice: The rule tries to avoid known false positives by ignoring
-# OPTIONS requests coming from known offending User-Agents via two
-# chained rules.
+# OPTIONS requests, CONNECT requests, and requests coming from known
+# offending User-Agents via two chained rules.
 # As ModSecurity only reports the match of the last matching rule,
 # the alert is misleading.
 #
@@ -1398,7 +1398,7 @@ SecRule &REQUEST_HEADERS:Accept "@eq 0" \
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'NOTICE',\
     chain"
-    SecRule REQUEST_METHOD "!@rx ^OPTIONS$" \
+    SecRule REQUEST_METHOD "!@rx ^(?:OPTIONS|CONNECT)$" \
         "chain"
         SecRule REQUEST_HEADERS:User-Agent "!@pm AppleWebKit Android" \
             "t:none,\

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920300.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920300.yaml
@@ -28,3 +28,53 @@
           data: ''
         output:
           log_contains: id "920300"
+  -
+    test_title: 920300-2
+    desc: "OPTIONS request: exempt from requiring an Accept request header"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: "127.0.0.1"
+          headers:
+            Host: "localhost"
+            User-Agent: "Mozilla/5.0 (X11; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0"
+          method: "OPTIONS"
+          uri: "*"
+          version: "HTTP/1.1"
+        output:
+          no_log_contains: "id \"920300\""
+  -
+    test_title: 920300-3
+    desc: "CONNECT request: exempt from requiring an Accept request header"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: "127.0.0.1"
+          port: 80
+          headers:
+            Host: "www.cnn.com:80"
+            User-Agent: "Mozilla/5.0 (X11; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0"
+            Proxy-Connection: "Keep-Alive"
+          method: "CONNECT"
+          uri: "www.cnn.com:80"
+          version: "HTTP/1.1"
+        output:
+          no_log_contains: "id \"920300\""
+  -
+    test_title: 920300-4
+    desc: "User-Agent containing AppleWebKit: exempt from requiring an Accept request header"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: "127.0.0.1"
+          headers:
+            Host: "localhost"
+            User-Agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
+          method: "GET"
+          uri: "/"
+          version: "HTTP/1.1"
+        output:
+          no_log_contains: "id \"920300\""


### PR DESCRIPTION
After some research*, it seems that HTTP `CONNECT` requests typically do not include an Accept request header.

A user with a web application making use of the `CONNECT` method would find that (at PL 3) rule 920300 causes false positives. This is because rule 920300 expects all requests to feature an Accept header (with the exception of `OPTIONS` requests and requests with a `User-Agent` of either "AppleWebKit" or "Android").

**This PR:**

- adds the `CONNECT` method as an additional exemption, next to the `OPTIONS` method which is already exempt;
- adds three new tests:
  - one covering the newly exempt `CONNECT` method;
  - one covering the exempt `OPTIONS` method;
  - and one covering an exempt `User-Agent` containing the string "AppleWebKit".

---

### *Sources

1. RFC 7231 [provides examples of `CONNECT` requests](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.6), none of which feature an Accept header.

1. Mozilla's documentation of HTTP methods includes [an example of a valid `CONNECT` request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/CONNECT#example) which does not feature an Accept header.

1. Constructing a valid HTTP `CONNECT` request using `cURL` does not include an Accept request header:
```
$ curl -v -o/dev/null -p -x localhost:80 http://test.com
...
> CONNECT test.com:80 HTTP/1.1
> Host: test.com:80
> User-Agent: curl/7.79.1
> Proxy-Connection: Keep-Alive
...
```