### PR TITLE
fix: 933160 regex

### DIFF
--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -333,7 +333,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     phase:2,\
     block,\
     capture,\
-    t:none,\
+    t:none,t:compressWhitespace,t:removeWhitespace,t:removeCommentsChar,\
     msg:'PHP Injection Attack: High-Risk PHP Function Call Found',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\


### PR DESCRIPTION
removed suffix `#*` and `//*` from regex since isn't a valid PHP syntax

```php
system#("ls");
system//("ls");
```

the only valid syntax should be
```php
system/*foo*/("ls");
```