### PR TITLE
Add new rules 920520 and 920521 to check for valid accept-encoding

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1160,6 +1160,31 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
     chain"
     SecRule TX:/^header_name_/ "@within %{tx.restricted_headers}" \
         "setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+#
+# Rule against CVE-2022-21907
+# This rule blocks Accept-Encoding headers larger than 50 characters
+#
+# This rule has a stricter sibling: 920521
+#
+SecRule REQUEST_HEADERS:Accept-Encoding "@gt 50" \
+    "id:920520,\
+    phase:1,\
+    block,\
+    t:none,t:lowercase,t:length\
+    msg:'Too large Accept-Encoding header',\
+    logdata:'%{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/255/153',\
+    tag:'PCI/12.1',\
+    ver:'OWASP_CRS/3.4.0-dev',\
+    severity:'CRITICAL',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:920013,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:920014,phase:2,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
@@ -1502,6 +1527,35 @@ SecRule &REQUEST_HEADERS:Cache-Control "@gt 0" \
     SecRule REQUEST_HEADERS:Cache-Control "!@rx ^(?:(?:max-age=[0-9]+|min-fresh=[0-9]+|no-cache|no-store|no-transform|only-if-cached|max-stale(?:=[0-9]+)?)(?:\s*\,\s*|$)){1,7}$" \
         "setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
+#
+# Rule against CVE-2022-21907
+# This rule checks for valid and not too large Accept-Encoding headers
+#
+# This rule has a less strict sibling: 920520
+# 
+# Regexp generated from util/regexp-assemble/data/920521.data using Regexp::Assemble.
+# To rebuild the regexp:
+#   cd util/regexp-assemble
+#   ./regexp-assemble.py 920521
+#
+SecRule REQUEST_HEADERS:Accept-Encoding "!@rx (?:x-(?:compress|gzip)|(?:pack200-)?gzip|aes128gcm|compress|identity|deflate|zstd|exi|^$|br|\*)" \
+    "id:920521,\
+    phase:1,\
+    block,\
+    t:none,t:lowercase,\
+    msg:'Illegal large Accept-Encoding header',\
+    logdata:'%{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    tag:'paranoia-level/3',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/255/153',\
+    tag:'PCI/12.1',\
+    ver:'OWASP_CRS/3.4.0-dev',\
+    severity:'CRITICAL',\
+    setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:920017,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:920018,phase:2,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1171,7 +1171,7 @@ SecRule REQUEST_HEADERS:Accept-Encoding "@gt 50" \
     phase:1,\
     block,\
     t:none,t:lowercase,t:length,\
-    msg:'Too large Accept-Encoding header',\
+    msg:'Accept-Encoding header exceeded sensible length',\
     logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1170,7 +1170,7 @@ SecRule REQUEST_HEADERS:Accept-Encoding "@gt 50" \
     "id:920520,\
     phase:1,\
     block,\
-    t:none,t:lowercase,t:length\
+    t:none,t:lowercase,t:length,\
     msg:'Too large Accept-Encoding header',\
     logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
@@ -1528,8 +1528,7 @@ SecRule &REQUEST_HEADERS:Cache-Control "@gt 0" \
         "setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 #
-# Rule against CVE-2022-21907
-# This rule checks for valid and not too large Accept-Encoding headers
+# This rule checks for valid Accept-Encoding headers
 #
 # This rule has a less strict sibling: 920520
 # 
@@ -1543,7 +1542,7 @@ SecRule REQUEST_HEADERS:Accept-Encoding "!@rx (?:x-(?:compress|gzip)|(?:pack200-
     phase:1,\
     block,\
     t:none,t:lowercase,\
-    msg:'Illegal large Accept-Encoding header',\
+    msg:'Illegal Accept-Encoding header',\
     logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920520.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920520.yaml
@@ -17,6 +17,7 @@
               port: 80
               headers:
                   User-Agent: "ModSecurity CRS 3 Tests"
+                  Accept: "*/*"
                   Host: "localhost"
                   Accept-Encoding: "gzip, deflate, br"
               protocol: "http"
@@ -36,6 +37,7 @@
               port: 80
               headers:
                   User-Agent: "ModSecurity CRS 3 Tests"
+                  Accept: "*/*"
                   Host: "localhost"
                   Accept-Encoding: "gzip,deflate,identity"
               protocol: "http"
@@ -55,6 +57,7 @@
               port: 80
               headers:
                   User-Agent: "ModSecurity CRS 3 Tests"
+                  Accept: "*/*"
                   Host: "localhost"
                   Accept-Encoding: "compress;q=0.5, gzip;q=1.0"
               protocol: "http"
@@ -74,6 +77,7 @@
               port: 80
               headers:
                   User-Agent: "ModSecurity CRS 3 Tests"
+                  Accept: "*/*"
                   Host: "localhost"
                   Accept-Encoding: "gzip;q=1.0, identity; q=0.5, *;q=0"
               protocol: "http"
