### PR TITLE
Email ruleset

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -685,33 +685,106 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
-# [ SMTP/IMAP/POP3 Command Execution ]
+# -=[ SMTP/IMAP/POP3 Command Execution ]=-
 #
-# This rule prevents execution of email system commands.
+# Rationale
+# =========
+#
+# The rules for email command execution are based on the RFCs for each protocol.
+# Some of the commands have optional and/or additional parameters, so we tried to be
+# precise to avoid as many FP in PL2 rules.
+# For those commands that resemble common English words, and may pose a higher risk of false positives,
+# they have been split off to a sibiling rule in PL3.
+
+# =[ SMTP Command Execution ]=
+#
+# This rule prevents execution of SMTP related system commands.
 # 
-# List of SMTP commands:
-# rfc
-# List of IMAP4 commands:
-# rfc
-# List of POP3 commands:
+# List of SMTP commands: from rfc 5321 (https://www.rfc-editor.org/rfc/rfc5321)
 #
 # To rebuild the word list regexp:
 #   cd util/regexp-assemble
-#   ./regexp-assemble.py 932210
-SecRule ARGS "(?s)\r\n.*?\b(CREATE|DELETE|RENAME|LIST|APPEND|SELECT|FETCH|COPY|CAPABILITY|STORE|CLOSE|SEARCH|STATUS|EXPUNGE|LOGOUT|EXAMINE|SUBSCRIBE|UNSUBSCRIBE|LSUB|CHECK|NOOP)\b" \
+#   ./regexp-assemble.py data/932300.data
+# 
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?is)\r\n.*?\b(?:AUTH [A-Z0-9-_]{1,20} (?:=|(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=))|R(?:CPT TO:(?:<.{1,64}@.{1,255}>|(?: ))?<.{1,64}>|SET\b)|VRFY (?:.{1,64} <.{1,64}@.{1,255}>|.{1,64}@.{1,255})|E(?:HLO [a-zA-Z-\.]{1,255}|XPN (?:.{1,64}))|MAIL FROM:<.{1,64}@.{1,255}>|HELO [a-zA-Z-\.]{1,255}|NOOP\b(?: .{1,255})?|STARTTLS\b)" \
     "id:932300,\
     phase:2,\
     block,\
