### PR TITLE
Detect prototype pollution

### DIFF
--- a/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
+++ b/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
@@ -196,7 +196,7 @@ SecRule ARGS "@rx (?i)(?:acap|bitcoin|blob|cap|cvs|svn|svn\+ssh|turn|udp|vnc|xmp
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \[\s*constructor\s*\]" \
-    "id:934140,\
+    "id:934131,\
     phase:2,\
     block,\
     capture,\

--- a/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
+++ b/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
@@ -104,6 +104,40 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
+# JavaScript prototype pollution injection attempts
+#
+# Example from https://hackerone.com/reports/869574 critical
+# vulnerability in the TypeORM library:
+# {"text":"a","title":{"__proto__":{"where":{"name":"sqlinjection","where":null}}}}
+# Test cases are based on this list of payloads:
+# https://github.com/BlackFan/client-side-prototype-pollution/blob/master/README.md
+# Note: only server-based (not DOM-based) attacks are covered here.
+# Stricter sibling: 934131
+
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:__proto__|constructor\s*(?:\.|\[)\s*prototype)" \
+    "id:934130,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:urlDecodeUni,t:base64Decode,\
+    msg:'JavaScript Prototype Pollution',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-javascript',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
+    tag:'attack-injection-generic',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/242',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.4.0-dev',\
+    severity:'CRITICAL',\
+    multiMatch,\
+    setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:934013,phase:1,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:934014,phase:2,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
 #
@@ -160,6 +194,29 @@ SecRule ARGS "@rx (?i)(?:acap|bitcoin|blob|cap|cvs|svn|svn\+ssh|turn|udp|vnc|xmp
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \[\s*constructor\s*\]" \
+    "id:934140,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:urlDecodeUni,t:base64Decode,\
+    msg:'JavaScript Prototype Pollution',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-javascript',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
+    tag:'attack-injection-generic',\
+    tag:'paranoia-level/2',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/242',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.4.0-dev',\
+    severity:'CRITICAL',\
+    multiMatch,\
+    setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:934015,phase:1,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"

--- a/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
+++ b/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
@@ -216,7 +216,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:934015,phase:1,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"

--- a/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
+++ b/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
@@ -109,8 +109,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
 # Example from https://hackerone.com/reports/869574 critical
 # vulnerability in the TypeORM library:
 # {"text":"a","title":{"__proto__":{"where":{"name":"sqlinjection","where":null}}}}
+#
 # Test cases are based on this list of payloads:
 # https://github.com/BlackFan/client-side-prototype-pollution/blob/master/README.md
+#
+# See also: https://cwe.mitre.org/data/definitions/1321.html
+#
 # Note: only server-based (not DOM-based) attacks are covered here.
 # Stricter sibling: 934131
 
@@ -129,7 +133,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'attack-injection-generic',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    tag:'capec/1000/152/242',\
+    tag:'capec/1/180/77',\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\

