### PR TITLE
re2: use compatible syntax in rule 953120

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,8 @@ jobs:
                 REQUEST-941-APPLICATION-ATTACK-XSS,
                 REQUEST-942-APPLICATION-ATTACK-SQLI,
                 REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION,
-                REQUEST-944-APPLICATION-ATTACK-JAVA]
+                REQUEST-944-APPLICATION-ATTACK-JAVA,
+                RESPONSE-953-DATA-LEAKAGES-PHP]
         # Will include soon for modsec3-nginx
 
     steps:

--- a/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -72,16 +72,13 @@ SecRule RESPONSE_BODY "@rx (?:\b(?:f(?:tp_(?:nb_)?f?(?:ge|pu)t|get(?:s?s|c)|scan
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
-# Detect the presence of the PHP open tag "<?" or "<?php" in output.
+# Detect the presence of the PHP open tag "<? ", "<?= " or "<?php " in output.
 #
-# To prevent false positives due to the short "<?" sequence, an attempt
-# is made to stop alerts in binary output. This is done by detecting
-# some common binary file format headers, such as gzip (\x1f\x8b\x08),
-# png (IHDR), mp3 (ID3), movie formats et cetera.
+# To prevent false positives (due to the short "<?" sequences), we also include,
+# the space after it in an attempt to stop alerts in binary output.
 #
-# Not supported by re2 (?!re).
 #
-SecRule RESPONSE_BODY "@rx <\?(?!xml)" \
+SecRule RESPONSE_BODY "@rx <\?(?:=|php)?\s+" \
     "id:953120,\
     phase:4,\
     block,\
@@ -100,12 +97,8 @@ SecRule RESPONSE_BODY "@rx <\?(?!xml)" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ERROR',\
-    chain"
-    SecRule RESPONSE_BODY "!@rx (?:\x1f\x8b\x08|\b(?:(?:i(?:nterplay|hdr|d3)|m(?:ovi|thd)|r(?:ar!|iff)|(?:ex|jf)if|f(?:lv|ws)|varg|cws)\b|gif)|B(?:%pdf|\.ra)\b|^wOF[F2])" \
-        "capture,\
-        t:none,\
-        setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:953013,phase:3,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"

--- a/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953120.yaml
+++ b/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953120.yaml
@@ -1,0 +1,133 @@
+---
+meta:
+  author: "fzipi"
+  enabled: true
+  name: "953120.yaml"
+  description: "Positive tests for rule 953120"
+tests:
+  - test_title: 953120-0
+    desc: "Just something that returns <?php "
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Accept-Charset: "ISO-8859-1,utf-8;q=0.7,*;q=0.7"
+              Accept-Encoding: "gzip,deflate"
+              Accept-Language: "en-us,en;q=0.5"
+              Content-Type: "text/plain"
+            method: "GET"
+            version: "HTTP/1.0"
+            uri: "/anything"
+            data: <?php echo "Hello World!\n" ?>
+          output:
+            log_contains: "id \"953120\""
+  - test_title: 953120-1
+    desc: "Negative test, returns <?php12345, should not match"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Accept-Charset: "ISO-8859-1,utf-8;q=0.7,*;q=0.7"
+              Accept-Encoding: "gzip,deflate"
+              Accept-Language: "en-us,en;q=0.5"
+              Content-Type: "text/plain"
+            method: "GET"
+            version: "HTTP/1.0"
+            uri: "/anything"
+            data: <?php12345
+          output:
+            no_log_contains: "id \"953120\""
+  - test_title: 953120-2
+    desc: "Positive test, returns <? "
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Accept-Charset: "ISO-8859-1,utf-8;q=0.7,*;q=0.7"
+              Accept-Encoding: "gzip,deflate"
+              Accept-Language: "en-us,en;q=0.5"
+              Content-Type: "text/plain"
+            method: "GET"
+            version: "HTTP/1.0"
+            uri: "/anything"
+            data: "<? "
+          output:
+            log_contains: "id \"953120\""
+  - test_title: 953120-3
+    desc: "Negative test, returns <?1234"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Accept-Charset: "ISO-8859-1,utf-8;q=0.7,*;q=0.7"
+              Accept-Encoding: "gzip,deflate"
+              Accept-Language: "en-us,en;q=0.5"
+              Content-Type: "text/plain"
+            method: "GET"
+            version: "HTTP/1.0"
+            uri: "/anything"
+            data: <?1234
+          output:
+            no_log_contains: "id \"953120\""
+  - test_title: 953120-4
+    desc: "Positive test, returns <?= "
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Accept-Charset: "ISO-8859-1,utf-8;q=0.7,*;q=0.7"
+              Accept-Encoding: "gzip,deflate"
+              Accept-Language: "en-us,en;q=0.5"
+              Content-Type: "text/plain"
+            method: "GET"
+            version: "HTTP/1.0"
+            uri: "/anything"
+            data: <?= "Hello World!\n" =?>
+          output:
+            log_contains: "id \"953120\""
+  - test_title: 953120-5
+    desc: "Negative test, returns <?=!@#$%^&"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: "ModSecurity CRS 3 Tests"
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Accept-Charset: "ISO-8859-1,utf-8;q=0.7,*;q=0.7"
+              Accept-Encoding: "gzip,deflate"
+              Accept-Language: "en-us,en;q=0.5"
+              Content-Type: "text/plain"
+            method: "GET"
+            version: "HTTP/1.0"
+            uri: "/anything"
+            data: <?=!@#$%^&
+          output:
+            no_log_contains: "id \"953120\""


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Remove pcre2 only syntax.

Fixes #2354 