### PR TITLE
Fixing attack type of few rules

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -560,7 +560,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
@@ -646,7 +646,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     chain"
     SecRule MATCHED_VAR "@rx /" "t:none,t:urlDecodeUni,chain"
         SecRule MATCHED_VAR "@rx \s" "t:none,t:urlDecodeUni,\
-            setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
+            setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
             setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 


### PR DESCRIPTION
Rules 932180 and 932200 are catching RCE attacks but are adding score to LFI - this PR fixes it.

Fixes #2225.