### PR TITLE
docs: add editorconfig file to keep spacing in good shape

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.py]
+charset = utf-8
+# 4 space indentation
+indent_style = space
+indent_size = 4
+
+# Indentation override for all JS under lib directory
+[tests/regression/tests/**/*.yaml]
+indent_style = space
+indent_size = 2
+


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Adds editorconfig file to keep files with correct newline/whitespace.

See https://editorconfig.org/.