@@ -93,6 +97,7 @@
               port: 80
               headers:
                   User-Agent: "ModSecurity CRS 3 Tests"
+                  Accept: "*/*"
                   Host: "localhost"
                   Accept-Encoding: "gzip;q=1.0, identity; q=0.5, *;q=0"
               protocol: "http"
@@ -112,6 +117,7 @@
               port: 80
               headers:
                   User-Agent: "ModSecurity CRS 3 Tests"
+                  Accept: "*/*"
                   Host: "localhost"
                   Accept-Encoding: ""
               protocol: "http"
@@ -131,6 +137,7 @@
               port: 80
               headers:
                   User-Agent: "ModSecurity CRS 3 Tests"
+                  Accept: "*/*"
                   Host: "localhost"
                   Accept-Encoding: "AAAAAAAAAAAAAAAAAAAAAAAA,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&AA&**AAAAAAAAAAAAAAAAAAAA**A,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,AAAAAAAAAAAAAAAAAAAAAAAAAAA,****************************AAAAAA, *, ,"
               protocol: "http"

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920520.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920520.yaml
@@ -1,0 +1,140 @@
+---
+  meta:
+    author: "Franziska Bühler"
+    enabled: true
+    name: "920520.yaml"
+    description: "Testing for allowed and forbidden Accept-Encoding"
+  tests:
+    -
+      test_title: 920520-1
+      desc: "Allowed Accept-Encoding: gzip, deflate, br"
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              method: "GET"
+              port: 80
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Accept-Encoding: "gzip, deflate, br"
+              protocol: "http"
+              uri: "/"
+              version: "HTTP/1.1"
+            output:
+              no_log_contains: "id \"920520\""
+    -
+      test_title: 920520-2
+      desc: "Allowed Accept-Encoding: gzip,deflate,identity"
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              method: "GET"
+              port: 80
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Accept-Encoding: "gzip,deflate,identity"
+              protocol: "http"
+              uri: "/"
+              version: "HTTP/1.1"
+            output:
+              no_log_contains: "id \"920520\""
+    -
+      test_title: 920520-3
+      desc: "Allowed Accept-Encoding: compress;q=0.5, gzip;q=1.0"
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              method: "GET"
+              port: 80
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Accept-Encoding: "compress;q=0.5, gzip;q=1.0"
+              protocol: "http"
+              uri: "/"
+              version: "HTTP/1.1"
+            output:
+              no_log_contains: "id \"920520\""
+    -
+      test_title: 920520-4
+      desc: "Allowed Accept-Encoding: gzip;q=1.0, identity; q=0.5, *;q=0"
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              method: "GET"
+              port: 80
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Accept-Encoding: "gzip;q=1.0, identity; q=0.5, *;q=0"
+              protocol: "http"
+              uri: "/"
+              version: "HTTP/1.1"
+            output:
+              no_log_contains: "id \"920520\""
+    -
+      test_title: 920520-5
+      desc: "Allowed Accept-Encoding: gzip;q=1.0, identity; q=0.5, *;q=0"
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              method: "GET"
+              port: 80
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Accept-Encoding: "gzip;q=1.0, identity; q=0.5, *;q=0"
+              protocol: "http"
+              uri: "/"
+              version: "HTTP/1.1"
+            output:
+              no_log_contains: "id \"920520\""
+    -
+      test_title: 920520-6
+      desc: "Allowed empty Accept-Encoding"
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              method: "GET"
+              port: 80
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Accept-Encoding: ""
+              protocol: "http"
+              uri: "/"
+              version: "HTTP/1.1"
+            output:
+              no_log_contains: "id \"920520\""
+    -
+      test_title: 920520-7
+      desc: "Not allowed Accept-Encoding CVE-2022-21907"
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              method: "GET"
+              port: 80
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Host: "localhost"
+                  Accept-Encoding: "AAAAAAAAAAAAAAAAAAAAAAAA,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&AA&**AAAAAAAAAAAAAAAAAAAA**A,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,AAAAAAAAAAAAAAAAAAAAAAAAAAA,****************************AAAAAA, *, ,"
+              protocol: "http"
+              uri: "/"
+              version: "HTTP/1.1"
+            output:
+              log_contains: "id \"920520\""

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920521.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920521.yaml
@@ -1,0 +1,147 @@
+---
+  meta:
+    author: "Franziska Bühler"
+    enabled: true
+    name: "920521.yaml"
+    description: "Testing for allowed and forbidden Accept-Encoding"
+  tests:
+    -
+      test_title: 920521-1
+      desc: "Allowed Accept-Encoding: gzip, deflate, br"
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              method: "GET"
+              port: 80
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Accept: "*/*"
+                  Host: "localhost"
+                  Accept-Encoding: "gzip, deflate, br"
+              protocol: "http"
+              uri: "/"
+              version: "HTTP/1.1"
+            output:
+              no_log_contains: "id \"920521\""
+    -
+      test_title: 920521-2
+      desc: "Allowed Accept-Encoding: gzip,deflate,identity"
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              method: "GET"
+              port: 80
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Accept: "*/*"
+                  Host: "localhost"
+                  Accept-Encoding: "gzip,deflate,identity"
+              protocol: "http"
+              uri: "/"
+              version: "HTTP/1.1"
+            output:
+              no_log_contains: "id \"920521\""
+    -
+      test_title: 920521-3
+      desc: "Allowed Accept-Encoding: compress;q=0.5, gzip;q=1.0"
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              method: "GET"
+              port: 80
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Accept: "*/*"
+                  Host: "localhost"
+                  Accept-Encoding: "compress;q=0.5, gzip;q=1.0"
+              protocol: "http"
+              uri: "/"
+              version: "HTTP/1.1"
+            output:
+              no_log_contains: "id \"920521\""
+    -
+      test_title: 920521-4
+      desc: "Allowed Accept-Encoding: gzip;q=1.0, identity; q=0.5, *;q=0"
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              method: "GET"
+              port: 80
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Accept: "*/*"
+                  Host: "localhost"
+                  Accept-Encoding: "gzip;q=1.0, identity; q=0.5, *;q=0"
+              protocol: "http"
+              uri: "/"
+              version: "HTTP/1.1"
+            output:
+              no_log_contains: "id \"920521\""
+    -
+      test_title: 920521-5
+      desc: "Allowed Accept-Encoding: gzip;q=1.0, identity; q=0.5, *;q=0"
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              method: "GET"
+              port: 80
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Accept: "*/*"
+                  Host: "localhost"
+                  Accept-Encoding: "gzip;q=1.0, identity; q=0.5, *;q=0"
+              protocol: "http"
+              uri: "/"
+              version: "HTTP/1.1"
+            output:
+              no_log_contains: "id \"920521\""
+    -
+      test_title: 920521-6
+      desc: "Allowed empty Accept-Encoding"
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              method: "GET"
+              port: 80
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Accept: "*/*"
+                  Host: "localhost"
+                  Accept-Encoding: ""
+              protocol: "http"
+              uri: "/"
+              version: "HTTP/1.1"
+            output:
+              no_log_contains: "id \"920521\""
+    -
+      test_title: 920521-7
+      desc: "Not allowed Accept-Encoding: foobar"
+      stages:
+        -
+          stage:
+            input:
+              dest_addr: "127.0.0.1"
+              method: "GET"
+              port: 80
+              headers:
+                  User-Agent: "ModSecurity CRS 3 Tests"
+                  Accept: "*/*"
+                  Host: "localhost"
+                  Accept-Encoding: "foobar"
+              protocol: "http"
+              uri: "/"
+              version: "HTTP/1.1"
+            output:
+              log_contains: "id \"920521\""

