### PR TITLE
Fixing FPs for PostgreSQL error messages

### DIFF
--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -389,7 +389,7 @@ SecRule TX:sql_error_match "@eq 1" \
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
-    SecRule RESPONSE_BODY "@rx (?i:PostgreSQL query failed:|pg_query\(\) \[:|pg_exec\(\) \[:|PostgreSQL.*ERROR|Warning.*\bpg_.*|valid PostgreSQL result|Npgsql\.|PG::[a-zA-Z]*Error|Supplied argument is not a valid PostgreSQL .*? resource|Unable to connect to PostgreSQL server)" \
+    SecRule RESPONSE_BODY "@rx (?i:PostgreSQL query failed:|pg_query\(\) \[:|pg_exec\(\) \[:|PostgreSQL.{1,20}ERROR|Warning.*\bpg_.*|valid PostgreSQL result|Npgsql\.|PG::[a-zA-Z]*Error|Supplied argument is not a valid PostgreSQL .*? resource|Unable to connect to PostgreSQL server)" \
         "capture,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\

--- a/rules/sql-errors.data
+++ b/rules/sql-errors.data
@@ -3,7 +3,7 @@ Server message
 SQL error
 Oracle error
 JET Database Engine
-Procedure or function 
+Procedure or function
 SQLite.Exception
 [IBM][CLI Driver][DB2/6000]
 the used select statements have different number of columns
@@ -34,7 +34,7 @@ Exception
 java.sql.SQLException
 Column count doesn't match value count at row
 Sybase message
- SQL Server
+SQL Server
 PostgreSQL query failed:
 Dynamic SQL Error
 System.Data.SQLite.SQLiteException
@@ -55,7 +55,7 @@ PostgreSQL
 org.hsqldb.jdbc
 ADODB.Field (0x800A0BCD)
 SQL syntax
-Exception 
+Exception
 System.Data.SqlClient.SqlException
 Data type mismatch in criteria expression.
 Driver
@@ -78,3 +78,4 @@ Warning
 <b>Warning</b>: ibase_
 Roadhouse.Cms.
 DB2 SQL error:
+SQLSTATE[


### PR DESCRIPTION
See comments here: https://github.com/coreruleset/coreruleset/issues/2150

I decided to not use regex suggest by @lifeforms (`(?:pg_query|PostgreSQL).{1-20}ERROR`) but this one instead `PostgreSQL.{1,20}ERROR` as error messages containing `pg_query` are catched with another regex (`Warning.*\bpg_.*`).