### PR TITLE
WordPress: add exclusion for aioseo plugin

### DIFF
--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -818,7 +818,8 @@ SecMarker "END-WORDPRESS-ADMIN"
 # Plugin slug: aioseo
 # Plugin URL: https://wordpress.org/plugins/all-in-one-seo-pack/
 # FP: ARGS_NAMES:json.wizard.additionalInformation.social.profiles.sameUsername.included.array_2
-SecRule REQUEST_FILENAME "@rx /wp-json/aioseo/v1/wizard" \
+# This hits on '.profile', a protected file name.
+SecRule REQUEST_FILENAME "@endsWith /wp-json/aioseo/v1/wizard" \
     "id:9002960,\
     phase:1,\
     pass,\

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -808,8 +808,24 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
             ctl:ruleRemoveTargetById=932120;ARGS:plugin,\
             ctl:ruleRemoveTargetById=932120;ARGS:slug"
 
-
 SecMarker "END-WORDPRESS-ADMIN"
+
+
+#
+# [ Plugins ]
+#
+
+# Plugin slug: aioseo
+# Plugin URL: https://wordpress.org/plugins/all-in-one-seo-pack/
+# FP: ARGS_NAMES:json.wizard.additionalInformation.social.profiles.sameUsername.included.array_2
+SecRule REQUEST_FILENAME "@rx /wp-json/aioseo/v1/wizard" \
+    "id:9002960,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetById=930120;ARGS_NAMES,\
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 
 SecMarker "END-WORDPRESS"


### PR DESCRIPTION
The WordPress plugin "All in One SEO" (https://wordpress.org/plugins/all-in-one-seo-pack/) does some calls which are currently blocked. This exclusion should resolve it.

It's an interesting precedent because it's the first time we moved from WordPress Core to plugins. The future and our users will hopefully tell which other plugins we will need to support in the future.

This resolves #2095.