### PR TITLE
Another PMA FP

### DIFF
--- a/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9008-PHPMYADMIN-EXCLUSION-RULES.conf
@@ -72,13 +72,13 @@ SecRule REQUEST_FILENAME "@endsWith /tbl_replace.php" \
         ctl:ruleRemoveTargetById=933120;ARGS,\
         ctl:ruleRemoveTargetById=933130;ARGS,\
         ctl:ruleRemoveTargetById=933160;ARGS,\
+        ctl:ruleRemoveTargetById=934100;ARGS,\
         ctl:ruleRemoveTargetById=942100;ARGS,\
         ctl:ruleRemoveTargetById=942170;ARGS,\
         ctl:ruleRemoveTargetById=942190;ARGS,\
         ctl:ruleRemoveTargetById=930100;ARGS:fields[multi_edit][0][],\
         ctl:ruleRemoveTargetById=930110;ARGS:fields[multi_edit][0][],\
-        ctl:ruleRemoveTargetById=933210;ARGS:fields[multi_edit][0][],\
-        ctl:ruleRemoveTargetById=934100;ARGS:fields[multi_edit][0][]"
+        ctl:ruleRemoveTargetById=933210;ARGS:fields[multi_edit][0][]"
 
 # Downloading row data
 SecRule REQUEST_FILENAME "@endsWith /tbl_get_field.php" \


### PR DESCRIPTION
Fixing FP in phpMyAdmin exclusions. Adding exclusion for whole `ARGS` as affected fields looks like this:
```
ARGS:fields_prev[multi_edit][0][2063c1608d6e0baf80249c42e2be5804]
ARGS:fields[multi_edit][0][2063c1608d6e0baf80249c42e2be5804]
```