--- a/tests/regression/tests/REQUEST-934-APPLICATION-ATTACK-GENERIC/934130.yaml
+++ b/tests/regression/tests/REQUEST-934-APPLICATION-ATTACK-GENERIC/934130.yaml
@@ -1,0 +1,202 @@
+---
+meta:
+  author: "lifeforms"
+  enabled: true
+  name: "934130.yaml"
+  description: "Tests for rule 934130"
+tests:
+  - test_title: 934130-0
+    desc: negative test case
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "*/*"
+              Host: localhost
+              User-Agent: ModSecurity CRS 3 Tests
+            method: GET
+            port: 80
+            uri: /?foo=proto
+            version: HTTP/1.0
+          output:
+            no_log_contains: id "934130"
+  - test_title: 934130-1
+    desc: positive test case with JSON POST
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "*/*"
+              Host: localhost
+              User-Agent: ModSecurity CRS 3 Tests
+              Content-Type: application/json
+            method: POST
+            port: 80
+            uri: /?foo=__proto__
+            version: HTTP/1.0
+            data: |
+              {"text":"a","title":{"__proto__":{"where":{"name":"sqlinjection","where":null}}}}
+          output:
+            log_contains: id "934130"
+  - test_title: 934130-2
+    desc: positive test case, CVE-2021-20083
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "*/*"
+              Host: localhost
+              User-Agent: ModSecurity CRS 3 Tests
+            method: GET
+            port: 80
+            uri: "/?__proto__[test]=test"
+            version: HTTP/1.0
+          output:
+            log_contains: id "934130"
+  - test_title: 934130-3
+    desc: positive test case, CVE-2021-20084, 1/2
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "*/*"
+              Host: localhost
+              User-Agent: ModSecurity CRS 3 Tests
+            method: GET
+            port: 80
+            uri: "/?__proto__.test=test"
+            version: HTTP/1.0
+          output:
+            log_contains: id "934130"
+  - test_title: 934130-4
+    desc: positive test case, CVE-2021-20084, 2/2
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "*/*"
+              Host: localhost
+              User-Agent: ModSecurity CRS 3 Tests
+            method: GET
+            port: 80
+            uri: "/?constructor.prototype.test=test"
+            version: HTTP/1.0
+          output:
+            log_contains: id "934130"
+  - test_title: 934130-5
+    desc: positive test case with space evasion, CVE-2021-20084, 2/2
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "*/*"
+              Host: localhost
+              User-Agent: ModSecurity CRS 3 Tests
+            method: GET
+            port: 80
+            uri: "/?constructor.prototype.%20test=test"
+            version: HTTP/1.0
+          output:
+            log_contains: id "934130"
+  - test_title: 934130-6
+    desc: positive test case with GET parameter, jQuery $.get
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "*/*"
+              Host: localhost
+              User-Agent: ModSecurity CRS 3 Tests
+            method: GET
+            port: 80
+            uri: "/?__proto__[context]=<img/src/onerror%3dalert(1)>"
+            version: HTTP/1.0
+          output:
+            log_contains: id "934130"
+  - test_title: 934130-6
+    desc: positive test case with GET parameter, V4Fire Core Library
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "*/*"
+              Host: localhost
+              User-Agent: ModSecurity CRS 3 Tests
+            method: GET
+            port: 80
+            uri: "?__proto__%5Btest%5D%3D%7B%22json%22%3A%22value%22%7D"
+            version: HTTP/1.0
+          output:
+            log_contains: id "934130"
+  - test_title: 934130-7
+    desc: positive test case with GET parameter, CVE-2021-20089
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "*/*"
+              Host: localhost
+              User-Agent: ModSecurity CRS 3 Tests
+            method: GET
+            port: 80
+            uri: "?__proto__%5Btest%5D%3D%7B%22json%22%3A%22value%22%7D"
+            version: HTTP/1.0
+          output:
+            log_contains: id "934130"
+  - test_title: 934130-8
+    desc: positive test case with GET parameter, analytics-utils < 1.0.3
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "*/*"
+              Host: localhost
+              User-Agent: ModSecurity CRS 3 Tests
+            method: GET
+            port: 80
+            uri: "?constructor%5Bprototype%5D%5Btest%5D%3Dtest"
+            version: HTTP/1.0
+          output:
+            log_contains: id "934130"
+  - test_title: 934130-9
+    desc: positive test case with GET parameter, jQuery $.get
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "*/*"
+              Host: localhost
+              User-Agent: ModSecurity CRS 3 Tests
+            method: GET
+            port: 80
+            uri: "?__proto__[jquery]=x"
+            version: HTTP/1.0
+          output:
+            log_contains: id "934130"
+  - test_title: 934130-10
+    desc: positive test case with GET parameter, Vue.js
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "*/*"
+              Host: localhost
+              User-Agent: ModSecurity CRS 3 Tests
+            method: GET
+            port: 80
+            uri: "?__proto__%5Bv-bind%3Aclass%5D%3D%27%27.constructor.constructor%28%27alert%281%29%27%29%28%29"
+            version: HTTP/1.0
+          output:
+            log_contains: id "934130"

