### PR TITLE
Backslashes 932200

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -625,7 +625,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #
 # Regex notes: https://regex101.com/r/V6wrCO/1
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:[*?`\\'][^/\n]+/|\$[({\[#@!?*\-_$a-zA-Z0-9]|/[^/]+?[*?`\\\\'])" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:[*?`\x5c'][^/\n]+/|\$[({\[#@!?*\-_$a-zA-Z0-9]|/[^/]+?[*?`\x5c'])" \
     "id:932200,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932200.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932200.yaml
@@ -187,7 +187,7 @@
           log_contains: id "932200"
   -
     test_title: 932200-11
-    desc: "Test first backslash match ([*?`\x5c'][^/\n]+/) with: c\at /ec/passwd"
+    desc: "Test first backslash match ([*?`\x5c'][^/\n]+/) with: c\at /etc/passwd"
     stages:
     -
       stage:

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932200.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932200.yaml
@@ -185,3 +185,39 @@
           version: HTTP/1.0
         output:
           log_contains: id "932200"
+  -
+    test_title: 932200-11
+    desc: "Test first backslash match ([*?`\x5c'][^/\n]+/) with: cat /e\tc/passwd"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+          method: GET
+          port: 80
+          uri: /?host=www.google.com;cat%20%2Fe%5Ctc%2Fpasswd
+          version: HTTP/1.0
+        output:
+          log_contains: id "932200"
+  -
+    test_title: 932200-12
+    desc: "Test second backslash match (/[^/]+?[*?`\x5c']) with: cat /etc/p\asswd"
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: localhost
+            User-Agent: ModSecurity CRS 3 Tests
+          method: GET
+          port: 80
+          uri: /?host=www.google.com;cat%20%2Fetc%2Fp%5Casswd
+          version: HTTP/1.0
+        output:
+          log_contains: id "932200"

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932200.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932200.yaml
@@ -187,7 +187,7 @@
           log_contains: id "932200"
   -
     test_title: 932200-11
-    desc: "Test first backslash match ([*?`\x5c'][^/\n]+/) with: cat /e\tc/passwd"
+    desc: "Test first backslash match ([*?`\x5c'][^/\n]+/) with: c\at /ec/passwd"
     stages:
     -
       stage:
@@ -199,7 +199,7 @@
             User-Agent: ModSecurity CRS 3 Tests
           method: GET
           port: 80
-          uri: /?host=www.google.com;cat%20%2Fe%5Ctc%2Fpasswd
+          uri: /?host=www.google.com;c%5Cat%20%2Fetc%2Fpasswd
           version: HTTP/1.0
         output:
           log_contains: id "932200"


### PR DESCRIPTION
This PR moves rule 932200 to use \x5c backslash representation and adds two tests for it.