--- a/util/regexp-assemble/data/920521.data
+++ b/util/regexp-assemble/data/920521.data
@@ -1,0 +1,39 @@
+##! This is a data file used to generate a regular expression for a CRS rule. 
+##! The generation of the regular expression happens with the help of 
+##! util/regexp-assemble/regexp-assemble.py.
+##! The ID of the rule in question is part of the file name of this data file. 
+##! Read more about the format of this data file and the use of the assembly 
+##! script in util/regexp-assemble/README.md.
+##!
+##! Lines starting with `##!` are comments and will be skipped,
+##! empty lines will be ignored completely.
+##! In addition, the quote character `'` at the beginning of a line will
+##! cause the line to be interpreted as literal by the cmdline preprocessor only.
+##! 
+##! Five special comments are at your disposal to influence the assembled expression:
+##! - `##!+`: the flag comment
+##! - `##!^`: the prefix comment
+##! - `##!$`: the suffix comment
+##! - `##!>`: the preprocessor comment
+##! - `##!<`: the block preprocessor end comment
+##!
+##! Currently supported preoprocessors:
+##! - cmdline [windows|unix] (file scope)
+##! - neglook (block scope)
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
+
+##! Current Accept-Encoding headers
+br
+compress
+deflate
+gzip
+identity
+\*
+^$
+##! Deprecated Accept-Encoding headers
+aes128gcm
+exi
+pack200-gzip
+zstd
+x-compress
+x-gzip


### PR DESCRIPTION
This PR adds two new rules that checks for valid Accept-Encoding request headers.

- Rule 920520 at PL1 only checks for length not greater than 50 characters.
- Rule 920521 at PL3 checks for valid known Accept-Encoding headers.

The PR also adds tests.

We first wanted to check for length in PL3 rule as well, but I think this does not make sense because we already check in rule 920520 at PL1.

Only rule at PL1 920520 blocks CVE-2022-21907. Rule 920521 does not, because `*` is allowed inside the header.

Sources: 
https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
https://www.iana.org/assignments/http-parameters/http-parameters.xml#http-parameters-1
https://github.com/antx-code/CVE-2022-21907

Feedback welcome.