### PR TITLE
Renaming tx.blocking_early to tx.early_blocking

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -330,14 +330,14 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # evaluation, then blocking happens immediately (if blocking is enabled) and
 # the phase 2 (and phase 4 respectively) will no longer be executed.
 #
-# Enable the rule 900120 that sets the variable tx.blocking_early to 1 in order
-# to enable early blocking. The variable tx.blocking_early is set to 0 by
+# Enable the rule 900120 that sets the variable tx.early_blocking to 1 in order
+# to enable early blocking. The variable tx.early_blocking is set to 0 by
 # default. Early blocking is thus disabled by default.
 #
-# Please note that blocking early will hide potential alerts from you. This
+# Please note that early blocking will hide potential alerts from you. This
 # means that a payload that would appear in an alert in phase 2 (or phase 4)
 # does not get evaluated if the request is being blocked early. So when you
-# disabled blocking early again at some point in the future, then new alerts
+# disabled early blocking again at some point in the future, then new alerts
 # from phase 2 might pop up.
 #SecAction \
 #  "id:900120,\
@@ -345,7 +345,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  nolog,\
 #  pass,\
 #  t:none,\
-#  setvar:tx.blocking_early=1"
+#  setvar:tx.early_blocking=1"
 
 
 # -- [[ Application Specific Rule Exclusions ]] ----------------------------------------

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -89,14 +89,14 @@ SecRule &TX:outbound_anomaly_score_threshold "@eq 0" \
     ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.outbound_anomaly_score_threshold=4'"
 
-# Default Blocking Early (rule 900120 in crs-setup.conf)
-SecRule &TX:blocking_early "@eq 0" \
+# Default Early Blocking (rule 900120 in crs-setup.conf)
+SecRule &TX:early_blocking "@eq 0" \
     "id:901115,\
     phase:1,\
     pass,\
     nolog,\
     ver:'OWASP_CRS/3.4.0-dev',\
-    setvar:'tx.blocking_early=0'"
+    setvar:'tx.early_blocking=0'"
 
 # Default Paranoia Level (rule 900000 in crs-setup.conf)
 SecRule &TX:paranoia_level "@eq 0" \

--- a/rules/REQUEST-949-BLOCKING-EVALUATION.conf
+++ b/rules/REQUEST-949-BLOCKING-EVALUATION.conf
@@ -14,21 +14,21 @@
 
 # Skipping early blocking
 
-SecRule TX:BLOCKING_EARLY "!@eq 1" \
+SecRule TX:EARLY_BLOCKING "!@eq 1" \
     "id:949050,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
-    skipAfter:BLOCKING_EARLY_ANOMALY_SCORING"
+    skipAfter:EARLY_BLOCKING_ANOMALY_SCORING"
 
-SecRule TX:BLOCKING_EARLY "!@eq 1" \
+SecRule TX:EARLY_BLOCKING "!@eq 1" \
     "id:949051,\
     phase:2,\
     pass,\
     t:none,\
     nolog,\
-    skipAfter:BLOCKING_EARLY_ANOMALY_SCORING"
+    skipAfter:EARLY_BLOCKING_ANOMALY_SCORING"
 
 # Summing up the anomaly score for early blocking
 
@@ -71,7 +71,7 @@ SecAction "id:949059,\
     nolog,\
     setvar:'tx.anomaly_score=0'"
 
-SecMarker BLOCKING_EARLY_ANOMALY_SCORING
+SecMarker EARLY_BLOCKING_ANOMALY_SCORING
 
 # NOTE: tx.anomaly_score should not be set initially, but masking would lead to difficult bugs.
 # So we add to it.
@@ -150,7 +150,7 @@ SecRule TX:ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score=%{tx.anomaly_score}'"
 
-SecRule TX:BLOCKING_EARLY "@eq 1" \
+SecRule TX:EARLY_BLOCKING "@eq 1" \
     "id:949111,\
     phase:1,\
     deny,\

--- a/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
+++ b/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
@@ -25,21 +25,21 @@
 
 # Skipping early blocking
 
-SecRule TX:BLOCKING_EARLY "!@eq 1" \
+SecRule TX:EARLY_BLOCKING "!@eq 1" \
     "id:959050,\
     phase:3,\
     pass,\
     t:none,\
     nolog,\
-    skipAfter:BLOCKING_EARLY_ANOMALY_SCORING"
+    skipAfter:EARLY_BLOCKING_ANOMALY_SCORING"
 
-SecRule TX:BLOCKING_EARLY "!@eq 1" \
+SecRule TX:EARLY_BLOCKING "!@eq 1" \
     "id:959051,\
     phase:4,\
     pass,\
     t:none,\
     nolog,\
-    skipAfter:BLOCKING_EARLY_ANOMALY_SCORING"
+    skipAfter:EARLY_BLOCKING_ANOMALY_SCORING"
 
 # Summing up the anomaly score for early blocking
 
@@ -82,7 +82,7 @@ SecAction "id:959059,\
     nolog,\
     setvar:'tx.outbound_anomaly_score=0'"
 
-SecMarker BLOCKING_EARLY_ANOMALY_SCORING
+SecMarker EARLY_BLOCKING_ANOMALY_SCORING
 
 # NOTE: tx.anomaly_score should not be set initially, but masking would lead to difficult bugs.
 # So we add to it.
@@ -136,7 +136,7 @@ SecRule TX:OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
     ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.anomaly_score=+%{tx.outbound_anomaly_score}'"
 
-SecRule TX:BLOCKING_EARLY "@eq 1" \
+SecRule TX:EARLY_BLOCKING "@eq 1" \
     "id:959101,\
     phase:3,\
     deny,\


### PR DESCRIPTION
This var name is more in line with the documentation and the name of the feature "early blocking" that we use.