### PR TITLE
Backslashes 941170

### DIFF
--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -178,7 +178,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
 #
 # [NoScript InjectionChecker] Attributes injection
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:\W|^)(?:javascript:(?:[\s\S]+[=\\\(\[\.<]|[\s\S]*?(?:\bname\b|[\\\\][ux]\d))|data:(?:(?:[a-z]\w+/\w[\w+-]+\w)?[;,]|[\s\S]*?;[\s\S]*?\b(?:base64|charset=)|[\s\S]*?,[\s\S]*?<[\s\S]*?\w[\s\S]*?>))|@\W*?i\W*?m\W*?p\W*?o\W*?r\W*?t\W*?(?:/\*[\s\S]*?)?(?:[\"']|\W*?u\W*?r\W*?l[\s\S]*?\()|[^-]*?-\W*?m\W*?o\W*?z\W*?-\W*?b\W*?i\W*?n\W*?d\W*?i\W*?n\W*?g[^:]*?:\W*?u\W*?r\W*?l[\s\S]*?\(" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:\W|^)(?:javascript:(?:[\s\S]+[=\x5c\(\[\.<]|[\s\S]*?(?:\bname\b|\x5c[ux]\d))|data:(?:(?:[a-z]\w+/\w[\w+-]+\w)?[;,]|[\s\S]*?;[\s\S]*?\b(?:base64|charset=)|[\s\S]*?,[\s\S]*?<[\s\S]*?\w[\s\S]*?>))|@\W*?i\W*?m\W*?p\W*?o\W*?r\W*?t\W*?(?:/\*[\s\S]*?)?(?:[\"']|\W*?u\W*?r\W*?l[\s\S]*?\()|[^-]*?-\W*?m\W*?o\W*?z\W*?-\W*?b\W*?i\W*?n\W*?d\W*?i\W*?n\W*?g[^:]*?:\W*?u\W*?r\W*?l[\s\S]*?\(" \
     "id:941170,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941170.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941170.yaml
@@ -42,7 +42,7 @@
           log_contains: id "941170"
   -
     test_title: 941170-3
-    desc: Test first backslash match (javascript:(?:[\s\S]+[=\x5c\(\[\.<]) with: javascript: \t
+    desc: 'Test first backslash match (javascript:(?:[\s\S]+[=\x5c\(\[\.<]) with: javascript: \t'
     stages:
     -
       stage:
@@ -59,7 +59,7 @@
           log_contains: id "941170"
   -
     test_title: 941170-4
-    desc: Test second backslash match (javascript:(?:...|\x5c[ux]\d)) with: javascript:\u0020
+    desc: 'Test second backslash match (javascript:(?:...|\x5c[ux]\d)) with: javascript:\u0020'
     stages:
     -
       stage:

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941170.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941170.yaml
@@ -42,7 +42,7 @@
           log_contains: id "941170"
   -
     test_title: 941170-3
-    desc: 'Test first backslash match (javascript:(?:[\s\S]+[=\x5c\(\[\.<]) with: javascript: \t'
+    desc: 'Test first backslash match (javascript:(?:[\s\S]+[=\x5c\(\[\.<]) with: javascript: \\\\t (extra backslashes to work around rule transformations)'
     stages:
     -
       stage:
@@ -50,7 +50,7 @@
           dest_addr: 127.0.0.1
           method: GET
           port: 80
-          uri: '/?var=javascript:%20%5Ct'
+          uri: '/?var=javascript:%20%5C%5C%5C%5Ct'
           headers:
             Accept: "*/*"
             User-Agent: ModSecurity CRS 3 Tests
@@ -59,7 +59,7 @@
           log_contains: id "941170"
   -
     test_title: 941170-4
-    desc: 'Test second backslash match (javascript:(?:...|\x5c[ux]\d)) with: javascript:\u0020'
+    desc: 'Test second backslash match (javascript:(?:...|\x5c[ux]\d)) with: javascript:\\\\u0020 (extra backslashes to work around rule transformations)'
     stages:
     -
       stage:
@@ -67,7 +67,7 @@
           dest_addr: 127.0.0.1
           method: GET
           port: 80
-          uri: '/?var=javascript:%5Cu0020'
+          uri: '/?var=javascript:%5C%5C%5C%5Cu0020'
           headers:
             Accept: "*/*"
             User-Agent: ModSecurity CRS 3 Tests

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941170.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941170.yaml
@@ -40,3 +40,37 @@
           data: "payload=javascript:/*--></title></style></textarea></script></xmp><svg/onload='+/\"/+/onmouseover=1/+/[*/[]/+alert(1)//'></a>"
         output:
           log_contains: id "941170"
+  -
+    test_title: 941170-3
+    desc: Test first backslash match (javascript:(?:[\s\S]+[=\x5c\(\[\.<]) with: javascript: \t
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          method: GET
+          port: 80
+          uri: '/?var=javascript:%20%5Ct'
+          headers:
+            Accept: "*/*"
+            User-Agent: ModSecurity CRS 3 Tests
+            Host: localhost
+        output:
+          log_contains: id "941170"
+  -
+    test_title: 941170-4
+    desc: Test second backslash match (javascript:(?:...|\x5c[ux]\d)) with: javascript:\u0020
+    stages:
+    -
+      stage:
+        input:
+          dest_addr: 127.0.0.1
+          method: GET
+          port: 80
+          uri: '/?var=javascript:%5Cu0020'
+          headers:
+            Accept: "*/*"
+            User-Agent: ModSecurity CRS 3 Tests
+            Host: localhost
+        output:
+          log_contains: id "941170"

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941170.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941170.yaml
@@ -17,6 +17,7 @@
           port: 80
           uri: '/char_test?mime=text/xml&body=%3Cx:script%20xmlns:x=%22http://www.w3.org/1999/xhtml%22%20src=%22data:,alert(1)%22%20/%3E'
           headers:
+            Accept: "*/*"
             User-Agent: ModSecurity CRS 3 Tests
             Host: localhost
         output:
@@ -32,6 +33,7 @@
           method: POST
           port: 80
           headers:
+            Accept: "*/*"
             User-Agent: ModSecurity CRS 3 Tests
             Host: localhost
           uri: '/'


### PR DESCRIPTION
This PR moves rule 941170 to use \x5c backslash representation and adds two tests for it.

As a bonus, the two existing tests for rule 941170 get Accept headers added (so that they no longer trigger rule 920300, "Request Missing an Accept Header").