### PR TITLE
Backslashes 920460

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1660,7 +1660,7 @@ SecRule REQUEST_HEADERS:Sec-Fetch-User|REQUEST_HEADERS:Sec-CH-UA-Mobile "!@rx ^(
 # This rule is also triggered by the following exploit(s):
 # [ SAP CRM Java vulnerability CVE-2018-2380 - Exploit tested: https://www.exploit-db.com/exploits/44292 ]
 #
-SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@rx (?:^|[^\\\\])\\\\[cdeghijklmpqwxyz123456789]" \
+SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@rx (?:^|[^\x5c])\x5c[cdeghijklmpqwxyz123456789]" \
     "id:920460,\
     phase:2,\
     block,\


### PR DESCRIPTION
This PR moves rule 920460 to use the \x5c representation of the backslash character.

**Note:** The backslash patterns are already covered by tests 920460-1 to 920460-6, so no new tests are being submitted here.

This is part of ongoing issue https://github.com/coreruleset/coreruleset/issues/2332.