--- a/tests/regression/tests/REQUEST-934-APPLICATION-ATTACK-GENERIC/934130.yaml
+++ b/tests/regression/tests/REQUEST-934-APPLICATION-ATTACK-GENERIC/934130.yaml
@@ -34,7 +34,7 @@ tests:
               Content-Type: application/json
             method: POST
             port: 80
-            uri: /?foo=__proto__
+            uri: /
             version: HTTP/1.0
             data: |
               {"text":"a","title":{"__proto__":{"where":{"name":"sqlinjection","where":null}}}}

--- a/tests/regression/tests/REQUEST-934-APPLICATION-ATTACK-GENERIC/934131.yaml
+++ b/tests/regression/tests/REQUEST-934-APPLICATION-ATTACK-GENERIC/934131.yaml
@@ -2,10 +2,10 @@
 meta:
   author: "lifeforms"
   enabled: true
-  name: "934140.yaml"
-  description: "Tests for rule 934140"
+  name: "934131.yaml"
+  description: "Tests for rule 934131"
 tests:
-  - test_title: 934140-0
+  - test_title: 934131-0
     desc: negative test case
     stages:
       - stage:
@@ -20,8 +20,8 @@ tests:
             uri: "I really like a constructor"
             version: HTTP/1.0
           output:
-            no_log_contains: id "934140"
-  - test_title: 934140-1
+            no_log_contains: id "934131"
+  - test_title: 934131-1
     desc: positive test case with GET parameter, String.constructor
     stages:
       - stage:
@@ -36,4 +36,4 @@ tests:
             uri: "?x=x&x[constructor][__parseStyleElement][innerHTML]=<img/src/onerror%3dalert(1)>"
             version: HTTP/1.0
           output:
-            log_contains: id "934140"
+            log_contains: id "934131"

--- a/tests/regression/tests/REQUEST-934-APPLICATION-ATTACK-GENERIC/934140.yaml
+++ b/tests/regression/tests/REQUEST-934-APPLICATION-ATTACK-GENERIC/934140.yaml
@@ -1,0 +1,39 @@
+---
+meta:
+  author: "lifeforms"
+  enabled: true
+  name: "934140.yaml"
+  description: "Tests for rule 934140"
+tests:
+  - test_title: 934140-0
+    desc: negative test case
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "*/*"
+              Host: localhost
+              User-Agent: ModSecurity CRS 3 Tests
+            method: GET
+            port: 80
+            uri: "I really like a constructor"
+            version: HTTP/1.0
+          output:
+            no_log_contains: id "934140"
+  - test_title: 934140-1
+    desc: positive test case with GET parameter, String.constructor
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "*/*"
+              Host: localhost
+              User-Agent: ModSecurity CRS 3 Tests
+            method: GET
+            port: 80
+            uri: "?x=x&x[constructor][__parseStyleElement][innerHTML]=<img/src/onerror%3dalert(1)>"
+            version: HTTP/1.0
+          output:
+            log_contains: id "934140"


### PR DESCRIPTION
Prototype pollution is a way to create malicious Javascript objects, for instance by setting their special property `__proto__` or `prototype`. It can lead to RCE, SQL injection and more. These rules detect the server-based attacks (DOM-based attacks after the hash are not seen by the WAF). Some variants are covered and I attempted to prevent bypasses.

Rules added:
- 934130 (PL1) finds `__proto__`, `constructor.prototype`, `constructor[prototype]`
- 934131 (PL2) finds `[constructor]`

Inspiration for payloads came from: https://github.com/BlackFan/client-side-prototype-pollution/blob/master/README.md

Example vulnerable library: TypeORM https://www.cvedetails.com/cve/CVE-2020-8158

I closed my former PR as I messed it up in Git.