### PR TITLE
Resolve triple dot false negative in rule 930110

### DIFF
--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -89,8 +89,11 @@ SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@r
 # To prevent '..' from triggering, the regexp is split into two parts:
 # - ../
 # - /..
+# OR
+# - .../
+# - /...
 
-SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@rx (?:(?:^|[\\\\/])\.\.[\\\\/]|[\\\\/]\.\.(?:[\\\\/]|$))" \
+SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@rx (?:(?:^|[\\\\/])\.{2,3}[\\\\/]|[\\\\/]\.{2,3}(?:[\\\\/]|$))" \
     "id:930110,\
     phase:2,\
     block,\

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -99,7 +99,7 @@ SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@rx (?
     block,\
     capture,\
     t:none,t:utf8toUnicode,t:urlDecodeUni,t:removeNulls,t:cmdLine,\
-    msg:'Path Traversal Attack (/../)',\
+    msg:'Path Traversal Attack (/../) or (/.../)',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\

--- a/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930110.yaml
+++ b/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930110.yaml
@@ -1,6 +1,6 @@
 ---
   meta:
-    author: "Christian S.J. Peron"
+    author: "Christian S.J. Peron, Franziska Bühler"
     enabled: true
     name: "930110.yaml"
     description: "Application attacks: Local file include"
@@ -126,5 +126,20 @@
               headers:
                   Host: "localhost"
               uri: '/?arg=..\pineapple'
+            output:
+              log_contains: id "930110"
+    -
+      test_title: 930110-9
+      desc: 'Path Traversal Attack triple dot (.../) query string'
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "localhost"
+              method: "GET"
+              port: 80
+              headers:
+                  Host: "localhost"
+              uri: '/?foo=.../.../WINDOWS/win.ini'
             output:
               log_contains: id "930110"


### PR DESCRIPTION
This PR resolves issue #2205, a false negative with triple dot (/.../), by extending the current regex with a `\.{2,3}` instead of only `\.\.`.
This PR also adds a positive testcase.