### PR TITLE
Backslashes 954100

### DIFF
--- a/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+++ b/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
@@ -21,7 +21,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:954012,phase:4,pass,nolog,skipAf
 #
 
 # IIS default location
-SecRule RESPONSE_BODY "@rx [a-z]:\\\\inetpub\b" \
+SecRule RESPONSE_BODY "@rx [a-z]:\x5cinetpub\b" \
     "id:954100,\
     phase:4,\
     block,\

--- a/tests/regression/tests/RESPONSE-954-DATA-LEAKAGES-IIS/954100.yaml
+++ b/tests/regression/tests/RESPONSE-954-DATA-LEAKAGES-IIS/954100.yaml
@@ -1,0 +1,23 @@
+---
+meta:
+  author: "Andrew Howe"
+  enabled: true
+  name: "954100.yaml"
+  description: "Tests for rule 954100"
+tests:
+  - test_title: 954100-0
+    desc: "Returns C:\inetpub in the response body. Sends as Base64 encoded rather than using /anything to avoid the backslash being escaped in the response."
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+            method: "GET"
+            version: "HTTP/1.0"
+            uri: "/base64/QzpcaW5ldHB1YiAK"
+          output:
+            log_contains: "id \"954100\""

--- a/tests/regression/tests/RESPONSE-954-DATA-LEAKAGES-IIS/954100.yaml
+++ b/tests/regression/tests/RESPONSE-954-DATA-LEAKAGES-IIS/954100.yaml
@@ -6,7 +6,7 @@ meta:
   description: "Tests for rule 954100"
 tests:
   - test_title: 954100-0
-    desc: "Returns C:\inetpub in the response body. Sends as Base64 encoded rather than using /anything to avoid the backslash being escaped in the response."
+    desc: 'Returns C:\inetpub in the response body. Sends as Base64 encoded rather than using /anything to avoid the backslash being escaped in the response.'
     stages:
       - stage:
           input:


### PR DESCRIPTION
This PR moves rule 954100 to use the \x5c representation of the backslash character.

A new test is added for rule 954100. It sends a Base64 encoded payload (QzpcaW5ldHB1YiAK) which is `C:\inetpub `. This string is then returned in the response body, causing rule 954100 to match.

This is part of ongoing issue https://github.com/coreruleset/coreruleset/issues/2332.