### PR TITLE
Backslashes 930110

### DIFF
--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -65,7 +65,7 @@ SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@r
 # - .../
 # - /...
 
-SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@rx (?:(?:^|[\\\\/])\.{2,3}[\\\\/]|[\\\\/]\.{2,3}(?:[\\\\/]|$))" \
+SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@rx (?:(?:^|[\x5c/])\.{2,3}[\x5c/]|[\x5c/]\.{2,3}(?:[\x5c/]|$))" \
     "id:930110,\
     phase:2,\
     block,\


### PR DESCRIPTION
This PR moves rule 930110 to use the \x5c representation of the backslash character.

**Note:** Backslash patterns are already tested by 930110-1 and 930110-8, so no new tests are being submitted here.

This is part of ongoing issue https://github.com/coreruleset/coreruleset/issues/2332.