### PR TITLE
Fixed end boundary string at the test body

### DIFF
--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932180.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932180.yaml
@@ -48,7 +48,7 @@ tests:
               ------WebKitFormBoundaryABCDEFGIJKLMNOPQ
 
               BINARYDATA
-              --0000--
+              ------WebKitFormBoundaryABCDEFGIJKLMNOPQ--
           output:
             log_contains: id "932180"
   - test_title: 932180-3


### PR DESCRIPTION
Looks like the test case [932180-2](https://github.com/coreruleset/coreruleset/blob/v3.4/dev/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932180.yaml#L51) has an invalid end boundary - this PR fixes it.