### PR TITLE
Adding sslvpn_websession into restricted files

### DIFF
--- a/rules/restricted-files.data
+++ b/rules/restricted-files.data
@@ -180,6 +180,8 @@ php_error.log
 php_errors.log
 # Java directory for non-pubic application data
 WEB-INF/
+# Fortinet SSL VPN session file
+sslvpn_websession
 # /proc entries (keep in sync with lfi-os-files.data)
 proc/0
 proc/1


### PR DESCRIPTION
Exploited in the wild, see CVE-2018-13379 .

`GET /remote/fgt_lang?lang=/../../../..//////////dev/cmdb/sslvpn_websession`