-    t:none,t:escapeSeqDecode,t:compressWhitespace,\
-    msg:'Remote Command Execution: SMTP/IMAP/POP3 Command Execution',\
+    t:none,t:escapeSeqDecode,\
+    msg:'Remote Command Execution: SMTP Command Execution',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
-    tag:'language-shell',\
-    tag:'platform-unix',\
+    tag:'platform-multi',\
     tag:'attack-rce',\
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/152/248/88',\
+    tag:'capec/137/134',\
+    tag:'PCI/6.5.2',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.4.0-dev',\
+    severity:'CRITICAL',\
+    setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+
+# =[ IMAP Command Execution ]=
+#
+# This rule prevents execution of IMAP4 related system commands.
+# 
+# List of IMAP4 commands: from rfc 3501 (https://datatracker.ietf.org/doc/html/rfc3501#section-9)
+#
+# Note: Mailbox International Naming Convention uses UTF-7, so it was left out explicitly.
+#
+# To rebuild the word list regexp:
+#   cd util/regexp-assemble
+#   ./regexp-assemble.py data/932310.data
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?is)\r\n\w{1,50}\b\ (?:A(?:PPEND (?:[\w\"\.\-\x5c\/%\*&#]+)?(?: \((?:[A-Za-z\x5c\ ])+\))?(?: \"?\d{1,2}-\w{3}-\d{4} \d{2}:\d{2}:\d{2} [+-]\d{4}\"?)? \{\d{1,20}\+?}|UTHENTICATE [A-Z0-9-_]{1,20}\r\n)|S(?:TATUS (?:[\w\"\.\-\x5c\/%\*&]+)? \((?:UNSEEN|UIDNEXT|MESSAGES|UIDVALIDITY|RECENT| )+\)|ETACL (?:[\w\"\.\-\x5c\/%\*&]+)? [+-][lrswipckdxtea]+?)|L(?:SUB (?:[\w\"~\/\*#\.]+)? (?:[\w\"\.\x5c\/%\*&]+)?|ISTRIGHTS (?:[\w\"\.\-\x5c\/%\*&]+)?)|(?:(?:DELETE|GET)ACL|MYRIGHTS) (?:[\w\"\.\-\x5c\/%\*&]+)?|UID (?:COPY|FETCH|STORE) (?:[0-9,:\*]+)?)" \
+    "id:932310,\
+    phase:2,\
+    block,\
+    t:none,t:escapeSeqDecode,\
+    msg:'Remote Command Execution: IMAP Command Execution',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
+    tag:'paranoia-level/2',\
+    tag:'OWASP_CRS',\
+    tag:'capec/137/134',\
+    tag:'PCI/6.5.2',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.4.0-dev',\
+    severity:'CRITICAL',\
+    setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+
+# =[ POP3 Command Execution ]=
+#
+# This rule prevents execution of POP3 related system commands.
+# 
+# List of POP3 commands: 
+# - from rfc 1939 (https://www.rfc-editor.org/rfc/rfc1939#appendix-B)
+# - extensions from rfc 2449 (https://www.rfc-editor.org/rfc/rfc2449)
+# 
+# These commands all have some kind of parameter that makes them a good PL2 target.
+#
+# To rebuild the word list regexp:
+#   cd util/regexp-assemble
+#   ./regexp-assemble.py data/932320.data
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?si)\r\n.*?\b(?:A(?:UTH [A-Z0-9-_]{1,20} (?:=|(?:[\w+/]{4})*(?:[\w+/]{2}==|[\w+/]{3}=))|POP [\w]+ [a-f0-9]{32})|(?:TOP \d+|LIST)(?: \d+)?|U(?:IDL(?: \d+)?|SER .+?)|(?:DELE|RETR) \d+?|PASS .+?)" \
+    "id:932320,\
+    phase:2,\
+    block,\
+    t:none,t:escapeSeqDecode,\
+    msg:'Remote Command Execution: POP3 Command Execution',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
+    tag:'paranoia-level/2',\
+    tag:'OWASP_CRS',\
+    tag:'capec/137/134',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
@@ -784,6 +857,106 @@ SecRule ARGS "@rx (?:/|\\\\)(?:[\?\*]+[a-z/\\\\]+|[a-z/\\\\]+[\?\*]+)" \
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.4.0-dev',\
+    severity:'CRITICAL',\
+    setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+
+
+# -=[ SMTP commands ]=-
+# 
+# This rule prevents execution of SMTP related system commands.
+# 
+# These commands may have a higher risk of false positives.
+# For explanation of this rule, see above rule 932300.
+#
+# Rule 932301 is a stricter sibling of rule 932300.
+#
+# To rebuild the word list regexp:
+#   cd util/regexp-assemble
+#   ./regexp-assemble.py data/932301.data
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?s)\r\n.*?\b(?:HELP(?: .{1,255})?|DATA|QUIT)" \
+    "id:932301,\
+    phase:2,\
+    block,\
+    t:none,t:escapeSeqDecode,\
+    msg:'Remote Command Execution: SMTP Command Execution',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
+    tag:'paranoia-level/3',\
+    tag:'OWASP_CRS',\
+    tag:'capec/137/134',\
+    tag:'PCI/6.5.2',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.4.0-dev',\
+    severity:'CRITICAL',\
+    setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+
+# =[ IMAP4 Command Execution ]=
+#
+# This rule prevents execution of IMAP4 related system commands.
+# 
+# These commands may have a higher risk of false positives.
+# For explanation of this rule, see above rule 932310.
+#
+# Rule 932311 is a stricter sibling of rule 932310.
+#
+# To rebuild the word list regexp:
+#   cd util/regexp-assemble
+#   ./regexp-assemble.py data/932311.data
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?is)\r\n\w{1,50}\b\ (?:S(?:E(?:ARCH(?: CHARSET [\w\-_\.]{1,40})? (?:(KEYWORD \x5c)?(?:ALL|ANSWERED|BCC|DELETED|DRAFT|FLAGGED|RECENT|SEEN|UNANSWERED|UNDELETED|UNDRAFT|UNFLAGGED|UNSEEN|NEW|OLD)|(?:TEXT .{1,255}|TO .{1,255}|UID [0-9,:\*]+?|UNKEYWORD (?:\x5c(Seen|Answered|Flagged|Deleted|Draft|Recent)))|(?:BEFORE|ON|SENTBEFORE|SENTON|SENTSINCE|SINCE) \"?\d{1,2}-\w{3}-\d{4}\"?|(?:OR .{1,255} .{1,255}|SMALLER \d{1,20}|SUBJECT .{1,255})|(?:(?:BODY|CC|FROM)|HEADER .{1,100}) .{1,255}|(?:LARGER \d{1,20}|NOT .{1,255}|[0-9,:\*]+))|LECT [\w\"\.\-\x5c\/%\*&#]+)|T(?:ORE [0-9,:\*]+? [+-]?FLAGS(?:\.SILENT)? (?:\(\x5c[A-Za-z]{1,20}\)){0,100}|ARTTLS)|UBSCRIBE [\w\"\.\-\x5c\/%\*&#]+)|L(?:IST [\w\"~\-\x5c\/\*#\.]+? [\w\"\.\-\x5c\/%\*&#]+|OG(?:IN [A-Z0-9-_\.\@]{1,40} .*? |OUT))|C(?:(?:OPY [0-9,:\*]+|REATE) [\w\"\.\-\x5c\/%\*&#]+|APABILITY|HECK|LOSE)|RENAME [\w\"\.\-\x5c\/%\*&#]+? [\w\"\.\-\x5c\/%\*&#]+|UN(?:SUBSCRIBE [\w\"\.\-\x5c\/%\*&#]+|AUTHENTICATE)|EX(?:AMINE [\w\"\.\-\x5c%\*&#]+|PUNGE)|DELETE [\w\"\.\-\x5c%\*&#]+|FETCH [0-9,:\*]+|NOOP)" \
+    "id:932311,\
+    phase:2,\
+    block,\
+    t:none,t:escapeSeqDecode,\
+    msg:'Remote Command Execution: IMAP Command Execution',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
+    tag:'paranoia-level/3',\
+    tag:'OWASP_CRS',\
+    tag:'capec/137/134',\
+    tag:'PCI/6.5.2',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.4.0-dev',\
+    severity:'CRITICAL',\
+    setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+
+# =[ POP3 Command Execution ]=
+#
+# This rule prevents execution of POP3 related system commands.
+# 
+# These commands may have a higher risk of false positives.
+# For explanation of this rule, see above rule 932320.
+#
+# Rule 932321 is a stricter sibling of rule 932320.
+#
+# To rebuild the word list regexp:
+#   cd util/regexp-assemble
+#   ./regexp-assemble.py data/932321.data
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?si)\r\n.*?\b(?:(?:QUI|RSE|STA)T|CAPA|NOOP)" \
+    "id:932321,\
+    phase:2,\
+    block,\
+    t:none,t:escapeSeqDecode,\
+    msg:'Remote Command Execution: POP3 Command Execution',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
+    tag:'paranoia-level/3',\
+    tag:'OWASP_CRS',\
+    tag:'capec/137/134',\
+    tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -685,6 +685,39 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
+# [ SMTP/IMAP/POP3 Command Execution ]
+#
+# This rule prevents execution of email system commands.
+# 
+# List of SMTP commands:
+# rfc
+# List of IMAP4 commands:
+# rfc
+# List of POP3 commands:
+#
+# To rebuild the word list regexp:
+#   cd util/regexp-assemble
+#   ./regexp-assemble.py 932210
+SecRule ARGS "(?s)\r\n.*?\b(CREATE|DELETE|RENAME|LIST|APPEND|SELECT|FETCH|COPY|CAPABILITY|STORE|CLOSE|SEARCH|STATUS|EXPUNGE|LOGOUT|EXAMINE|SUBSCRIBE|UNSUBSCRIBE|LSUB|CHECK|NOOP)\b" \
+    "id:932300,\
+    phase:2,\
+    block,\
+    t:none,t:escapeSeqDecode,t:compressWhitespace,\
+    msg:'Remote Command Execution: SMTP/IMAP/POP3 Command Execution',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-shell',\
+    tag:'platform-unix',\
+    tag:'attack-rce',\
+    tag:'paranoia-level/2',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/248/88',\
+    tag:'PCI/6.5.2',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.4.0-dev',\
+    severity:'CRITICAL',\
+    setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:932015,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:932016,phase:2,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932300.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932300.yaml
@@ -1,0 +1,177 @@
+---
+  meta:
+    author: fzipi
+    description: "Remote Command Execution: SMTP Command Injection test cases"
+    enabled: true
+    name: 932300.yaml
+  tests:
+  -
+    test_title: 932300-1
+    desc: "SMTP MAIL FROM Command injection positive test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: GET
+          port: 80
+          uri: /get?attackme=%0d%0aMAIL%20FROM%3A%3Ca%40b.com%3E
+          version: HTTP/1.0
+        output:
+          log_contains: id "932300"
+  -
+    test_title: 932300-2
+    desc: "SMTP MAIL FROM Command Injection true negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: GET
+          port: 80
+          uri: /get?text=We%20received%20this%20mail%20from%20Mars
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932300"
+  -
+    test_title: 932300-3
+    desc: "SMTP Command Injection negative test 2"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=Hello%21%20We%20finally%20received%20this%20mail%20from%3A%3Ctest%40coreruleset.org%3E%2C%20which%20means%20that%20we%20can%20do%20this%20finally.
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932300"
+  -
+    test_title: 932300-4
+    desc: "SMTP EHLO Command injection positive test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: GET
+          port: 80
+          uri: /get?attackme=%0d%0aEHLO%20test.com
+          version: HTTP/1.0
+        output:
+          log_contains: id "932300"
+  -
+    test_title: 932300-5
+    desc: "SMTP Command EHLO Injection negative test using ehlo typo in text"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=Hello%21%20This%20text%20introduces%20a%20typo%20when%20saying%20%22hello%22%20so%20we%20say%20ehlo%3A%20coreruleset.org%20to%20all%21
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932300"
+  -
+    test_title: 932300-6
+    desc: "SMTP RCPT TO Command injection positive test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: GET
+          port: 80
+          uri: /get?attackme=%0d%0aRCPT%20TO%3A%3CPostmaster%3E
+          version: HTTP/1.0
+        output:
+          log_contains: id "932300"
+  -
+    test_title: 932300-7
+    desc: "SMTP RCPT TO Command Injection true negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=Hello%21%20This%20text%20introduces%20a%20typo%20when%20saying%20%22receipt%20to%22%20so%20we%20say%20rcpt%20to%3A%20%3Ccoreruleset.org%3E
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932300"
+  -
+    test_title: 932300-8
+    desc: "SMTP VRFY TO Command injection positive test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: GET
+          port: 80
+          uri: /get?attackme=%0d%0aRCPT%20TO%3A%3CPostmaster%3E
+          version: HTTP/1.0
+        output:
+          log_contains: id "932300"
+  -
+    test_title: 932300-100
+    desc: "SMTP Command Injection Full SMTP dialog negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=S%3A%20220%20foo.com%20Simple%20Mail%20Transfer%20Service%20Ready%0AC%3A%20EHLO%20bar.com%0AS%3A%20250-foo.com%20greets%20bar.com%0AS%3A%20250-8BITMIME%0AS%3A%20250-SIZE%0AS%3A%20250-DSN%0AS%3A%20250%20HELP%0AC%3A%20MAIL%20FROM%3A%3CSmith%40bar.com%3E%0AS%3A%20250%20OK%0AC%3A%20RCPT%20TO%3A%3CJones%40foo.com%3E%0AS%3A%20250%20OK%0AC%3A%20RCPT%20TO%3A%3CGreen%40foo.com%3E%0AS%3A%20550%20No%20such%20user%20here%0AC%3A%20RCPT%20TO%3A%3CBrown%40foo.com%3E%0AS%3A%20250%20OK%0AC%3A%20DATA%0AS%3A%20354%20Start%20mail%20input%3B%20end%20with%20%3CCRLF%3E.%3CCRLF%3E%0AC%3A%20Blah%20blah%20blah...%0AC%3A%20...etc.%20etc.%20etc.%0AC%3A%20.%0AS%3A%20250%20OK%0AC%3A%20QUIT%0AS%3A%20221%20foo.com%20Service%20closing%20transmission%20channel
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932300"

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932301.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932301.yaml
@@ -1,0 +1,139 @@
+---
+  meta:
+    author: fzipi
+    description: "Remote Command Execution: SMTP Command Injection test cases PL3"
+    enabled: true
+    name: 932301.yaml
+  tests:
+  -
+    test_title: 932301-1
+    desc: "SMTP DATA Command injection positive test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: GET
+          port: 80
+          uri: /get?test=%0d%0aDATA
+          version: HTTP/1.0
+        output:
+          log_contains: id "932301"
+  -
+    test_title: 932301-2
+    desc: "SMTP DATA Command Injection true negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: GET
+          port: 80
+          uri: /get?text=We%20need%20that%20data%20now
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932301"
+  -
+    test_title: 932301-3
+    desc: "SMTP Command Injection negative test 2"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=Hello%21%20World.%0adata%20not%20found.
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932301"
+  -
+    test_title: 932301-4
+    desc: "SMTP QUIT Command injection positive test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: GET
+          port: 80
+          uri: /get?attackme=%0d%0aQUIT
+          version: HTTP/1.0
+        output:
+          log_contains: id "932301"
+  -
+    test_title: 932301-5
+    desc: "SMTP Command QUIT Injection negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=Hey%20please%20do%20not%20quit
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932301"
+  -
+    test_title: 932301-6
+    desc: "SMTP HELP Command injection positive test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: GET
+          port: 80
+          uri: /get?attackme=%0d%0aHELP%20Postmaster
+          version: HTTP/1.0
+        output:
+          log_contains: id "932301"
+  -
+    test_title: 932301-7
+    desc: "SMTP HELP Command Injection true negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=Hello%21%20This%20text%20needs%20help%20now
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932301"

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932310.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932310.yaml
@@ -1,0 +1,161 @@
+---
+  meta:
+    author: fzipi
+    description: "Remote Command Execution: IMAP Command Injection test cases"
+    enabled: true
+    name: 932310.yaml
+  tests:
+  -
+    test_title: 932310-1
+    desc: "IMAP APPEND Command injection positive test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=%0D%0AA003%20APPEND%20saved-messages%20(%5CSeen)%20%7B310%7D%0D%0A%20Date%3A%20Mon%2C%207%20Feb%201994%2021%3A52%3A25%20-0800%20(PST)%0D%0A%20From%3A%20Test%20CRS%20%3Ctest%40coreruleset.org%3E%0D%0A%20Subject%3A%20Appending%0D%0A%20To%3A%20test%40coreruleset.org%0D%0A%20Message-Id%3A%20%3CB27397-0100000%40coreruleset.org%3E%0D%0A%20MIME-Version%3A%201.0%0D%0A%20Content-Type%3A%20TEXT%2FPLAIN%3B%20CHARSET%3DUS-ASCII%0D%0A%20%0D%0A%20Hello%20World%2C%20can%20I%20append%3F
+          version: HTTP/1.0
+        output:
+          log_contains: id "932310"
+  -
+    test_title: 932310-2
+    desc: "IMAP APPEND Command Injection negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: GET
+          port: 80
+          uri: /get?text=I%20wanted%20to%20append%20something%20%28annoying%29%20%7Bclosed%7D
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932310"
+  -
+    test_title: 932310-3
+    desc: "IMAP AUTHENTICATE Command injection positive test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=%0D%0Aa001%20authenticate%20PLAIN%0D%0A
+          version: HTTP/1.0
+        output:
+          log_contains: id "932310"
+  -
+    test_title: 932310-4
+    desc: "IMAP AUTHENTICATE Command Injection negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: GET
+          port: 80
+          uri: /get?text=Cannot%20authenticate%20anyways
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932310"
+  -
+    test_title: 932310-5
+    desc: "IMAP STATUS Command injection positive test"
+    # STATUS [a-zA-Z0-9\"\./%\*&]+? (?:\((UNSEEN|UIDNEXT|MESSAGES|UIDVALIDITY|RECENT| )+\))?
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=%0D%0Aa001%20STATUS%20INBOX%20(MESSAGES)
+          version: HTTP/1.0
+        output:
+          log_contains: id "932310"
+  -
+    test_title: 932310-6
+    desc: "IMAP STATUS Command Injection negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: GET
+          port: 80
+          uri: /get?text=Please%20send%20me%20an%20update%20status%20all%20messages%20are%20being%20denied
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932310"
+  -
+    test_title: 932310-7
+    desc: "IMAP UID Command injection positive test"
+    # UID (COPY|FETCH|STORE) [0-9,:\*]+?
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=%0D%0Aa001%20uid%20store%20231%3A233%0D%0A
+          version: HTTP/1.0
+        output:
+          log_contains: id "932310"
+  -
+    test_title: 932310-8
+    desc: "IMAP UID Command Injection negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: GET
+          port: 80
+          uri: /get?text=The%20uid%20is%020not%020working
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932310"

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932311.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932311.yaml
@@ -1,0 +1,265 @@
+---
+  meta:
+    author: fzipi
+    description: "Remote Command Execution: IMAP Command Injection test cases PL3"
+    enabled: true
+    name: 932311.yaml
+  tests:
+  -
+    test_title: 932311-1
+    desc: "IMAP CREATE/DELETE/EXAMINE/SELECT/SUBSCRIBE/UNSUBSCRIBE Command injection positive test"
+    comment: "All these receive the same arguments"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: GET
+          port: 80
+          uri: /get?attackme=%0d%0aa001%20EXAMINE%20INBOX
+          version: HTTP/1.0
+        output:
+          log_contains: id "932311"
+  -
+    test_title: 932311-2
+    desc: "IMAP CREATE/DELETE/EXAMINE/SELECT/SUBSCRIBE/UNSUBSCRIBE Command Injection true negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+            X-CRS-test: "CREATE:1"
+          method: GET
+          port: 80
+          uri: /get?text=We%examine%20this%20mail%20from%20Mars
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932311"
+  -
+    test_title: 932311-3
+    desc: "IMAP COPY Command Injection positive test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=%0d%0aa002%20copy%202%3A4%20MEETING
+          version: HTTP/1.0
+        output:
+          log_contains: id "932311"
+  -
+    test_title: 932311-4
+    desc: "IMAP COPY Command Injection negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=Just%20to%20remind%20you%20that%20I%20need%20to%20copy%20those%20documents
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932311"
+  -
+    test_title: 932311-5
+    desc: "IMAP LIST Command Injection positive test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=%0d%0aA1%20list%20%22INBOX%2F%22%20%22%2A%22
+          version: HTTP/1.0
+        output:
+          log_contains: id "932311"
+  -
+    test_title: 932311-6
+    desc: "IMAP LIST Command Injection negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=We%20need%20the%20list%20%22ASAP%22
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932311"
+  -
+    test_title: 932311-7
+    desc: "IMAP STORE Command Injection positive test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=%0d%0ad%20store%202%20%2BFLAGS%20%28%5CDeleted%29
+          version: HTTP/1.0
+        output:
+          log_contains: id "932311"
+  -
+    test_title: 932311-8
+    desc: "IMAP STORE Command Injection negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=%0aLet%27s%20go%20to%20the%20store%20%28sale%20time%21%29
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932311"
+  -
+    test_title: 932311-9
+    desc: "IMAP SEARCH Command Injection positive test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=%0d%0aA282%20SEARCH%20FLAGGED%20SINCE%201-Feb-1994%20NOT%20FROM%20%22Smith%22
+          version: HTTP/1.0
+        output:
+          log_contains: id "932311"
+  -
+    test_title: 932311-10
+    desc: "IMAP SEARCH with CHARSET Command Injection positive test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=%0d%0aZ001%20SEARCH%20CHARSET%20WINDOWS-1252%20DELETED%20SINCE%201-Feb-1994
+          version: HTTP/1.0
+        output:
+          log_contains: id "932311"
+  -
+    test_title: 932311-11
+    desc: "IMAP SEARCH using TEXT Command Injection positive test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=%0d%0aA283%20SEARCH%20TEXT%20%22string%20not%20in%20mailbox%22
+          version: HTTP/1.0
+        output:
+          log_contains: id "932311"
+  -
+    test_title: 932311-11
+    desc: "IMAP SEARCH using CHARSET and range Command Injection positive test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=%0d%0aA284%20SEARCH%20CHARSET%20UTF-8%20TEXT%20%7B6%7D
+          version: HTTP/1.0
+        output:
+          log_contains: id "932311"
+  -
+    test_title: 932311-12
+    desc: "IMAP SEARCH Command Injection negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=In%20all%20search%20keys%20that%20use%20strings%2C%20a%20message%20matches%20the%20key%20if%20the%20string%20is%20a%20substring%20of%20the%20field.%20%20The%20matching%20is%20case-insensitive.
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932311"

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932320.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932320.yaml
@@ -1,0 +1,215 @@
+---
+  meta:
+    author: fzipi
+    description: "Remote Command Execution: POP3 Command Injection test cases"
+    enabled: true
+    name: 932320.yaml
+  tests:
+  -
+    test_title: 932320-1
+    desc: "POP3 RETR/DELE Command injection positive test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: GET
+          port: 80
+          uri: /get?attackme=%0d%0aRETR%20123
+          version: HTTP/1.0
+        output:
+          log_contains: id "932320"
+  -
+    test_title: 932320-2
+    desc: "POP3 RETR Command Injection negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: GET
+          port: 80
+          uri: /get?text=Let%20me%20retrieve%2010%20of%20those
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932320"
+  -
+    test_title: 932320-3
+    desc: "POP3 DELE Command Injection negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=We%20should%20delete%20nine
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932320"
+  -
+    test_title: 932320-4
+    desc: "POP3 LIST Command injection positive test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: GET
+          port: 80
+          uri: /get?attackme=%0d%0alist%203
+          version: HTTP/1.0
+        output:
+          log_contains: id "932320"
+  -
+    test_title: 932320-5
+    desc: "POP3 LIST Command Injection negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=This%20text%20is%20a%20way%20of%20list%203%20things
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932320"
+  -
+    test_title: 932320-6
+    desc: "POP3 TOP Command injection positive test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: GET
+          port: 80
+          uri: /get?attackme=%0d%0aTOP%201%202
+          version: HTTP/1.0
+        output:
+          log_contains: id "932320"
+  -
+    test_title: 932320-7
+    desc: "POP3 TOP Command Injection true negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=These%20are%20top%10%20rules
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932320"
+  -
+    test_title: 932320-8
+    desc: "POP3 AUTH Command injection positive test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: GET
+          port: 80
+          uri: /get?attackme=%0d%0aAUTH%20corerulest%20dGhpc2lzIWF0ZXN0cGFzc3dvcmQ=
+          version: HTTP/1.0
+        output:
+          log_contains: id "932320"
+  -
+    test_title: 932320-9
+    desc: "POP3 AUTH Command Injection negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=Hey%2C%20sent%20me%20those%20auth%20codes%20please!
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932320"
+  -
+    test_title: 932320-10
+    desc: "POP3 APOP Command injection positive test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: GET
+          port: 80
+          uri: /get?attackme=%0d%0aAPOP%20corerulest%207d0a3bd8e5b2abcfb3e256633c23b891
+          version: HTTP/1.0
+        output:
+          log_contains: id "932320"
+  -
+    test_title: 932320-11
+    desc: "POP3 APOP Command Injection negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=Look%2C%20apop%20star!
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932320"

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932321.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932321.yaml
@@ -1,0 +1,121 @@
+---
+  meta:
+    author: fzipi
+    description: "Remote Command Execution: POP3 PL3 Command Injection test cases"
+    enabled: true
+    name: 932321.yaml
+  tests:
+  -
+    test_title: 932321-1
+    desc: "POP3 QUIT/STAT/NOOP/RSET/CAPA Command injection positive test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: GET
+          port: 80
+          uri: /get?attackme=%0d%0aQUIT
+          version: HTTP/1.0
+        output:
+          log_contains: id "932321"
+  -
+    test_title: 932321-2
+    desc: "POP3 QUIT Command Injection negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: GET
+          port: 80
+          uri: /get?text=Don't%20quit
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932321"
+  -
+    test_title: 932321-3
+    desc: "POP3 CAPA Command Injection negative test 2"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=we%20do%20not%20have%20that%20capability
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932321"
+  -
+    test_title: 932321-4
+    desc: "POP3 STAT Command Injection negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=Hi%20lestat!
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932321"
+  -
+    test_title: 932321-6
+    desc: "POP3 NOOP Command injection negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: GET
+          port: 80
+          uri: /get?attackme=%0aSeriously%2C%20noop
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932321"
+  -
+    test_title: 932321-7
+    desc: "POP3 RSET Command Injection negative test"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "Coreruleset"
+          method: POST
+          port: 80
+          uri: /post
+          data: |
+            textarea=Someone%20bought%20this%20nice%20lerset
+          version: HTTP/1.0
+        output:
+          no_log_contains: id "932321"

--- a/util/regexp-assemble/data/932300.data
+++ b/util/regexp-assemble/data/932300.data
@@ -1,0 +1,34 @@
+##! This is a data file used to generate a regular expression for a CRS rule. 
+##! The generation of the regular expression happens with the help of 
+##! util/regexp-assemble/regexp-assemble.py.
+##! The ID of the rule in question is part of the file name of this data file. 
+##! Read more about the format of this data file and the use of the assembly 
+##! script in util/regexp-assemble/README.md.
+##!
+##! Lines starting with `##!` are comments and will be skipped,
+##! empty lines will be ignored completely.
+##! 
+##! Five special comments are at your disposal to influence the assembled expression:
+##! - `##!+`: the flag comment
+##! - `##!^`: the prefix comment
+##! - `##!$`: the suffix comment
+##! - `##!>`: the preprocessor comment
+##! - `##!<`: the block preprocessor end comment
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
+
+##!^ (?is)\r\n.*?\b
+##!$
+
+##! - SMTP Commands
+EHLO [a-zA-Z-\.]{1,255}
+HELO [a-zA-Z-\.]{1,255}
+MAIL FROM:<.{1,64}@.{1,255}>
+RCPT TO:(?:<.{1,64}@.{1,255}>|(?: ))?<.{1,64}>
+VRFY (?:.{1,64} <.{1,64}@.{1,255}>|.{1,64}@.{1,255})
+EXPN (?:.{1,64})
+AUTH [A-Z0-9-_]{1,20} (?:=|(?:[\w+/]{4})*(?:[\w+/]{2}==|[\w+/]{3}=))
+
+##! - SMTP Commands without params
+STARTTLS\b
+RSET\b
+NOOP\b(?: .{1,255})?

--- a/util/regexp-assemble/data/932301.data
+++ b/util/regexp-assemble/data/932301.data
@@ -1,0 +1,28 @@
+##! This is a data file used to generate a regular expression for a CRS rule. 
+##! The generation of the regular expression happens with the help of 
+##! util/regexp-assemble/regexp-assemble.py.
+##! The ID of the rule in question is part of the file name of this data file. 
+##! Read more about the format of this data file and the use of the assembly 
+##! script in util/regexp-assemble/README.md.
+##!
+##! Lines starting with `##!` are comments and will be skipped,
+##! empty lines will be ignored completely.
+##! 
+##! Five special comments are at your disposal to influence the assembled expression:
+##! - `##!+`: the flag comment
+##! - `##!^`: the prefix comment
+##! - `##!$`: the suffix comment
+##! - `##!>`: the preprocessor comment
+##! - `##!<`: the block preprocessor end comment
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
+
+##!^ (?s)\r\n.*?\b
+
+##! - SMTP Commands without or optional params
+DATA
+QUIT
+HELP(?: .{1,255})?
+
+##! - SMTP Commands with params
+
+##! Not covered -  X<atom> Command (client extensions)

--- a/util/regexp-assemble/data/932310.data
+++ b/util/regexp-assemble/data/932310.data
@@ -1,0 +1,36 @@
+##! This is a data file used to generate a regular expression for a CRS rule. 
+##! The generation of the regular expression happens with the help of 
+##! util/regexp-assemble/regexp-assemble.py.
+##! The ID of the rule in question is part of the file name of this data file. 
+##! Read more about the format of this data file and the use of the assembly 
+##! script in util/regexp-assemble/README.md.
+##!
+##! Lines starting with `##!` are comments and will be skipped,
+##! empty lines will be ignored completely.
+##! 
+##! Five special comments are at your disposal to influence the assembled expression:
+##! - `##!+`: the flag comment
+##! - `##!^`: the prefix comment
+##! - `##!$`: the suffix comment
+##! - `##!>`: the preprocessor comment
+##! - `##!<`: the block preprocessor end comment
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
+
+##! All IMAP4 commands start with a "tag"
+
+##!^ (?is)\r\n\w{1,50}\b\ 
+
+##! IMAP4 Commands - PL2
+
+##! - IMAP4Rev1 Commands - with params
+APPEND (?:[\w\"\.\-\x5c\/%\*&#]+)?(?: \((?:[A-Za-z\x5c\ ])+\))?(?: \"?\d{1,2}-\w{3}-\d{4} \d{2}:\d{2}:\d{2} [+-]\d{4}\"?)? \{\d{1,20}\+?\}
+AUTHENTICATE [A-Z0-9-_]{1,20}\r\n
+LSUB (?:[\w\"~\/\*#\.]+)? (?:[\w\"\.\x5c\/%\*&]+)?
+STATUS (?:[\w\"\.\-\x5c\/%\*&]+)? \((?:UNSEEN|UIDNEXT|MESSAGES|UIDVALIDITY|RECENT| )+\)
+UID (?:COPY|FETCH|STORE) (?:[0-9,:\*]+)?
+##! - IMAP4Rev1 Commands Extensions - with params
+DELETEACL (?:[\w\"\.\-\x5c\/%\*&]+)?
+GETACL (?:[\w\"\.\-\x5c\/%\*&]+)?
+MYRIGHTS (?:[\w\"\.\-\x5c\/%\*&]+)?
+LISTRIGHTS (?:[\w\"\.\-\x5c\/%\*&]+)?
+SETACL (?:[\w\"\.\-\x5c\/%\*&]+)? [+-][lrswipckdxtea]+?

--- a/util/regexp-assemble/data/932311.data
+++ b/util/regexp-assemble/data/932311.data
@@ -1,0 +1,59 @@
+##! This is a data file used to generate a regular expression for a CRS rule. 
+##! The generation of the regular expression happens with the help of 
+##! util/regexp-assemble/regexp-assemble.py.
+##! The ID of the rule in question is part of the file name of this data file. 
+##! Read more about the format of this data file and the use of the assembly 
+##! script in util/regexp-assemble/README.md.
+##!
+##! Lines starting with `##!` are comments and will be skipped,
+##! empty lines will be ignored completely.
+##! 
+##! Five special comments are at your disposal to influence the assembled expression:
+##! - `##!+`: the flag comment
+##! - `##!^`: the prefix comment
+##! - `##!$`: the suffix comment
+##! - `##!>`: the preprocessor comment
+##! - `##!<`: the block preprocessor end comment
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
+
+##! All IMAP4 commands start with a "tag"
+
+##! TDB: representing charset and language (if needed)
+
+##!^ (?is)\r\n\w{1,50}\b\ 
+
+##! - IMAP4 Commands - PL3
+
+##! - IMAP4Rev1 Commands - with params
+CREATE [\w\"\.\-\x5c\/%\*&#]+
+COPY [0-9,:\*]+ [\w\"\.\-\x5c\/%\*&#]+
+DELETE [\w\"\.\-\x5c%\*&#]+
+EXAMINE [\w\"\.\-\x5c%\*&#]+
+FETCH [0-9,:\*]+
+LIST [\w\"~\-\x5c\/\*#\.]+? [\w\"\.\-\x5c\/%\*&#]+
+LOGIN [A-Z0-9-_\.\@]{1,40} .*? 
+RENAME [\w\"\.\-\x5c\/%\*&#]+? [\w\"\.\-\x5c\/%\*&#]+
+SELECT [\w\"\.\-\x5c\/%\*&#]+
+STORE [0-9,:\*]+? [+-]?FLAGS(?:\.SILENT)? (?:\(\x5c[A-Za-z]{1,20}\)){0,100}
+SUBSCRIBE [\w\"\.\-\x5c\/%\*&#]+
+UNSUBSCRIBE [\w\"\.\-\x5c\/%\*&#]+
+##! Search has plenty of variants
+SEARCH(?: CHARSET [\w\-_\.]{1,40})? (KEYWORD \x5c)?(?:ALL|ANSWERED|BCC|DELETED|DRAFT|FLAGGED|RECENT|SEEN|UNANSWERED|UNDELETED|UNDRAFT|UNFLAGGED|UNSEEN|NEW|OLD)
+SEARCH(?: CHARSET [\w\-_\.]{1,40})? (?:BODY|CC|FROM) .{1,255}
+SEARCH(?: CHARSET [\w\-_\.]{1,40})? HEADER .{1,100} .{1,255}
+SEARCH(?: CHARSET [\w\-_\.]{1,40})? (?:LARGER \d{1,20}|NOT .{1,255}|[0-9,:\*]+)
+SEARCH(?: CHARSET [\w\-_\.]{1,40})? (?:BEFORE|ON|SENTBEFORE|SENTON|SENTSINCE|SINCE) \"?\d{1,2}-\w{3}-\d{4}\"?
+SEARCH(?: CHARSET [\w\-_\.]{1,40})? (?:OR .{1,255} .{1,255}|SMALLER \d{1,20}|SUBJECT .{1,255})
+SEARCH(?: CHARSET [\w\-_\.]{1,40})? (?:TEXT .{1,255}|TO .{1,255}|UID [0-9,:\*]+?|UNKEYWORD (?:\x5c(Seen|Answered|Flagged|Deleted|Draft|Recent)))
+
+##! - IMAP4rev1 Commands - without params
+CAPABILITY
+CHECK
+CLOSE
+EXPUNGE
+LOGOUT
+NOOP
+STARTTLS
+UNAUTHENTICATE
+
+##! Not covered -  X<atom> Command (client extensions)

--- a/util/regexp-assemble/data/932320.data
+++ b/util/regexp-assemble/data/932320.data
@@ -1,0 +1,32 @@
+##! This is a data file used to generate a regular expression for a CRS rule. 
+##! The generation of the regular expression happens with the help of 
+##! util/regexp-assemble/regexp-assemble.py.
+##! The ID of the rule in question is part of the file name of this data file. 
+##! Read more about the format of this data file and the use of the assembly 
+##! script in util/regexp-assemble/README.md.
+##!
+##! Lines starting with `##!` are comments and will be skipped,
+##! empty lines will be ignored completely.
+##! 
+##! Five special comments are at your disposal to influence the assembled expression:
+##! - `##!+`: the flag comment
+##! - `##!^`: the prefix comment
+##! - `##!$`: the suffix comment
+##! - `##!>`: the preprocessor comment
+##! - `##!<`: the block preprocessor end comment
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
+
+##! POP3 Commands - PL2
+
+##!^ (?si)\r\n.*?\b
+
+##! POP3 Commands - with args
+LIST(?: \d+)?
+USER .+?
+PASS .+?
+RETR \d+?
+DELE \d+?
+UIDL(?: \d+)?
+APOP [\w]+ [a-f0-9]{32}
+TOP \d+(?: \d+)?
+AUTH [A-Z0-9-_]{1,20} (?:=|(?:[\w+/]{4})*(?:[\w+/]{2}==|[\w+/]{3}=))

--- a/util/regexp-assemble/data/932321.data
+++ b/util/regexp-assemble/data/932321.data
@@ -1,0 +1,28 @@
+##! This is a data file used to generate a regular expression for a CRS rule. 
+##! The generation of the regular expression happens with the help of 
+##! util/regexp-assemble/regexp-assemble.py.
+##! The ID of the rule in question is part of the file name of this data file. 
+##! Read more about the format of this data file and the use of the assembly 
+##! script in util/regexp-assemble/README.md.
+##!
+##! Lines starting with `##!` are comments and will be skipped,
+##! empty lines will be ignored completely.
+##! 
+##! Five special comments are at your disposal to influence the assembled expression:
+##! - `##!+`: the flag comment
+##! - `##!^`: the prefix comment
+##! - `##!$`: the suffix comment
+##! - `##!>`: the preprocessor comment
+##! - `##!<`: the block preprocessor end comment
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
+
+##!^ (?si)\r\n.*?\b
+
+##! POP3 Commands - PL3
+
+##! POP3 Commands - No args
+QUIT
+STAT
+NOOP
+RSET
+CAPA


### PR DESCRIPTION
These are two new rules for dealing with email related protocol remote commands (smtp/pop3/imap4).

- New rule 932300 tries to capture base commands that are different enough from common English words to prevent FP
- New rule 932310 is a stricter sibling in PL3 with all the remaining commands

Still to be defined to be considered for merging:
- the prefix/suffix for matching commands
- tests!