### PR TITLE
Web shells: Simplifying one of regexes

### DIFF
--- a/rules/RESPONSE-955-WEB-SHELLS.conf
+++ b/rules/RESPONSE-955-WEB-SHELLS.conf
@@ -64,7 +64,7 @@ SecRule RESPONSE_BODY "@rx (<title>r57 Shell Version [0-9.]+</title>|<title>r57 
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # WSO web shell
-SecRule RESPONSE_BODY "@rx <title>.*? - WSO [0-9.]+</title>" \
+SecRule RESPONSE_BODY "@rx ^<html><head><meta http-equiv='Content-Type' content='text/html; charset=Windows-1251'><title>.*? - WSO [0-9.]+</title>" \
     "id:955120,\
     phase:4,\
     block,\


### PR DESCRIPTION
Regex for WSO shell is doing lots of noise such as this:
`Execution error - PCRE limits exceeded`

Fixed by making it anchored.