### PR TITLE
Disassemble 930100 regex

### DIFF
--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -55,7 +55,15 @@ SecRule &ARGS_GET "@eq 3" \
 #
 # [ Encoded /../ Payloads ]
 #
-SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@rx (?i)(?:\x5c|(?:%(?:c(?:0%(?:[2aq]f|5c|9v)|1%(?:[19p]c|8s|af))|2(?:5(?:c(?:0%25af|1%259c)|2f|5c)|%46|f)|(?:(?:f(?:8%8)?0%8|e)0%80%a|bg%q)f|%3(?:2(?:%(?:%6|4)6|F)|5%%63)|u(?:221[56]|002f|EFC8|F025)|1u|5c)|0x(?:2f|5c)|/))(?:%(?:(?:f(?:(?:c%80|8)%8)?0%8|e)0%80%ae|2(?:(?:5(?:c0%25a|2))?e|%45)|u(?:(?:002|ff0)e|2024)|%32(?:%(?:%6|4)5|E)|c0(?:%[256aef]e|\.))|\.(?:%0[01]|\?)?|\?\.?|0x2e){2}(?:\x5c|(?:%(?:c(?:0%(?:[2aq]f|5c|9v)|1%(?:[19p]c|8s|af))|2(?:5(?:c(?:0%25af|1%259c)|2f|5c)|%46|f)|(?:(?:f(?:8%8)?0%8|e)0%80%a|bg%q)f|%3(?:2(?:%(?:%6|4)6|F)|5%%63)|u(?:221[56]|002f|EFC8|F025)|1u|5c)|0x(?:2f|5c)|/))" \
+# Regexp generated from util/regexp-assemble/930100-slashes.data and
+# util/regexp-assemble/930100-dots.data using Regexp::Assemble.
+# To rebuild the regexp:
+#   cd util/regexp-assemble
+#   echo "(?i)"$(./regexp-assemble.py 930100-slashes)$(./regexp-assemble.py 930100-dots)$(./regexp-assemble.py 930100-slashes)
+# The above command sandwiches together the final regular expression, like so:
+#   (?i)[SLASHES PATTERN][DOTS PATTERN][SLASHES PATTERN]
+#
+SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@rx (?i)(?:\x5c|(?:%(?:c(?:0%(?:[2aq]f|5c|9v)|1%(?:[19p]c|8s|af))|2(?:5(?:c(?:0%25af|1%259c)|2f|5c)|%46|f)|(?:(?:f(?:8%8)?0%8|e)0%80%a|bg%q)f|%3(?:2(?:%(?:%6|4)6|F)|5%%63)|u(?:221[56]|002f|EFC8|F025)|1u|5c)|0x(?:2f|5c)|\/))(?:%(?:(?:f(?:(?:c%80|8)%8)?0%8|e)0%80%ae|2(?:(?:5(?:c0%25a|2))?e|%45)|u(?:(?:002|ff0)e|2024)|%32(?:%(?:%6|4)5|E)|c0(?:%[256aef]e|\.))|\.(?:%0[01]|\?)?|\?\.?|0x2e){2}(?:\x5c|(?:%(?:c(?:0%(?:[2aq]f|5c|9v)|1%(?:[19p]c|8s|af))|2(?:5(?:c(?:0%25af|1%259c)|2f|5c)|%46|f)|(?:(?:f(?:8%8)?0%8|e)0%80%a|bg%q)f|%3(?:2(?:%(?:%6|4)6|F)|5%%63)|u(?:221[56]|002f|EFC8|F025)|1u|5c)|0x(?:2f|5c)|\/))" \
     "id:930100,\
     phase:2,\
     block,\

--- a/util/regexp-assemble/data/930100-dots.data
+++ b/util/regexp-assemble/data/930100-dots.data
@@ -1,0 +1,76 @@
+##! This is a data file used to generate a regular expression for a CRS rule. 
+##! The generation of the regular expression happens with the help of 
+##! util/regexp-assemble/regexp-assemble.py.
+##! The ID of the rule in question is part of the file name of this data file. 
+##! Read more about the format of this data file and the use of the assembly 
+##! script in util/regexp-assemble/README.md.
+##!
+##! Lines starting with `##!` are comments and will be skipped,
+##! empty lines will be ignored completely.
+##! In addition, the quote character `'` at the beginning of a line will
+##! cause the line to be interpreted as literal by the cmdline preprocessor only.
+##! 
+##! Five special comments are at your disposal to influence the assembled expression:
+##! - `##!+`: the flag comment
+##! - `##!^`: the prefix comment
+##! - `##!$`: the suffix comment
+##! - `##!>`: the preprocessor comment
+##! - `##!<`: the block preprocessor end comment
+##!
+##! Currently supported preoprocessors:
+##! - cmdline [windows|unix] (file scope)
+##! - neglook (block scope)
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
+
+##! Source: https://github.com/wireghoul/dotdotpwn/blob/master/DotDotPwn/TraversalEngine.pm
+##! Attack description: https://doc.lagout.org/security/McGraw.Hill.HackNotes.Web.Security.Portable.Reference.eBook-DDU.pdf
+##! Excerpt:
+##! In short, IIS turns %c0%af into
+##! the ASCII / character, but parses it at a point where security checks for
+##! ‘../’ traversals have already occurred!
+##! What has really happened? The attack uses an overlong Unicode
+##! representation for a forward or backward slash (/ or \).
+##! Unicode permits multibyte encoding of the same character.
+##! The fundamental representation can be referred to as a one (character) to one (byte field)
+##! representation. The overlong representation is a one (character) to many
+##! (bytes) version.
+##! Two more valid strings that represent the backward slash are %c1%1c
+##! and %c1%9c. The difference between these two hex values is 128. More
+##! valid slash representations boil down to a matter of math. For example,
+##! %c0%9v works even though %9v isn’t a hexadecimal value. Try adding
+##! the value for “9” (57) to “v” (118); if the result is greater than 127, then
+##! subtract 128—hint, the final result should be 47.
+
+##! Append {2} to the result, as we're looking for two dots (e.g. /../)
+##!$ {2}
+
+##! These use the same techniques as for slashes to evade the detection of '.'
+\.
+\.%00
+\.%01
+\.\?
+\?\.
+\?
+%2e
+0x2e
+%c0\.
+%252e
+%c0%2e
+%c0%ae
+%c0%5e
+%c0%ee
+%c0%fe
+%uff0e
+%%32%%65
+%e0%80%ae
+%25c0%25ae
+%f0%80%80%ae
+%f8%80%80%80%ae
+%fc%80%80%80%80%ae
+%2%45
+%u002e
+%uff0e
+%u2024
+%%32%45
+%%32E
+%c0%6e

