### PR TITLE
REQUEST-901-INITIALIZATION.conf: fix typo in crs config file name

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -12,7 +12,7 @@
 # This file REQUEST-901-INITIALIZATION.conf initializes the Core Rules
 # and performs preparatory actions. It also fixes errors and omissions
 # of variable definitions in the file crs-setup.conf.
-# The setup.conf can and should be edited by the user, this file
+# The crs-setup.conf can and should be edited by the user, this file
 # is part of the CRS installation and should not be altered.
 #
 
@@ -67,7 +67,7 @@ SecRule &TX:crs_setup_version "@eq 0" \
 # -=[ Default setup values ]=-
 #
 # Some constructs or individual rules will fail if certain parameters
-# are not set in the setup.conf file. The following rules will catch
+# are not set in the crs-setup.conf file. The following rules will catch
 # these cases and assign sane default values.
 #
 


### PR DESCRIPTION
Rename setup.conf to crs-setup.conf