### PR TITLE
REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example: fix old url link

### DIFF
--- a/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example
+++ b/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example
@@ -82,7 +82,7 @@
 # This ruleset allows you to control how ModSecurity will handle traffic
 # originating from Authorized Vulnerability Scanning (AVS) sources.  See
 # related blog post -
-# http://blog.spiderlabs.com/2010/12/advanced-topic-of-the-week-handling-authorized-scanning-traffic.html
+# https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/updated-advanced-topic-of-the-week-handling-authorized-scanning-traffic/
 #
 # Allow List ASV network block (no blocking or logging of AVS traffic) Update
 # IP network block as appropriate for your AVS traffic


### PR DESCRIPTION
fix old url link from https://blog.spiderlab.com
to https://www.trustwave.com/