### PR TITLE
fix(913100): move ecairn to scanners from crawlers

### DIFF
--- a/rules/crawlers-user-agents.data
+++ b/rules/crawlers-user-agents.data
@@ -13,8 +13,6 @@ blackwidow
 # User-Agent: Censys: Mozilla/5.0 (compatible; CensysInspect/1.1; +https://about.censys.io/)
 CensysInspect
 # SEO
-# User-Agent: mozilla/5.0 ecairn-grabber/1.0 (+http://ecairn.com/grabber)
-ecairn-grabber
 # advertising targeting
 # https://www.grapeshot.com/crawler/
 grapeFX

--- a/rules/scanners-user-agents.data
+++ b/rules/scanners-user-agents.data
@@ -63,6 +63,8 @@ domino hunter
 # vuln scanner - directory traversal fuzzer
 # https://github.com/wireghoul/dotdotpwn
 dotdotpwn
+# User-Agent: mozilla/5.0 ecairn-grabber/1.0 (+http://ecairn.com/grabber)
+ecairn-grabber
 email extractor
 # vuln scanner
 fhscan core 1.


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

This one fixes #2397.