--- a/util/regexp-assemble/data/930100-slashes.data
+++ b/util/regexp-assemble/data/930100-slashes.data
@@ -1,0 +1,84 @@
+##! This is a data file used to generate a regular expression for a CRS rule. 
+##! The generation of the regular expression happens with the help of 
+##! util/regexp-assemble/regexp-assemble.py.
+##! The ID of the rule in question is part of the file name of this data file. 
+##! Read more about the format of this data file and the use of the assembly 
+##! script in util/regexp-assemble/README.md.
+##!
+##! Lines starting with `##!` are comments and will be skipped,
+##! empty lines will be ignored completely.
+##! In addition, the quote character `'` at the beginning of a line will
+##! cause the line to be interpreted as literal by the cmdline preprocessor only.
+##! 
+##! Five special comments are at your disposal to influence the assembled expression:
+##! - `##!+`: the flag comment
+##! - `##!^`: the prefix comment
+##! - `##!$`: the suffix comment
+##! - `##!>`: the preprocessor comment
+##! - `##!<`: the block preprocessor end comment
+##!
+##! Currently supported preoprocessors:
+##! - cmdline [windows|unix] (file scope)
+##! - neglook (block scope)
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
+
+##! Source: https://github.com/wireghoul/dotdotpwn/blob/master/DotDotPwn/TraversalEngine.pm
+##! Attack description: https://doc.lagout.org/security/McGraw.Hill.HackNotes.Web.Security.Portable.Reference.eBook-DDU.pdf
+##! Excerpt:
+##! In short, IIS turns %c0%af into
+##! the ASCII / character, but parses it at a point where security checks for
+##! ‘../’ traversals have already occurred!
+##! What has really happened? The attack uses an overlong Unicode
+##! representation for a forward or backward slash (/ or \).
+##! Unicode permits multibyte encoding of the same character.
+##! The fundamental representation can be referred to as a one (character) to one (byte field)
+##! representation. The overlong representation is a one (character) to many
+##! (bytes) version.
+##! Two more valid strings that represent the backward slash are %c1%1c
+##! and %c1%9c. The difference between these two hex values is 128. More
+##! valid slash representations boil down to a matter of math. For example,
+##! %c0%9v works even though %9v isn’t a hexadecimal value. Try adding
+##! the value for “9” (57) to “v” (118); if the result is greater than 127, then
+##! subtract 128—hint, the final result should be 47.
+
+##! URI encoded
+%2f
+%5c
+##! Hex encoded
+0x2f
+0x5c
+##! Double URI encoded
+%252f
+%255c
+##! Overlong Unicode sequences (target IIS)
+%c0%2f
+%c0%af
+%c0%5c
+%c1%9c
+%c1%pc
+%c0%9v
+%c0%qf
+%c1%8s
+%c1%1c
+%c1%af
+%bg%qf
+##! Unicode 16 "alternative" glyphs
+%u2215
+%u2216
+##! Unknown
+%uEFC8
+%uF025
+##! More double encoding and variations on the above
+%%32%%66
+%%35%%63
+%e0%80%af
+%25c1%259c
+%25c0%25af
+%f0%80%80%af
+%f8%80%80%80%af
+%2%46
+%%32%46
+%%32F
+%u002f
+%1u
+/

--- a/util/regexp-assemble/data/930100-slashes.data
+++ b/util/regexp-assemble/data/930100-slashes.data
@@ -41,6 +41,21 @@
 ##! the value for “9” (57) to “v” (118); if the result is greater than 127, then
 ##! subtract 128—hint, the final result should be 47.
 
+##! Prepend the "\x5c" pattern manually because Regexp::Assemble will
+##! automatically convert it into a "\" character if it's fed in with the other
+##! pattern lines below. We want to maintain the original form of "\x5c" because
+##! a.) that maintains the original regular expression, and b.) using "\x5c"
+##! works as intended with both ModSecurity 2 and libmodsecurity (i.e. it works
+##! around the issue of representing a literal backslash character, using tricks
+##! like [\\\\], etc.).
+
+##!^ (?:\x5c|
+
+##! Manually append the closing bracket to match the manually prepended opening
+##! one.
+
+##!$ )
+
 ##! URI encoded
 %2f
 %5c


### PR DESCRIPTION
This PR disassembles the regular expression from rule 930100, which resolves #2221 _(Disassemble regex in 930100: The regex in 930100 is rather hard to read.)_.

Updated instructions are provided in the rule comments describing how to build the newly disassembled regular expression.