### PR TITLE
Refactor scoring variables

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,8 +132,8 @@ Please read file ```crs-setup.conf.example``` for an introduction and a more det
 
 The CRS project used the numerical id rule namespace from 900,000 to 999,999 for the CRS rules as well as 9,000,000 to 9,999,999 for default CRS rule exclusion packages.
 
-Rules applying to the incoming request use the id range 900,000 to 949,999.
-Rules applying to the outgoing response use the id range 950,000 to 999,999.
+Rules applying to the inbound request use the id range 900,000 to 949,999.
+Rules applying to the outbound response use the id range 950,000 to 999,999.
 
 The rules are grouped by vulnerability class they address (SQLi, RCE, etc.) or functionality (initialization). These groups occupy blocks of thousands (e.g. SQLi: 942,000 - 942,999).
 The grouped rules are defined in files dedicated to a single group or functionality. The filename takes up the first three digits of the rule ids defined within the file (e.g. SQLi: REQUEST-942-APPLICATION-ATTACK-SQLI.conf).

--- a/INSTALL
+++ b/INSTALL
@@ -216,8 +216,8 @@ OWASP CRS Configuration
     Alternative configuration modes are supported and explained
     in crs-setup.conf.
 
-    The default anomaly/correlation mode establishes an incoming
-    anomaly score threshold of 5 and an outgoing anomaly score
+    The default anomaly/correlation mode establishes an inbound
+    anomaly score threshold of 5 and an outbound anomaly score
     threshold of 4. The default installation has been tuned to
     reduce false positives in a way that will allow most requests
     to pass in this default setup.

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -180,7 +180,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #   nolog,\
 #   pass,\
 #   t:none,\
-#   setvar:tx.paranoia_level=1"
+#   setvar:tx.blocking_paranoia_level=1"
 
 
 # It is possible to execute rules from a higher paranoia level but not include
@@ -189,16 +189,16 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # the new rules would lead to false positives that raise your score above the
 # threshold.
 # This optional feature is enabled by uncommenting the following rule and
-# setting the tx.executing_paranoia_level.
-# Technically, rules up to the level defined in tx.executing_paranoia_level
-# will be executed, but only the rules up to tx.paranoia_level affect the
+# setting the tx.detection_paranoia_level.
+# Technically, rules up to the level defined in tx.detection_paranoia_level
+# will be executed, but only the rules up to tx.blocking_paranoia_level affect the
 # anomaly scores.
-# By default, tx.executing_paranoia_level is set to tx.paranoia_level.
-# tx.executing_paranoia_level must not be lower than tx.paranoia_level.
+# By default, tx.detection_paranoia_level is set to tx.blocking_paranoia_level.
+# tx.detection_paranoia_level must not be lower than tx.blocking_paranoia_level.
 #
-# Please notice that setting tx.executing_paranoia_level to a higher paranoia
+# Please notice that setting tx.detection_paranoia_level to a higher paranoia
 # level results in a performance impact that is equally high as setting
-# tx.paranoia_level to said level.
+# tx.blocking_paranoia_level to said level.
 #
 #SecAction \
 #  "id:900001,\
@@ -206,7 +206,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #   nolog,\
 #   pass,\
 #   t:none,\
-#   setvar:tx.executing_paranoia_level=1"
+#   setvar:tx.detection_paranoia_level=1"
 
 
 #

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -318,6 +318,30 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  setvar:tx.inbound_anomaly_score_threshold=5,\
 #  setvar:tx.outbound_anomaly_score_threshold=4"
 
+
+#
+# -- [[ Anomaly Score Reporting Level ]] ------------------------------
+#
+# By setting the reporting level, the verbosity of the reporting rules in
+# phase 5 can be configured. There are 4 reporting levels: 0, 1, 2, 3. The
+# higher the reporting level, the more verbose the reporting is. By setting the
+# reporting level to 0 reports in phase 5 are disabled completely.
+# 0 - No phase 5 reporting
+# 1 - Reporting for requests that were blocked
+# 2 - Reporting for requests that scored larger than 0
+# 3 - Reporting for all requests
+#
+# The default reporting level is 2.
+#
+#SecAction \
+# "id:900115,\
+#  phase:1,\
+#  nolog,\
+#  pass,\
+#  t:none,\
+#  setvar:tx.reporting_level=2"
+
+
 #
 # -- [[ Early Anomaly Scoring Mode Blocking ]] ------------------------------
 #

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -322,16 +322,27 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #
 # -- [[ Anomaly Score Reporting Level ]] ------------------------------
 #
-# By setting the reporting level, the verbosity of the reporting rules in
-# phase 5 can be configured. There are 4 reporting levels: 0, 1, 2, 3. The
-# higher the reporting level, the more verbose the reporting is. By setting the
-# reporting level to 0 reports in phase 5 are disabled completely.
-# 0 - No phase 5 reporting
-# 1 - Reporting for requests that were blocked
-# 2 - Reporting for requests that scored larger than 0
+# When a request is being blocked due to the anomaly score meeting
+# the anomaly threshold, then the blocking rule will also report the
+# anomaly score. This applies to the separate inbound and outbound
+# anomaly score.
+# In phase 5, there are additional rules that can perform additional
+# reporting of anomaly scores with a verbosity that depends on
+# the reporting level defined below.
+# By setting the reporting level you control whether you want additional
+# reporting beyond the blocking rule or not and if yes, which requests should
+# be covered.
+# There are 4 reporting levels: 0, 1, 2, 3.
+# The higher the reporting level, the more verbose the reporting is.
+#
+# 0 - Reporting disabled
+# 1 - Reporting for requests that were blocked due to anomaly score
+# 2 - Reporting for requests with an anomaly score larger than 0
 # 3 - Reporting for all requests
 #
-# The default reporting level is 2.
+# A value of 3 can be useful on platforms where you are interested
+# non-scoring requests, yet it is not possible to report this information in
+# the request / access log. This applies to NGINX for example.
 #
 #SecAction \
 # "id:900115,\

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -98,23 +98,23 @@ SecRule &TX:early_blocking "@eq 0" \
     ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.early_blocking=0'"
 
-# Default Paranoia Level (rule 900000 in crs-setup.conf)
-SecRule &TX:paranoia_level "@eq 0" \
+# Default Blocking Paranoia Level (rule 900000 in crs-setup.conf)
+SecRule &TX:BLOCKING_PARANOIA_LEVEL "@eq 0" \
     "id:901120,\
     phase:1,\
     pass,\
     nolog,\
     ver:'OWASP_CRS/3.4.0-dev',\
-    setvar:'tx.paranoia_level=1'"
+    setvar:'tx.blocking_paranoia_level=1'"
 
-# Default Executing Paranoia Level (rule 900000 in crs-setup.conf)
-SecRule &TX:executing_paranoia_level "@eq 0" \
+# Default Detection Paranoia Level (rule 900000 in crs-setup.conf)
+SecRule &TX:detection_paranoia_level "@eq 0" \
     "id:901125,\
     phase:1,\
     pass,\
     nolog,\
     ver:'OWASP_CRS/3.4.0-dev',\
-    setvar:'tx.executing_paranoia_level=%{TX.PARANOIA_LEVEL}'"
+    setvar:'tx.detection_paranoia_level=%{TX.blocking_paranoia_level}'"
 
 # Default Sampling Percentage (rule 900400 in crs-setup.conf)
 SecRule &TX:sampling_percentage "@eq 0" \
@@ -264,11 +264,12 @@ SecAction \
     t:none,\
     nolog,\
     ver:'OWASP_CRS/3.4.0-dev',\
-    setvar:'tx.anomaly_score=0',\
-    setvar:'tx.anomaly_score_pl1=0',\
-    setvar:'tx.anomaly_score_pl2=0',\
-    setvar:'tx.anomaly_score_pl3=0',\
-    setvar:'tx.anomaly_score_pl4=0',\
+    setvar:'tx.blocking_inbound_anomaly_score=0',\
+    setvar:'tx.detection_inbound_anomaly_score=0',\
+    setvar:'tx.inbound_anomaly_score_pl1=0',\
+    setvar:'tx.inbound_anomaly_score_pl2=0',\
+    setvar:'tx.inbound_anomaly_score_pl3=0',\
+    setvar:'tx.inbound_anomaly_score_pl4=0',\
     setvar:'tx.sql_injection_score=0',\
     setvar:'tx.xss_score=0',\
     setvar:'tx.rfi_score=0',\
@@ -277,8 +278,8 @@ SecAction \
     setvar:'tx.php_injection_score=0',\
     setvar:'tx.http_violation_score=0',\
     setvar:'tx.session_fixation_score=0',\
-    setvar:'tx.inbound_anomaly_score=0',\
-    setvar:'tx.outbound_anomaly_score=0',\
+    setvar:'tx.blocking_outbound_anomaly_score=0',\
+    setvar:'tx.detection_outbound_anomaly_score=0',\
     setvar:'tx.outbound_anomaly_score_pl1=0',\
     setvar:'tx.outbound_anomaly_score_pl2=0',\
     setvar:'tx.outbound_anomaly_score_pl3=0',\
@@ -423,13 +424,13 @@ SecMarker "END-SAMPLING"
 # Configuration Plausibility Checks
 #
 
-# Make sure executing paranoia level is not lower than paranoia level
-SecRule TX:executing_paranoia_level "@lt %{tx.paranoia_level}" \
+# Make sure detection paranoia level is not lower than paranoia level
+SecRule TX:detection_paranoia_level "@lt %{tx.blocking_paranoia_level}" \
     "id:901500,\
     phase:1,\
     deny,\
     status:500,\
     t:none,\
     log,\
-    msg:'Executing paranoia level configured is lower than the paranoia level itself. This is illegal. Blocking request. Aborting',\
+    msg:'Detection paranoia level configured is lower than the paranoia level itself. This is illegal. Blocking request. Aborting',\
     ver:'OWASP_CRS/3.4.0-dev'"

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -108,7 +108,7 @@ SecRule &TX:early_blocking "@eq 0" \
     setvar:'tx.early_blocking=0'"
 
 # Default Blocking Paranoia Level (rule 900000 in crs-setup.conf)
-SecRule &TX:BLOCKING_PARANOIA_LEVEL "@eq 0" \
+SecRule &TX:blocking_paranoia_level "@eq 0" \
     "id:901120,\
     phase:1,\
     pass,\

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -89,6 +89,15 @@ SecRule &TX:outbound_anomaly_score_threshold "@eq 0" \
     ver:'OWASP_CRS/3.4.0-dev',\
     setvar:'tx.outbound_anomaly_score_threshold=4'"
 
+# Default Reporting Level (rule 900115 in crs-setup.conf)
+SecRule &TX:reporting_level "@eq 0" \
+    "id:901111,\
+    phase:1,\
+    pass,\
+    nolog,\
+    ver:'OWASP_CRS/3.4.0-dev',\
+    setvar:'tx.reporting_level=2'"
+
 # Default Early Blocking (rule 900120 in crs-setup.conf)
 SecRule &TX:early_blocking "@eq 0" \
     "id:901115,\

--- a/rules/REQUEST-910-IP-REPUTATION.conf
+++ b/rules/REQUEST-910-IP-REPUTATION.conf
@@ -13,10 +13,10 @@
 #
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:910011,phase:1,pass,nolog,skipAfter:END-REQUEST-910-IP-REPUTATION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:910012,phase:2,pass,nolog,skipAfter:END-REQUEST-910-IP-REPUTATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:910011,phase:1,pass,nolog,skipAfter:END-REQUEST-910-IP-REPUTATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:910012,phase:2,pass,nolog,skipAfter:END-REQUEST-910-IP-REPUTATION"
 #
-# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 #
@@ -46,7 +46,7 @@ SecRule TX:DO_REPUT_BLOCK "@eq 1" \
     chain,\
     skipAfter:BEGIN-REQUEST-BLOCKING-EVAL"
     SecRule IP:REPUT_BLOCK_FLAG "@eq 1" \
-        "setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        "setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -77,7 +77,7 @@ SecRule TX:HIGH_RISK_COUNTRY_CODES "!@rx ^$" \
     SecRule TX:REAL_IP "@geoLookup" \
         "chain"
         SecRule GEO:COUNTRY_CODE "@within %{tx.high_risk_country_codes}" \
-            "setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+            "setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
             setvar:'ip.reput_block_flag=1',\
             setvar:'ip.reput_block_reason=%{rule.msg}',\
             expirevar:'ip.reput_block_flag=%{tx.reput_block_duration}'"
@@ -173,7 +173,7 @@ SecRule TX:block_search_ip "@eq 1" \
     chain,\
     skipAfter:END-RBL-CHECK"
     SecRule TX:httpbl_msg "@rx Search Engine" \
-        "setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+        "setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'ip.reput_block_flag=1',\
         setvar:'ip.reput_block_reason=%{rule.msg}',\
         setvar:'ip.previous_rbl_check=1',\
@@ -197,7 +197,7 @@ SecRule TX:block_spammer_ip "@eq 1" \
     chain,\
     skipAfter:END-RBL-CHECK"
     SecRule TX:httpbl_msg "@rx (?i)^.*? spammer .*?$" \
-        "setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+        "setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'ip.reput_block_flag=1',\
         setvar:'ip.reput_block_reason=%{rule.msg}',\
         setvar:'ip.previous_rbl_check=1',\
@@ -221,7 +221,7 @@ SecRule TX:block_suspicious_ip "@eq 1" \
     chain,\
     skipAfter:END-RBL-CHECK"
     SecRule TX:httpbl_msg "@rx (?i)^.*? suspicious .*?$" \
-        "setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+        "setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'ip.reput_block_flag=1',\
         setvar:'ip.reput_block_reason=%{rule.msg}',\
         setvar:'ip.previous_rbl_check=1',\
@@ -245,7 +245,7 @@ SecRule TX:block_harvester_ip "@eq 1" \
     chain,\
     skipAfter:END-RBL-CHECK"
     SecRule TX:httpbl_msg "@rx (?i)^.*? harvester .*?$" \
-        "setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+        "setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'ip.reput_block_flag=1',\
         setvar:'ip.reput_block_reason=%{rule.msg}',\
         setvar:'ip.previous_rbl_check=1',\
@@ -272,26 +272,26 @@ SecMarker "END-RBL-LOOKUP"
 SecMarker "END-RBL-CHECK"
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:910013,phase:1,pass,nolog,skipAfter:END-REQUEST-910-IP-REPUTATION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:910014,phase:2,pass,nolog,skipAfter:END-REQUEST-910-IP-REPUTATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:910013,phase:1,pass,nolog,skipAfter:END-REQUEST-910-IP-REPUTATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:910014,phase:2,pass,nolog,skipAfter:END-REQUEST-910-IP-REPUTATION"
 #
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
-#
-
-
-
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:910015,phase:1,pass,nolog,skipAfter:END-REQUEST-910-IP-REPUTATION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:910016,phase:2,pass,nolog,skipAfter:END-REQUEST-910-IP-REPUTATION"
-#
-# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:910017,phase:1,pass,nolog,skipAfter:END-REQUEST-910-IP-REPUTATION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:910018,phase:2,pass,nolog,skipAfter:END-REQUEST-910-IP-REPUTATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:910015,phase:1,pass,nolog,skipAfter:END-REQUEST-910-IP-REPUTATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:910016,phase:2,pass,nolog,skipAfter:END-REQUEST-910-IP-REPUTATION"
 #
-# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
+#
+
+
+
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:910017,phase:1,pass,nolog,skipAfter:END-REQUEST-910-IP-REPUTATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:910018,phase:2,pass,nolog,skipAfter:END-REQUEST-910-IP-REPUTATION"
+#
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
 
 

--- a/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
+++ b/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
@@ -14,10 +14,10 @@
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:911011,phase:1,pass,nolog,skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:911012,phase:2,pass,nolog,skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:911011,phase:1,pass,nolog,skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:911012,phase:2,pass,nolog,skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
 #
-# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 #
@@ -41,31 +41,31 @@ SecRule REQUEST_METHOD "!@within %{tx.allowed_methods}" \
     tag:'PCI/12.1',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:911013,phase:1,pass,nolog,skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:911014,phase:2,pass,nolog,skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:911013,phase:1,pass,nolog,skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:911014,phase:2,pass,nolog,skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
 #
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
-#
-
-
-
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:911015,phase:1,pass,nolog,skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:911016,phase:2,pass,nolog,skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
-#
-# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:911017,phase:1,pass,nolog,skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:911018,phase:2,pass,nolog,skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:911015,phase:1,pass,nolog,skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:911016,phase:2,pass,nolog,skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
 #
-# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
+#
+
+
+
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:911017,phase:1,pass,nolog,skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:911018,phase:2,pass,nolog,skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+#
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
 
 

--- a/rules/REQUEST-912-DOS-PROTECTION.conf
+++ b/rules/REQUEST-912-DOS-PROTECTION.conf
@@ -91,10 +91,10 @@ SecRule &TX:dos_burst_time_slice "@eq 0" \
         SecRule &TX:dos_block_timeout "@eq 0"
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:912011,phase:1,pass,nolog,skipAfter:END-REQUEST-912-DOS-PROTECTION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:912012,phase:2,pass,nolog,skipAfter:END-REQUEST-912-DOS-PROTECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:912011,phase:1,pass,nolog,skipAfter:END-REQUEST-912-DOS-PROTECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:912012,phase:2,pass,nolog,skipAfter:END-REQUEST-912-DOS-PROTECTION"
 #
-# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 #
@@ -270,11 +270,11 @@ SecRule IP:DOS_BURST_COUNTER "@ge 2" \
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:912013,phase:1,pass,nolog,skipAfter:END-REQUEST-912-DOS-PROTECTION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:912014,phase:2,pass,nolog,skipAfter:END-REQUEST-912-DOS-PROTECTION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:912019,phase:5,pass,nolog,skipAfter:END-REQUEST-912-DOS-PROTECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:912013,phase:1,pass,nolog,skipAfter:END-REQUEST-912-DOS-PROTECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:912014,phase:2,pass,nolog,skipAfter:END-REQUEST-912-DOS-PROTECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:912019,phase:5,pass,nolog,skipAfter:END-REQUEST-912-DOS-PROTECTION"
 #
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 #
@@ -303,18 +303,18 @@ SecRule IP:DOS_BURST_COUNTER "@ge 1" \
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:912015,phase:1,pass,nolog,skipAfter:END-REQUEST-912-DOS-PROTECTION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:912016,phase:2,pass,nolog,skipAfter:END-REQUEST-912-DOS-PROTECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:912015,phase:1,pass,nolog,skipAfter:END-REQUEST-912-DOS-PROTECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:912016,phase:2,pass,nolog,skipAfter:END-REQUEST-912-DOS-PROTECTION"
 #
-# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:912017,phase:1,pass,nolog,skipAfter:END-REQUEST-912-DOS-PROTECTION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:912018,phase:2,pass,nolog,skipAfter:END-REQUEST-912-DOS-PROTECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:912017,phase:1,pass,nolog,skipAfter:END-REQUEST-912-DOS-PROTECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:912018,phase:2,pass,nolog,skipAfter:END-REQUEST-912-DOS-PROTECTION"
 #
-# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
 
 

--- a/rules/REQUEST-913-SCANNER-DETECTION.conf
+++ b/rules/REQUEST-913-SCANNER-DETECTION.conf
@@ -14,10 +14,10 @@
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:913011,phase:1,pass,nolog,skipAfter:END-REQUEST-913-SCANNER-DETECTION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:913012,phase:2,pass,nolog,skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:913011,phase:1,pass,nolog,skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:913012,phase:2,pass,nolog,skipAfter:END-REQUEST-913-SCANNER-DETECTION"
 #
-# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 #
@@ -54,7 +54,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scanners-user-agents.data" \
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VARS "!@rx ^(?:urlgrabber/[0-9\.]+ yum/[0-9\.]+|mozilla/[0-9\.]+ ecairn-grabber/[0-9\.]+ \(\+http://ecairn.com/grabber\))$" \
-        "setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+        "setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'ip.reput_block_flag=1',\
         setvar:'ip.reput_block_reason=%{rule.msg}',\
         expirevar:'ip.reput_block_flag=%{tx.reput_block_duration}'"
@@ -77,7 +77,7 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@pmFromFile scanners-headers.data
     tag:'PCI/6.5.10',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'ip.reput_block_flag=1',\
     setvar:'ip.reput_block_reason=%{rule.msg}',\
     expirevar:'ip.reput_block_flag=%{tx.reput_block_duration}'"
@@ -102,16 +102,16 @@ SecRule REQUEST_FILENAME|ARGS "@pmFromFile scanners-urls.data" \
     tag:'PCI/6.5.10',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'ip.reput_block_flag=1',\
     setvar:'ip.reput_block_reason=%{rule.msg}',\
     expirevar:'ip.reput_block_flag=%{tx.reput_block_duration}'"
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:913013,phase:1,pass,nolog,skipAfter:END-REQUEST-913-SCANNER-DETECTION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:913014,phase:2,pass,nolog,skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:913013,phase:1,pass,nolog,skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:913014,phase:2,pass,nolog,skipAfter:END-REQUEST-913-SCANNER-DETECTION"
 #
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
@@ -142,7 +142,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scripting-user-agents.data" \
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
     setvar:'ip.reput_block_flag=1',\
     setvar:'ip.reput_block_reason=%{rule.msg}',\
     expirevar:'ip.reput_block_flag=%{tx.reput_block_duration}'"
@@ -176,24 +176,24 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile crawlers-user-agents.data" \
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
     setvar:'ip.reput_block_flag=1',\
     setvar:'ip.reput_block_reason=%{rule.msg}',\
     expirevar:'ip.reput_block_flag=%{tx.reput_block_duration}'"
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:913015,phase:1,pass,nolog,skipAfter:END-REQUEST-913-SCANNER-DETECTION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:913016,phase:2,pass,nolog,skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:913015,phase:1,pass,nolog,skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:913016,phase:2,pass,nolog,skipAfter:END-REQUEST-913-SCANNER-DETECTION"
 #
-# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:913017,phase:1,pass,nolog,skipAfter:END-REQUEST-913-SCANNER-DETECTION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:913018,phase:2,pass,nolog,skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:913017,phase:1,pass,nolog,skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:913018,phase:2,pass,nolog,skipAfter:END-REQUEST-913-SCANNER-DETECTION"
 #
-# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
 
 

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -23,10 +23,10 @@
 #
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:920011,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:920012,phase:2,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:920011,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:920012,phase:2,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 #
-# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 #
@@ -66,7 +66,7 @@ SecRule REQUEST_LINE "!@rx (?i)^(?:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::
     tag:'capec/1000/210/272',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
 
 #
@@ -121,7 +121,7 @@ SecRule FILES|FILES_NAMES "!@rx (?i)^(?:&(?:(?:[aeiouclnrszg]acut|[aeiou]grav|[a
     tag:'capec/1000/210/272',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -150,7 +150,7 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^\d+$" \
     tag:'capec/1000/210/272',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -187,7 +187,7 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
     chain"
     SecRule REQUEST_HEADERS:Content-Length "!@rx ^0?$" \
         "t:none,\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -212,7 +212,7 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
     chain"
     SecRule &REQUEST_HEADERS:Transfer-Encoding "!@eq 0" \
         "t:none,\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -251,7 +251,7 @@ SecRule REQUEST_PROTOCOL "!@within HTTP/2 HTTP/2.0" \
         SecRule &REQUEST_HEADERS:Content-Length "@eq 0" \
             "chain"
             SecRule &REQUEST_HEADERS:Transfer-Encoding "@eq 0" \
-                "setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
+                "setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
 #
 # As per RFC7230 3.3.2: A sender MUST NOT send a Content-Length
@@ -278,7 +278,7 @@ SecRule &REQUEST_HEADERS:Transfer-Encoding "!@eq 0" \
     chain"
     SecRule &REQUEST_HEADERS:Content-Length "!@eq 0" \
         "t:none,\
-        setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
 
 #
@@ -315,7 +315,7 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx (\d+)-(\d+)" \
     severity:'WARNING',\
     chain"
     SecRule TX:2 "@lt %{tx.1}" \
-        "setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
+        "setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
 
 #
@@ -346,7 +346,7 @@ SecRule REQUEST_HEADERS:Connection "@rx \b(?:keep-alive|close),\s?(?:keep-alive|
     tag:'capec/1000/210/272',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
 #
 # Check URL encodings
@@ -381,7 +381,7 @@ SecRule REQUEST_URI "@rx \x25" \
     severity:'WARNING',\
     chain"
     SecRule REQUEST_URI "@validateUrlEncoding" \
-        "setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
+        "setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
 SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)application/x-www-form-urlencoded" \
     "id:920240,\
@@ -403,7 +403,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)application/x-www-form-urlencoded
     SecRule REQUEST_BODY "@rx \x25" \
         "chain"
         SecRule REQUEST_BODY "@validateUrlEncoding" \
-            "setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
+            "setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
 
 #
@@ -433,7 +433,7 @@ SecRule TX:CRS_VALIDATE_UTF8_ENCODING "@eq 1" \
     severity:'WARNING',\
     chain"
     SecRule REQUEST_FILENAME|ARGS|ARGS_NAMES "@validateUtf8Encoding" \
-        "setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
+        "setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
 
 #
@@ -470,7 +470,7 @@ SecRule REQUEST_URI|REQUEST_BODY "@rx \%u[fF]{2}[0-9a-fA-F]{2}" \
     tag:'capec/1000/255/153/267/72',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
 
 #
@@ -526,7 +526,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 1-255" \
     tag:'capec/1000/210/272',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -558,7 +558,7 @@ SecRule &REQUEST_HEADERS:Host "@eq 0" \
     tag:'PCI/6.5.10',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}',\
     skipAfter:END-HOST-CHECK"
 
 
@@ -577,7 +577,7 @@ SecRule REQUEST_HEADERS:Host "@rx ^$" \
     tag:'capec/1000/210/272',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
 SecMarker "END-HOST-CHECK"
 
@@ -622,7 +622,7 @@ SecRule REQUEST_HEADERS:Accept "@rx ^$" \
         "chain"
         SecRule REQUEST_HEADERS:User-Agent "!@pm AppleWebKit Android Business Enterprise Entreprise" \
             "t:none,\
-            setvar:'tx.anomaly_score_pl1=+%{tx.notice_anomaly_score}'"
+            setvar:'tx.inbound_anomaly_score_pl1=+%{tx.notice_anomaly_score}'"
 
 #
 # This rule is a sibling of rule 920310.
@@ -647,7 +647,7 @@ SecRule REQUEST_HEADERS:Accept "@rx ^$" \
         "chain"
         SecRule &REQUEST_HEADERS:User-Agent "@eq 0" \
             "t:none,\
-            setvar:'tx.anomaly_score_pl1=+%{tx.notice_anomaly_score}'"
+            setvar:'tx.inbound_anomaly_score_pl1=+%{tx.notice_anomaly_score}'"
 
 
 #
@@ -675,7 +675,7 @@ SecRule REQUEST_HEADERS:User-Agent "@rx ^$" \
     tag:'capec/1000/210/272',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'NOTICE',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.notice_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.notice_anomaly_score}'"
 
 #
 # Missing Content-Type Header with Request Body
@@ -715,7 +715,7 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
     chain"
     SecRule &REQUEST_HEADERS:Content-Type "@eq 0" \
         "t:none,\
-        setvar:'tx.anomaly_score_pl1=+%{tx.notice_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl1=+%{tx.notice_anomaly_score}'"
 
 # Check that the host header is not an IP address
 # This is not an HTTP RFC violation but it is indicative of automated client access.
@@ -757,7 +757,7 @@ SecRule REQUEST_HEADERS:Host "@rx (?:^([\d.]+|\[[\da-f:]+\]|[\da-f:]+)(:[\d]+)?$
     tag:'PCI/6.5.10',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
 
 # In most cases, you should expect a certain volume of each a request on your
@@ -792,7 +792,7 @@ SecRule &TX:MAX_NUM_ARGS "@eq 1" \
     chain"
     SecRule &ARGS "@gt %{tx.max_num_args}" \
         "t:none,\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 ## -- Arguments limits --
 #
@@ -817,7 +817,7 @@ SecRule &TX:ARG_NAME_LENGTH "@eq 1" \
     chain"
     SecRule ARGS_NAMES "@gt %{tx.arg_name_length}" \
         "t:none,t:length,\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #
 # Limit argument value length
@@ -844,7 +844,7 @@ SecRule &TX:ARG_LENGTH "@eq 1" \
     chain"
     SecRule ARGS "@gt %{tx.arg_length}" \
         "t:none,t:length,\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #
 # Limit arguments total length
@@ -868,7 +868,7 @@ SecRule &TX:TOTAL_ARG_LENGTH "@eq 1" \
     chain"
     SecRule ARGS_COMBINED_SIZE "@gt %{tx.total_arg_length}" \
         "t:none,\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -895,7 +895,7 @@ SecRule &TX:MAX_FILE_SIZE "@eq 1" \
         "chain"
         SecRule REQUEST_HEADERS:Content-Length "@gt %{tx.max_file_size}" \
             "t:none,\
-            setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+            setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #
 # Combined file size is limited
@@ -919,7 +919,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
     chain"
     SecRule FILES_COMBINED_SIZE "@gt %{tx.combined_file_sizes}" \
         "t:none,\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 
@@ -956,7 +956,7 @@ SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+*-]+(?:\s?;\s?(?:action|bounda
     tag:'PCI/12.1',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # In case Content-Type header can be parsed, check the mime-type against
 # the policy defined in the 'allowed_request_content_type' variable.
@@ -983,7 +983,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
     chain"
     SecRule TX:content_type "!@within %{tx.allowed_request_content_type}" \
         "t:lowercase,\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -1012,7 +1012,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx charset\s*=\s*[\"']?([^;\"'\s]+)" \
     SecRule TX:content_type_charset "!@within %{tx.allowed_request_content_type_charset}" \
         "t:lowercase,\
         ctl:forceRequestBodyVariable=On,\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -1035,7 +1035,7 @@ SecRule REQUEST_PROTOCOL "!@within %{tx.allowed_http_versions}" \
     tag:'PCI/6.5.10',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #
 # Restrict file extension
@@ -1062,7 +1062,7 @@ SecRule REQUEST_BASENAME "@rx \.([^.]+)$" \
     chain"
     SecRule TX:EXTENSION "@within %{tx.restricted_extensions}" \
         "t:none,t:urlDecodeUni,t:lowercase,\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #
 # Backup or "working" file extension
@@ -1085,7 +1085,7 @@ SecRule REQUEST_FILENAME "@rx \.[^.~]+~(?:/.*|)$" \
     tag:'PCI/6.5.10',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #
 # Restricted HTTP headers
@@ -1133,7 +1133,7 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
     setvar:'tx.header_name_%{tx.0}=/%{tx.0}/',\
     chain"
     SecRule TX:/^header_name_/ "@within %{tx.restricted_headers}" \
-        "setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        "setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 #
 # Rule against CVE-2022-21907
 # This rule blocks Accept-Encoding headers longer than 50 characters.
@@ -1161,13 +1161,13 @@ SecRule REQUEST_HEADERS:Accept-Encoding "@gt 50" \
     tag:'PCI/12.1',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:920013,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:920014,phase:2,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:920013,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:920014,phase:2,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 #
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 #
@@ -1208,7 +1208,7 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d
     severity:'WARNING',\
     chain"
     SecRule REQUEST_BASENAME "!@endsWith .pdf" \
-        "setvar:'tx.anomaly_score_pl2=+%{tx.warning_anomaly_score}'"
+        "setvar:'tx.inbound_anomaly_score_pl2=+%{tx.warning_anomaly_score}'"
 
 #
 # This is a sibling of rule 920200
@@ -1232,7 +1232,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     severity:'WARNING',\
     chain"
     SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d+)?-(?:\d+)?\s*,?\s*){63}" \
-        "setvar:'tx.anomaly_score_pl2=+%{tx.warning_anomaly_score}'"
+        "setvar:'tx.inbound_anomaly_score_pl2=+%{tx.warning_anomaly_score}'"
 
 
 SecRule ARGS "@rx %[0-9a-fA-F]{2}" \
@@ -1251,7 +1251,7 @@ SecRule ARGS "@rx %[0-9a-fA-F]{2}" \
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.warning_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.warning_anomaly_score}'"
 
 
 #
@@ -1273,7 +1273,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 9,10,13,
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 
@@ -1300,7 +1300,7 @@ SecRule &REQUEST_HEADERS:User-Agent "@eq 0" \
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'NOTICE',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.notice_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.notice_anomaly_score}'"
 
 
 #
@@ -1322,7 +1322,7 @@ SecRule FILES_NAMES|FILES "@rx ['\";=]" \
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -1350,13 +1350,13 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
     chain"
     SecRule &REQUEST_HEADERS:Content-Type "@eq 0" \
         "t:none,\
-        setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:920015,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:920016,phase:2,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:920015,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:920016,phase:2,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 #
-# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 #
@@ -1381,7 +1381,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteR
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 #
 # Missing Accept Header
@@ -1420,7 +1420,7 @@ SecRule &REQUEST_HEADERS:Accept "@eq 0" \
         "chain"
         SecRule REQUEST_HEADERS:User-Agent "!@pm AppleWebKit Android" \
             "t:none,\
-            setvar:'tx.anomaly_score_pl3=+%{tx.notice_anomaly_score}'"
+            setvar:'tx.inbound_anomaly_score_pl3=+%{tx.notice_anomaly_score}'"
 
 
 #
@@ -1451,7 +1451,7 @@ SecRule &REQUEST_HEADERS:x-up-devcap-post-charset "@ge 1" \
     chain"
     SecRule REQUEST_HEADERS:User-Agent "@rx ^(?i)up" \
         "t:none,\
-        setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -1503,7 +1503,7 @@ SecRule &REQUEST_HEADERS:Cache-Control "@gt 0" \
     severity:'CRITICAL',\
     chain"
     SecRule REQUEST_HEADERS:Cache-Control "!@rx ^(?:(?:max-age=[0-9]+|min-fresh=[0-9]+|no-cache|no-store|no-transform|only-if-cached|max-stale(?:=[0-9]+)?)(?:\s*\,\s*|$)){1,7}$" \
-        "setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+        "setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 #
 # This rule checks for valid Accept-Encoding headers
@@ -1532,12 +1532,12 @@ SecRule REQUEST_HEADERS:Accept-Encoding "!@rx (?:x-(?:compress|gzip)|(?:pack200-
     tag:'PCI/12.1',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:920017,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:920018,phase:2,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:920017,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:920018,phase:2,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 #
-# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
 
 #
@@ -1562,7 +1562,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     severity:'WARNING',\
     chain"
     SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d+)?-(?:\d+)?\s*,?\s*){6}" \
-        "setvar:'tx.anomaly_score_pl4=+%{tx.warning_anomaly_score}'"
+        "setvar:'tx.inbound_anomaly_score_pl4=+%{tx.warning_anomaly_score}'"
 
 
 #
@@ -1587,7 +1587,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteRange 38,44-46,48-58,61,65-90
     tag:'paranoia-level/4',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
 
 #
 # This is a stricter sibling of 920270.
@@ -1608,7 +1608,7 @@ SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!RE
     tag:'paranoia-level/4',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
 
 #
 # This is a stricter sibling of 920270.
@@ -1634,7 +1634,7 @@ SecRule REQUEST_HEADERS:Sec-Fetch-User|REQUEST_HEADERS:Sec-CH-UA-Mobile "!@rx ^(
     tag:'paranoia-level/4',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
 
 # -=[ Abnormal Character Escapes ]=-
 #
@@ -1680,7 +1680,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@rx (?:^|[^\x5c])\x5c[cdegh
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
 
 
 #

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -14,10 +14,10 @@
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:921011,phase:1,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:921012,phase:2,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:921011,phase:1,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:921012,phase:2,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 #
-# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 #
@@ -50,7 +50,7 @@ SecRule ARGS_NAMES|ARGS|REQUEST_BODY|XML:/* "@rx (?:get|post|head|options|connec
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #
 # -=[ HTTP Response Splitting ]=-
@@ -83,7 +83,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:\bhttp/\d|<(?:html|meta)\b)" \
@@ -105,7 +105,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #
 # -=[ HTTP Header Injection ]=-
@@ -140,7 +140,7 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@rx [\n\r]" \
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 # Detect newlines in argument names.
@@ -169,7 +169,7 @@ SecRule ARGS_NAMES "@rx [\n\r]" \
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 SecRule ARGS_GET_NAMES|ARGS_GET "@rx [\n\r]+(?:\s|location|refresh|(?:set-)?cookie|(?:x-)?(?:forwarded-(?:for|host|server)|host|via|remote-ip|remote-addr|originating-IP))\s*:" \
@@ -191,7 +191,7 @@ SecRule ARGS_GET_NAMES|ARGS_GET "@rx [\n\r]+(?:\s|location|refresh|(?:set-)?cook
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 # -=[ HTTP Splitting ]=-
@@ -217,7 +217,7 @@ SecRule REQUEST_FILENAME "@rx [\n\r]" \
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -250,13 +250,13 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:921013,phase:1,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:921014,phase:2,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:921013,phase:1,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:921014,phase:2,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 #
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
@@ -285,13 +285,13 @@ SecRule ARGS_GET "@rx [\n\r]" \
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:921015,phase:1,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:921016,phase:2,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:921015,phase:1,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:921016,phase:2,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 #
-# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 #
 
@@ -347,14 +347,14 @@ SecRule TX:/paramcounter_.*/ "@gt 1" \
     SecRule MATCHED_VARS_NAMES "@rx TX:paramcounter_(.*)" \
         "capture,\
         setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:921017,phase:1,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:921018,phase:2,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:921017,phase:1,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:921018,phase:2,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 #
-# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
 
 

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -14,10 +14,10 @@
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:930011,phase:1,pass,nolog,skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:930012,phase:2,pass,nolog,skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:930011,phase:1,pass,nolog,skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:930012,phase:2,pass,nolog,skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
 #
-# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 #
@@ -54,7 +54,7 @@ SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|FILES|XML:
     tag:'capec/1000/255/153/126',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}'"
 
 #
@@ -85,7 +85,7 @@ SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|FILES|XML:/* "
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     multiMatch,\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}'"
 
 #
@@ -116,7 +116,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #
 # -=[ Restricted File Access ]=-
@@ -143,30 +143,30 @@ SecRule REQUEST_FILENAME "@pmFromFile restricted-files.data" \
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:930013,phase:1,pass,nolog,skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:930014,phase:2,pass,nolog,skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:930013,phase:1,pass,nolog,skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:930014,phase:2,pass,nolog,skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
 #
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
-#
-
-
-
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:930015,phase:1,pass,nolog,skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:930016,phase:2,pass,nolog,skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
-#
-# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:930017,phase:1,pass,nolog,skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:930018,phase:2,pass,nolog,skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:930015,phase:1,pass,nolog,skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:930016,phase:2,pass,nolog,skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
 #
-# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
+#
+
+
+
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:930017,phase:1,pass,nolog,skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:930018,phase:2,pass,nolog,skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+#
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
 
 

--- a/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
+++ b/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
@@ -17,10 +17,10 @@
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:931011,phase:1,pass,nolog,skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:931012,phase:2,pass,nolog,skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:931011,phase:1,pass,nolog,skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:931012,phase:2,pass,nolog,skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
 #
-# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 # -=[ Rule Logic ]=-
@@ -53,7 +53,7 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?)://(?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 SecRule QUERY_STRING|REQUEST_BODY "@rx (?i)(?:\binclude\s*\([^)]*|mosConfig_absolute_path|_CONF\[path\]|_SERVER\[DOCUMENT_ROOT\]|GALLERY_BASEDIR|path\[docroot\]|appserv_root|config\[root_dir\])=(?:file|ftps?|https?)://" \
     "id:931110,\
@@ -74,7 +74,7 @@ SecRule QUERY_STRING|REQUEST_BODY "@rx (?i)(?:\binclude\s*\([^)]*|mosConfig_abso
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 SecRule ARGS "@rx ^(?i:file|ftps?|https?).*?\?+$" \
     "id:931120,\
@@ -95,14 +95,14 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?).*?\?+$" \
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:931013,phase:1,pass,nolog,skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:931014,phase:2,pass,nolog,skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:931013,phase:1,pass,nolog,skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:931014,phase:2,pass,nolog,skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
 #
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 SecRule ARGS "@rx ^(?i:file|ftps?|https?)://([^/]*).*$" \
@@ -127,22 +127,22 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?)://([^/]*).*$" \
     chain"
     SecRule TX:/rfi_parameter_.*/ "!@endsWith .%{request_headers.host}" \
         "setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:931015,phase:1,pass,nolog,skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:931016,phase:2,pass,nolog,skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:931015,phase:1,pass,nolog,skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:931016,phase:2,pass,nolog,skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
 #
-# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:931017,phase:1,pass,nolog,skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:931018,phase:2,pass,nolog,skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:931017,phase:1,pass,nolog,skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:931018,phase:2,pass,nolog,skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
 #
-# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
 
 

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -14,10 +14,10 @@
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:932011,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:932012,phase:2,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:932011,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:932012,phase:2,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 #
-# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 
@@ -115,7 +115,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Apache 2.2 requires configuration file lines to be under 8kB.
 # Therefore, some remaining commands have been split off to a separate rule.
@@ -145,7 +145,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 # [ Windows command injection ]
@@ -236,7 +236,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Apache 2.2 requires configuration file lines to be under 8kB.
 # Therefore, some remaining commands have been split off to a separate rule.
@@ -269,7 +269,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 # [ Windows PowerShell, cmdlets and options ]
@@ -304,7 +304,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 # [ Unix shell expressions ]
@@ -348,7 +348,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 # [ Windows FOR, IF commands ]
@@ -394,7 +394,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 # [ Unix direct remote command execution ]
@@ -439,7 +439,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 # [ Unix shell snippets ]
@@ -476,7 +476,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 # [ Shellshock vulnerability (CVE-2014-6271 and CVE-2014-7169) ]
@@ -508,7 +508,7 @@ SecRule REQUEST_HEADERS|REQUEST_LINE "@rx ^\(\s*\)\s+{" \
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 SecRule ARGS_NAMES|ARGS|FILES_NAMES "@rx ^\(\s*\)\s+{" \
     "id:932171,\
@@ -530,7 +530,7 @@ SecRule ARGS_NAMES|ARGS|FILES_NAMES "@rx ^\(\s*\)\s+{" \
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -565,13 +565,13 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:932013,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:932014,phase:2,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:932013,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:932014,phase:2,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 #
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 # This is a stricter sibling of rule 932100.
@@ -603,7 +603,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # This is a stricter sibling of rule 932130.
 #
@@ -680,7 +680,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     SecRule MATCHED_VAR "@rx /" "t:none,t:urlDecodeUni,chain"
         SecRule MATCHED_VAR "@rx \s" "t:none,t:urlDecodeUni,\
             setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-            setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+            setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 # [ Sqlite System Command Execution ]
@@ -716,7 +716,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # -=[ SMTP/IMAP/POP3 Command Execution ]=-
 #
@@ -825,10 +825,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:932015,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:932016,phase:2,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:932015,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:932016,phase:2,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 #
-# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 # Missing Unix commands have been added to a new word list i.e.
@@ -862,7 +862,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 #
 # -=[ Bypass Rule 930120 (wildcard) ]=-
@@ -898,7 +898,7 @@ SecRule ARGS "@rx /(?:[?*]+[a-z/]+|[a-z/]+[?*]+)" \
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
 # -=[ SMTP commands ]=-
@@ -932,7 +932,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 # =[ IMAP4 Command Execution ]=
 #
@@ -965,7 +965,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 # =[ POP3 Command Execution ]=
 #
@@ -998,12 +998,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:932017,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:932018,phase:2,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:932017,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:932018,phase:2,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 #
-# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
 
 

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -14,10 +14,10 @@
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:933011,phase:1,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:933012,phase:2,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:933011,phase:1,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:933012,phase:2,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
 #
-# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 #
@@ -63,7 +63,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #
 # [ PHP Script Uploads ]
@@ -105,7 +105,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -134,7 +134,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     SecRule MATCHED_VARS "@pm =" \
         "capture,\
         setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -159,7 +159,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -196,7 +196,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -225,7 +225,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -293,7 +293,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -344,7 +344,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -400,7 +400,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 
@@ -456,7 +456,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # [ PHP Functions: Variable Function Prevent Bypass ]
 #
@@ -499,12 +499,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:933013,phase:1,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:933014,phase:2,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:933013,phase:1,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:933014,phase:2,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
 #
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 #
@@ -547,15 +547,15 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     SecRule MATCHED_VARS "@pm (" \
         "capture,\
         setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:933015,phase:1,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:933016,phase:2,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:933015,phase:1,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:933016,phase:2,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
 #
-# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 #
@@ -598,7 +598,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -641,7 +641,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -684,7 +684,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
 # [ PHP Closing Tag Found ]
@@ -714,13 +714,13 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:933017,phase:1,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:933018,phase:2,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:933017,phase:1,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:933018,phase:2,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
 #
-# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
 
 

--- a/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
+++ b/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
@@ -14,10 +14,10 @@
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:934011,phase:1,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:934012,phase:2,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:934011,phase:1,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:934012,phase:2,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
 #
-# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 
@@ -67,7 +67,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # -=[ SSRF Attacks ]=-
 #
@@ -102,7 +102,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # JavaScript prototype pollution injection attempts
 #
@@ -139,13 +139,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
-
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:934013,phase:1,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:934014,phase:2,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:934013,phase:1,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:934014,phase:2,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
 #
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 # -=[ SSRF Attacks ]=-
@@ -197,7 +196,7 @@ SecRule ARGS "@rx (?i)(?:acap|bitcoin|blob|cap|cvs|svn|svn\+ssh|turn|udp|vnc|xmp
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \[\s*constructor\s*\]" \
     "id:934131,\
@@ -220,19 +219,19 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:934015,phase:1,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:934016,phase:2,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:934015,phase:1,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:934016,phase:2,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
 #
-# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:934017,phase:1,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:934018,phase:2,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:934017,phase:1,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:934018,phase:2,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
 #
-# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
 
 

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -14,10 +14,10 @@
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:941011,phase:1,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:941012,phase:2,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:941011,phase:1,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:941012,phase:2,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
 #
-# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 
@@ -53,7 +53,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -80,7 +80,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -110,7 +110,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -139,7 +139,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -172,7 +172,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -197,7 +197,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -224,7 +224,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -251,7 +251,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:<.*[:]?vmlframe.*?[\s/+]*?src[\s/+]*=)" \
@@ -273,7 +273,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:j|&#x?0*(?:74|4A|106|6A);?)(?:\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:a|&#x?0*(?:65|41|97|61);?)(?:\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:v|&#x?0*(?:86|56|118|76);?)(?:\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:a|&#x?0*(?:65|41|97|61);?)(?:\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:s|&#x?0*(?:83|53|115|73);?)(?:\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:c|&#x?0*(?:67|43|99|63);?)(?:\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:r|&#x?0*(?:82|52|114|72);?)(?:\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:i|&#x?0*(?:73|49|105|69);?)(?:\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:p|&#x?0*(?:80|50|112|70);?)(?:\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:t|&#x?0*(?:84|54|116|74);?)(?:\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?::|&(?:#x?0*(?:58|3A);?|colon;)).)" \
@@ -295,7 +295,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:v|&#x?0*(?:86|56|118|76);?)(?:\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:b|&#x?0*(?:66|42|98|62);?)(?:\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:s|&#x?0*(?:83|53|115|73);?)(?:\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:c|&#x?0*(?:67|43|99|63);?)(?:\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:r|&#x?0*(?:82|52|114|72);?)(?:\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:i|&#x?0*(?:73|49|105|69);?)(?:\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:p|&#x?0*(?:80|50|112|70);?)(?:\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:t|&#x?0*(?:84|54|116|74);?)(?:\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?::|&(?:#x?0*(?:58|3A);?|colon;)).)" \
@@ -317,7 +317,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)<EMBED[\s/+].*?(?:src|type).*?=" \
@@ -339,7 +339,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx <[?]?import[\s/+\S]*?implementation[\s/+]*?=" \
@@ -361,7 +361,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:<META[\s/+].*?http-equiv[\s/+]*=[\s/+]*[\"'`]?(?:(?:c|&#x?0*(?:67|43|99|63);?)|(?:r|&#x?0*(?:82|52|114|72);?)|(?:s|&#x?0*(?:83|53|115|73);?)))" \
@@ -383,7 +383,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:<META[\s/+].*?charset[\s/+]*=)" \
@@ -405,7 +405,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)<LINK[\s/+].*?href[\s/+]*=" \
@@ -427,7 +427,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)<BASE[\s/+].*?href[\s/+]*=" \
@@ -449,7 +449,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)<APPLET[\s/+>]" \
@@ -471,7 +471,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)<OBJECT[\s/+].*?(?:type|codetype|classid|code|data)[\s/+]*=" \
@@ -493,7 +493,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #
 # https://www.owasp.org/www-community/xss-filter-evasion-cheatsheet
@@ -556,7 +556,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
         "t:none,t:lowercase,t:urlDecode,t:htmlEntityDecode,t:jsDecode,\
         ctl:auditLogParts=+E,\
         setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #
 # https://nedbatchelder.com/blog/200704/xss_with_utf7.html
@@ -583,7 +583,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #
 # Defend against JSFuck and Hieroglyphy obfuscation of Javascript code
@@ -625,7 +625,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #
 # Prevent 941180 bypass by using JavaScript global variables
@@ -653,13 +653,13 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS|XML:
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:941013,phase:1,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:941014,phase:2,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:941013,phase:1,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:941014,phase:2,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
 #
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 #
@@ -684,7 +684,7 @@ SecRule REQUEST_FILENAME|REQUEST_HEADERS:Referer "@detectXSS" \
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -718,7 +718,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -744,7 +744,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 
@@ -772,7 +772,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 
@@ -859,7 +859,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:[\"'][ ]*(?:[^a-z0-9~_:' ]|in).*?(?:(?:l|\x5cu006C)(?:o|\x5cu006F)(?:c|\x5cu0063)(?:a|\x5cu0061)(?:t|\x5cu0074)(?:i|\x5cu0069)(?:o|\x5cu006F)(?:n|\x5cu006E)|(?:n|\x5cu006E)(?:a|\x5cu0061)(?:m|\x5cu006D)(?:e|\x5cu0065)|(?:o|\x5cu006F)(?:n|\x5cu006E)(?:e|\x5cu0065)(?:r|\x5cu0072)(?:r|\x5cu0072)(?:o|\x5cu006F)(?:r|\x5cu0072)|(?:v|\x5cu0076)(?:a|\x5cu0061)(?:l|\x5cu006C)(?:u|\x5cu0075)(?:e|\x5cu0065)(?:O|\x5cu004F)(?:f|\x5cu0066)).*?=)" \
     "id:941330,\
@@ -880,7 +880,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # This rule is also triggered by the following exploit(s):
 # [ SAP CRM Java vulnerability CVE-2018-2380 - Exploit tested: https://www.exploit-db.com/exploits/44292 ]
@@ -904,7 +904,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 #
 # Defend against AngularJS client side template injection
@@ -937,22 +937,22 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:941015,phase:1,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:941016,phase:2,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:941015,phase:1,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:941016,phase:2,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
 #
-# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:941017,phase:1,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:941018,phase:2,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:941017,phase:1,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:941018,phase:2,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
 #
-# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
 
 

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -14,10 +14,10 @@
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:942011,phase:1,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:942012,phase:2,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:942011,phase:1,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:942012,phase:2,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
 #
-# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 #
@@ -62,7 +62,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     multiMatch,\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
 
@@ -94,7 +94,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -137,7 +137,7 @@ SecRule REQUEST_BASENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIE
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Regexp generated from util/regexp-assemble/data/942170.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -163,7 +163,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Regexp generated from util/regexp-assemble/data/942190.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -189,7 +189,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Magic number crash in PHP strtod from 2011:
 # https://www.exploringbinary.com/php-hangs-on-numeric-value-2-2250738585072011e-308/
@@ -213,7 +213,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Regexp generated from util/regexp-assemble/942230.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -239,7 +239,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Regexp generated from util/regexp-assemble/data/942240.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -265,7 +265,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:merge.*?using\s*?\(|execute\s*?immediate\s*?[\"'`]|match\s*?[\w(),+-]+\s*?against\s*?\()" \
     "id:942250,\
@@ -286,7 +286,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)union.*?select.*?from" \
     "id:942270,\
@@ -307,7 +307,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Regexp generated from util/regexp-assemble/data/942280.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -333,7 +333,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:(?:\[\$(?:ne|eq|lte?|gte?|n?in|mod|all|size|exists|type|slice|x?or|div|like|between|and)\]))" \
     "id:942290,\
@@ -354,7 +354,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Regexp generated from util/regexp-assemble/data/942320.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -380,7 +380,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Regexp generated from util/regexp-assemble/data/942350.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -406,7 +406,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # This rule has two stricter sibling: 942361 and 942362.
 # The keywords 'alter' and 'union' led to false positives.
@@ -445,7 +445,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #
 # -=[ Detect MySQL in-line comments ]=-
@@ -481,13 +481,13 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:942013,phase:1,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:942014,phase:2,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:942013,phase:1,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:942014,phase:2,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
 #
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
@@ -519,7 +519,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?:^\s*[\"'`;]+|[\"'`]+\s*$)" \
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.warning_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.warning_anomaly_score}'"
 
 
 #
@@ -552,7 +552,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:not\s+between\s+(?:(?:(?:'[^']*')|(?:
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -638,7 +638,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s'\"`()]*?\b([\d\w]+)\b[\s'\"`()]*?(?:
     SecRule TX:942131_lhs "!@streq %{TX.2}" \
         "t:none,\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 #
 # -=[ SQL Function Names ]=-
@@ -671,7 +671,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # Regexp generated from util/regexp-assemble/data/942180.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -697,7 +697,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # This rule is also triggered by the following exploit(s):
 # [ SAP CRM Java vulnerability CVE-2018-2380 - Exploit tested: https://www.exploit-db.com/exploits/44292 ]
@@ -726,7 +726,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # This rule is also triggered by the following exploit(s):
 # [ SAP CRM Java vulnerability CVE-2018-2380 - Exploit tested: https://www.exploit-db.com/exploits/44292 ]
@@ -755,7 +755,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # Regexp generated from util/regexp-assemble/data/942260.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -781,7 +781,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # Regexp generated from util/regexp-assemble/data/942300.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -807,7 +807,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # Regexp generated from util/regexp-assemble/data/942310.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -833,7 +833,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 #
 # -=[ SQL Injection Probings ]=-
@@ -867,7 +867,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # Regexp generated from util/regexp-assemble/data/942340.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -895,7 +895,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # This rule is a stricter sibling of 942360.
 # The keywords 'alter' and 'union' led to false positives.
@@ -920,7 +920,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # This rule is a stricter sibling of 942360.
 # The loose word boudaries and light context led to false positives.
@@ -950,7 +950,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 # This rule is a sibling of 942330. See that rule for a description and overview.
@@ -982,7 +982,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # Regexp generated from util/regexp-assemble/data/942380.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -1009,7 +1009,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # Regexp generated from util/regexp-assemble/data/942390.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -1036,7 +1036,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # Regexp generated from util/regexp-assemble/data/942400.data using Regexp::Assemble.
 # To rebuild the regexp:
@@ -1063,7 +1063,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # The former rule id 942410 was split into three new rules: 942410, 942470, 942480
 #
@@ -1095,7 +1095,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 # The former rule id 942410 was split into three new rules: 942410, 942470, 942480
@@ -1125,7 +1125,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 # The former rule id 942410 was split into three new rules: 942410, 942470, 942480
@@ -1155,7 +1155,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -1195,7 +1195,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.warning_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"
 
 
@@ -1246,7 +1246,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VARS "!@rx ^ey[A-Z-a-z0-9-_]+[.]ey[A-Z-a-z0-9-_]+[.][A-Z-a-z0-9-_]+$" "t:none,\
-        setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
+        setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
 
@@ -1272,7 +1272,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -1321,13 +1321,13 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:942015,phase:1,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:942016,phase:2,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:942015,phase:1,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:942016,phase:2,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
 #
-# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
@@ -1360,7 +1360,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 # This rule is a stricter sibling of 942330. See that rule for a
 # description and overview.
@@ -1384,7 +1384,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 #
 # [ SQL Injection Character Anomaly Usage ]
@@ -1423,7 +1423,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
-    setvar:'tx.anomaly_score_pl3=+%{tx.warning_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"
 
 
@@ -1452,7 +1452,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     tag:'paranoia-level/3',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
-    setvar:'tx.anomaly_score_pl3=+%{tx.warning_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"
 
 
@@ -1483,7 +1483,7 @@ SecRule ARGS "@rx \W{4}" \
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl3=+%{tx.warning_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.warning_anomaly_score}'"
 
 
 #
@@ -1517,7 +1517,7 @@ SecRule REQUEST_BASENAME "@detectSQLi" \
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -1567,12 +1567,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:942017,phase:1,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:942018,phase:2,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:942017,phase:1,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:942018,phase:2,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
 #
-# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
 
 #
@@ -1599,7 +1599,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'paranoia-level/4',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
-    setvar:'tx.anomaly_score_pl4=+%{tx.warning_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl4=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"
 
 
@@ -1628,7 +1628,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     tag:'paranoia-level/4',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'WARNING',\
-    setvar:'tx.anomaly_score_pl4=+%{tx.warning_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl4=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"
 
 

--- a/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
+++ b/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
@@ -14,10 +14,10 @@
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:943011,phase:1,pass,nolog,skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:943012,phase:2,pass,nolog,skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:943011,phase:1,pass,nolog,skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:943012,phase:2,pass,nolog,skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
 #
-# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 #
@@ -47,7 +47,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.session_fixation_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsession|phpsessid|weblogicsession|session_id|session-id|cfid|cftoken|cfsid|jservsession|jwsession)$" \
@@ -74,7 +74,7 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
         chain"
         SecRule TX:1 "!@endsWith %{request_headers.host}" \
             "setvar:'tx.session_fixation_score=+%{tx.critical_anomaly_score}',\
-            setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+            setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsession|phpsessid|weblogicsession|session_id|session-id|cfid|cftoken|cfsid|jservsession|jwsession)$" \
@@ -98,31 +98,31 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
     chain"
     SecRule &REQUEST_HEADERS:Referer "@eq 0" \
         "setvar:'tx.session_fixation_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:943013,phase:1,pass,nolog,skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:943014,phase:2,pass,nolog,skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:943013,phase:1,pass,nolog,skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:943014,phase:2,pass,nolog,skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
 #
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
-#
-
-
-
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:943015,phase:1,pass,nolog,skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:943016,phase:2,pass,nolog,skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
-#
-# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:943017,phase:1,pass,nolog,skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:943018,phase:2,pass,nolog,skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:943015,phase:1,pass,nolog,skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:943016,phase:2,pass,nolog,skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
 #
-# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
+#
+
+
+
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:943017,phase:1,pass,nolog,skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:943018,phase:2,pass,nolog,skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+#
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
 
 

--- a/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -13,10 +13,10 @@
 #
 # Many rules check request bodies, use "SecRequestBodyAccess On" to enable it on main modsecurity configuration file.
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:944011,phase:1,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:944012,phase:2,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:944011,phase:1,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:944012,phase:2,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
 #
-# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 # This rule is also triggered by an Apache Struts exploit:
 # [ Apache Struts vulnerability CVE-2017-5638 - Exploit tested: https://github.com/xsscx/cve-2017-5638 ]
@@ -49,7 +49,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # This rule is also triggered by the following exploit(s):
 # [ Apache Struts vulnerability CVE-2017-5638 - Exploit tested: https://github.com/xsscx/cve-2017-5638 ]
@@ -84,7 +84,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     chain"
     SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* "@rx (?:unmarshaller|base64data|java\.)" \
         "setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Magic bytes detected and payload included possibly RCE vulnerable classes detected and process execution methods detected
 # anomaly score set to critical as all conditions indicate the request try to perform RCE.
@@ -109,7 +109,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     chain"
     SecRule MATCHED_VARS "@rx (?:runtime|processbuilder)" \
         "setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # This rule is also triggered by the following exploit(s):
 # [ Apache Struts vulnerability CVE-2017-5638 - Exploit tested: https://github.com/mazen160/struts-pwn ]
@@ -139,7 +139,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -228,10 +228,10 @@ SecRule REQUEST_LINE|ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUE
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:944013,phase:1,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:944014,phase:2,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:944013,phase:1,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:944014,phase:2,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
 #
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 # This is a stricter sibling of 944150.
@@ -294,7 +294,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # Detecting possible base64 text to match encoded magic bytes \xac\xed\x00\x05 with padding encoded in base64 strings are rO0ABQ KztAAU Cs7QAF
 SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \
@@ -315,7 +315,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \
     "@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)" \
@@ -336,7 +336,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # This rule is also triggered by the following exploit(s):
 # [ SAP CRM Java vulnerability CVE-2018-2380 - Exploit tested: https://www.exploit-db.com/exploits/44292 ]
@@ -360,7 +360,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 # This rule is also triggered by the following exploit(s):
@@ -389,10 +389,10 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:944015,phase:1,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:944016,phase:2,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:944015,phase:1,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:944016,phase:2,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
 #
-# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 # Interesting keywords for possibly RCE on vulnerable classes and methods base64 encoded
 # Keywords = ['runtime', 'processbuilder', 'clonetransformer', 'forclosure', 'instantiatefactory', 'instantiatetransformer', 'invokertransformer', 'prototypeclonefactory', 'prototypeserializationfactory', 'whileclosure']
@@ -420,13 +420,13 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:944017,phase:1,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:944018,phase:2,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:944017,phase:1,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:944018,phase:2,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
 #
-# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
 
 # This is a stricter sibling of 944150.

--- a/rules/REQUEST-949-BLOCKING-EVALUATION.conf
+++ b/rules/REQUEST-949-BLOCKING-EVALUATION.conf
@@ -12,100 +12,147 @@
 # -= Paranoia Level 0 (empty) =- (apply unconditionally)
 #
 
-# Skipping early blocking
+# Summing up the blocking and detection anomaly scores in phase 1
+# even when early blocking is disabled, we need to sum up the scores in phase 1
+# this prevents bugs in phase 5 if Apache skips phases because of error handling
+# See: https://github.com/coreruleset/coreruleset/issues/2319#issuecomment-1047503932
 
-SecRule TX:EARLY_BLOCKING "!@eq 1" \
-    "id:949050,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    skipAfter:EARLY_BLOCKING_ANOMALY_SCORING"
-
-SecRule TX:EARLY_BLOCKING "!@eq 1" \
-    "id:949051,\
-    phase:2,\
-    pass,\
-    t:none,\
-    nolog,\
-    skipAfter:EARLY_BLOCKING_ANOMALY_SCORING"
-
-# Summing up the anomaly score for early blocking
-
-SecRule TX:PARANOIA_LEVEL "@ge 1" \
+SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 1" \
     "id:949052,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
-    setvar:'tx.anomaly_score=+%{tx.anomaly_score_pl1}'"
+    setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl1}'"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 1" \
+    "id:949152,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl1}'"
 
-SecRule TX:PARANOIA_LEVEL "@ge 2" \
+SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
     "id:949053,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
-    setvar:'tx.anomaly_score=+%{tx.anomaly_score_pl2}'"
+    setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl2}'"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 2" \
+    "id:949153,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl2}'"
 
-SecRule TX:PARANOIA_LEVEL "@ge 3" \
+SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
     "id:949054,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
-    setvar:'tx.anomaly_score=+%{tx.anomaly_score_pl3}'"
+    setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl3}'"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 3" \
+    "id:949154,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl3}'"
 
-SecRule TX:PARANOIA_LEVEL "@ge 4" \
+SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
     "id:949055,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
-    setvar:'tx.anomaly_score=+%{tx.anomaly_score_pl4}'"
+    setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl4}'"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
+    "id:949155,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl4}'"
 
+# at start of phase 2, we reset the aggregate scores to 0 to prevent duplicate counting of per-PL scores
+# this is necessary because the per-PL scores are counted across phases
 SecAction "id:949059,\
     phase:2,\
     pass,\
     t:none,\
     nolog,\
-    setvar:'tx.anomaly_score=0'"
+    setvar:'tx.blocking_inbound_anomaly_score=0'"
+SecAction "id:949159,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.detection_inbound_anomaly_score=0'"
 
-SecMarker "EARLY_BLOCKING_ANOMALY_SCORING"
+# Summing up the blocking and detection anomaly scores in phase 2
 
-# NOTE: tx.anomaly_score should not be set initially, but masking would lead to difficult bugs.
-# So we add to it.
-SecRule TX:PARANOIA_LEVEL "@ge 1" \
+SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 1" \
     "id:949060,\
     phase:2,\
     pass,\
     t:none,\
     nolog,\
-    setvar:'tx.anomaly_score=+%{tx.anomaly_score_pl1}'"
+    setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl1}'"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 1" \
+    "id:949160,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl1}'"
 
-SecRule TX:PARANOIA_LEVEL "@ge 2" \
+SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
     "id:949061,\
     phase:2,\
     pass,\
     t:none,\
     nolog,\
-    setvar:'tx.anomaly_score=+%{tx.anomaly_score_pl2}'"
+    setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl2}'"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 2" \
+    "id:949161,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl2}'"
 
-SecRule TX:PARANOIA_LEVEL "@ge 3" \
+SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
     "id:949062,\
     phase:2,\
     pass,\
     t:none,\
     nolog,\
-    setvar:'tx.anomaly_score=+%{tx.anomaly_score_pl3}'"
+    setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl3}'"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 3" \
+    "id:949162,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl3}'"
 
-SecRule TX:PARANOIA_LEVEL "@ge 4" \
+SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
     "id:949063,\
     phase:2,\
     pass,\
     t:none,\
     nolog,\
-    setvar:'tx.anomaly_score=+%{tx.anomaly_score_pl4}'"
+    setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl4}'"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
+    "id:949163,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl4}'"
 
 
 SecMarker "BEGIN-REQUEST-BLOCKING-EVAL"
@@ -130,71 +177,62 @@ SecRule IP:REPUT_BLOCK_FLAG "@eq 1" \
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
-    SecRule TX:DO_REPUT_BLOCK "@eq 1" \
-        "setvar:'tx.inbound_anomaly_score=%{tx.anomaly_score}'"
+    SecRule TX:DO_REPUT_BLOCK "@eq 1"
 
 #
 # -=[ Anomaly Mode: Overall Transaction Anomaly Score ]=-
 #
-SecRule TX:ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
-    "id:949110,\
-    phase:2,\
-    deny,\
-    t:none,\
-    msg:'Inbound Anomaly Score Exceeded (Total Score: %{TX.ANOMALY_SCORE})',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-multi',\
-    tag:'attack-generic',\
-    ver:'OWASP_CRS/3.4.0-dev',\
-    severity:'CRITICAL',\
-    setvar:'tx.inbound_anomaly_score=%{tx.anomaly_score}'"
 
-SecRule TX:EARLY_BLOCKING "@eq 1" \
+# if early blocking is active, check threshold in phase 1
+SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
     "id:949111,\
     phase:1,\
     deny,\
     t:none,\
-    msg:'Inbound Anomaly Score Exceeded in phase 1 (Total Score: %{TX.ANOMALY_SCORE})',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-multi',\
-    tag:'attack-generic',\
+    msg:'Inbound Anomaly Score Exceeded in phase 1 (Total Score: %{TX.BLOCKING_INBOUND_ANOMALY_SCORE})',\
+    tag:'anomaly-evaluation',\
     ver:'OWASP_CRS/3.4.0-dev',\
-    severity:'CRITICAL',\
     chain"
-    SecRule TX:ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
-        "setvar:'tx.inbound_anomaly_score=%{tx.anomaly_score}'"
+    SecRule TX:EARLY_BLOCKING "@eq 1"
 
+# always check threshold in phase 2
+SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
+    "id:949110,\
+    phase:2,\
+    deny,\
+    t:none,\
+    msg:'Inbound Anomaly Score Exceeded (Total Score: %{TX.BLOCKING_INBOUND_ANOMALY_SCORE})',\
+    tag:'anomaly-evaluation',\
+    ver:'OWASP_CRS/3.4.0-dev'"
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:949011,phase:1,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:949012,phase:2,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:949011,phase:1,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:949012,phase:2,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
 #
-# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
-#
-
-
-
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:949013,phase:1,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:949014,phase:2,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-#
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
-#
-
-
-
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:949015,phase:1,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:949016,phase:2,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-#
-# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:949017,phase:1,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:949018,phase:2,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:949013,phase:1,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:949014,phase:2,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
 #
-# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
+#
+
+
+
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:949015,phase:1,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:949016,phase:2,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+#
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
+#
+
+
+
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:949017,phase:1,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:949018,phase:2,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+#
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
 
 

--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -19,10 +19,10 @@
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:950020,phase:3,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:950021,phase:4,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:950020,phase:3,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:950021,phase:4,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
 #
-# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 #
@@ -47,8 +47,7 @@ SecRule RESPONSE_BODY "@rx (?:<(?:TITLE>Index of.*?<H|title>Index of.*?<h)1>Inde
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
 #
 # -=[ CGI Source Code Leakage ]=-
@@ -81,14 +80,13 @@ SecRule RESPONSE_BODY "@rx ^#\!\s?/" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:950013,phase:3,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:950014,phase:4,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:950013,phase:3,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:950014,phase:4,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
 #
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 #
@@ -113,23 +111,22 @@ SecRule RESPONSE_STATUS "@rx ^5\d{2}$" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl2=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl2=+%{tx.error_anomaly_score}'"
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:950015,phase:3,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:950016,phase:4,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:950015,phase:3,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:950016,phase:4,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
 #
-# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:950017,phase:3,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:950022,phase:4,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:950017,phase:3,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:950022,phase:4,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
 #
-# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
 
 

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -14,10 +14,10 @@
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:951011,phase:3,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:951012,phase:4,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:951011,phase:3,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:951012,phase:4,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
 #
-# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 #
@@ -64,8 +64,7 @@ SecRule TX:sql_error_match "@eq 1" \
     SecRule RESPONSE_BODY "@rx (?i:JET Database Engine|Access Database Engine|\[Microsoft\]\[ODBC Microsoft Access Driver\])" \
         "capture,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
 SecRule TX:sql_error_match "@eq 1" \
     "id:951120,\
@@ -89,8 +88,7 @@ SecRule TX:sql_error_match "@eq 1" \
     SecRule RESPONSE_BODY "@rx (?i:ORA-[0-9][0-9][0-9][0-9]|java\.sql\.SQLException|Oracle error|Oracle.*Driver|Warning.*oci_.*|Warning.*ora_.*)" \
         "capture,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
 SecRule TX:sql_error_match "@eq 1" \
     "id:951130,\
@@ -114,8 +112,7 @@ SecRule TX:sql_error_match "@eq 1" \
     SecRule RESPONSE_BODY "@rx (?i:DB2 SQL error:|\[IBM\]\[CLI Driver\]\[DB2/6000\]|CLI Driver.*DB2|DB2 SQL error|db2_\w+\()" \
         "capture,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
 SecRule TX:sql_error_match "@eq 1" \
     "id:951140,\
@@ -139,8 +136,7 @@ SecRule TX:sql_error_match "@eq 1" \
     SecRule RESPONSE_BODY "@rx (?i:\[DM_QUERY_E_SYNTAX\]|has occurred in the vicinity of:)" \
         "capture,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
 SecRule TX:sql_error_match "@eq 1" \
     "id:951150,\
@@ -164,8 +160,7 @@ SecRule TX:sql_error_match "@eq 1" \
     SecRule RESPONSE_BODY "@rx (?i)Dynamic SQL Error" \
         "capture,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
 
 SecRule TX:sql_error_match "@eq 1" \
@@ -190,8 +185,7 @@ SecRule TX:sql_error_match "@eq 1" \
     SecRule RESPONSE_BODY "@rx (?i)Exception (?:condition )?\d+\. Transaction rollback\." \
         "capture,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
 SecRule TX:sql_error_match "@eq 1" \
     "id:951170,\
@@ -215,8 +209,7 @@ SecRule TX:sql_error_match "@eq 1" \
     SecRule RESPONSE_BODY "@rx (?i)org\.hsqldb\.jdbc" \
         "capture,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
 SecRule TX:sql_error_match "@eq 1" \
     "id:951180,\
@@ -240,8 +233,7 @@ SecRule TX:sql_error_match "@eq 1" \
     SecRule RESPONSE_BODY "@rx (?i:An illegal character has been found in the statement|com\.informix\.jdbc|Exception.*Informix)" \
         "capture,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
 
 SecRule TX:sql_error_match "@eq 1" \
@@ -266,8 +258,7 @@ SecRule TX:sql_error_match "@eq 1" \
     SecRule RESPONSE_BODY "@rx (?i:Warning.*ingres_|Ingres SQLSTATE|Ingres\W.*Driver)" \
         "capture,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
 
 SecRule TX:sql_error_match "@eq 1" \
@@ -292,8 +283,7 @@ SecRule TX:sql_error_match "@eq 1" \
     SecRule RESPONSE_BODY "@rx (?i:<b>Warning</b>: ibase_|Unexpected end of command in statement)" \
         "capture,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
 SecRule TX:sql_error_match "@eq 1" \
     "id:951210,\
@@ -317,8 +307,7 @@ SecRule TX:sql_error_match "@eq 1" \
     SecRule RESPONSE_BODY "@rx (?i:SQL error.*POS[0-9]+.*|Warning.*maxdb.*)" \
         "capture,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
 SecRule TX:sql_error_match "@eq 1" \
     "id:951220,\
@@ -342,8 +331,7 @@ SecRule TX:sql_error_match "@eq 1" \
     SecRule RESPONSE_BODY "@rx (?i)(?:System\.Data\.OleDb\.OleDbException|\[Microsoft\]\[ODBC SQL Server Driver\]|\[Macromedia\]\[SQLServer JDBC Driver\]|\[SqlException|System\.Data\.SqlClient\.SqlException|Unclosed quotation mark after the character string|'80040e14'|mssql_query\(\)|Microsoft OLE DB Provider for ODBC Drivers|Microsoft OLE DB Provider for SQL Server|Incorrect syntax near|Sintaxis incorrecta cerca de|Syntax error in string in query expression|Procedure or function .* expects parameter|Unclosed quotation mark before the character string|Syntax error .* in query expression|Data type mismatch in criteria expression\.|ADODB\.Field \(0x800A0BCD\)|the used select statements have different number of columns|OLE DB.*SQL Server|Warning.*mssql_.*|Driver.*SQL[ _-]*Server|SQL Server.*Driver|SQL Server.*[0-9a-fA-F]{8}|Exception.*\WSystem\.Data\.SqlClient\.)" \
         "capture,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
 SecRule TX:sql_error_match "@eq 1" \
     "id:951230,\
@@ -367,8 +355,7 @@ SecRule TX:sql_error_match "@eq 1" \
     SecRule RESPONSE_BODY "@rx (?i)(?:supplied argument is not a valid MySQL|Column count doesn't match value count at row|mysql_fetch_array\(\)|on MySQL result index|You have an error in your SQL syntax;|You have an error in your SQL syntax near|MySQL server version for the right syntax to use|\[MySQL\]\[ODBC|Column count doesn't match|Table '[^']+' doesn't exist|SQL syntax.*MySQL|Warning.*mysql_.*|valid MySQL result|MySqlClient\.|ERROR [0-9]{4} \([A-Z0-9]{5}\):)" \
         "capture,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
 SecRule TX:sql_error_match "@eq 1" \
     "id:951240,\
@@ -392,8 +379,7 @@ SecRule TX:sql_error_match "@eq 1" \
     SecRule RESPONSE_BODY "@rx (?i:PostgreSQL query failed:|pg_query\(\) \[:|pg_exec\(\) \[:|PostgreSQL.{1,20}ERROR|Warning.*\bpg_.*|valid PostgreSQL result|Npgsql\.|PG::[a-zA-Z]*Error|Supplied argument is not a valid PostgreSQL .*? resource|Unable to connect to PostgreSQL server)" \
         "capture,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
 SecRule TX:sql_error_match "@eq 1" \
     "id:951250,\
@@ -417,8 +403,7 @@ SecRule TX:sql_error_match "@eq 1" \
     SecRule RESPONSE_BODY "@rx (?i)(?:Warning.*sqlite_.*|Warning.*SQLite3::|SQLite/JDBCDriver|SQLite\.Exception|System\.Data\.SQLite\.SQLiteException)" \
         "capture,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
 SecRule TX:sql_error_match "@eq 1" \
     "id:951260,\
@@ -442,31 +427,30 @@ SecRule TX:sql_error_match "@eq 1" \
     SecRule RESPONSE_BODY "@rx (?i)(?:Sybase message:|Warning.{2,20}sybase|Sybase.*Server message.*)" \
         "capture,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:951013,phase:3,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:951014,phase:4,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:951013,phase:3,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:951014,phase:4,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
 #
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
-#
-
-
-
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:951015,phase:3,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:951016,phase:4,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
-#
-# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:951017,phase:3,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:951018,phase:4,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:951015,phase:3,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:951016,phase:4,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
 #
-# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
+#
+
+
+
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:951017,phase:3,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:951018,phase:4,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+#
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
 
 

--- a/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
+++ b/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
@@ -14,10 +14,10 @@
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:952011,phase:3,pass,nolog,skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:952012,phase:4,pass,nolog,skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:952011,phase:3,pass,nolog,skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:952012,phase:4,pass,nolog,skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
 #
-# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 #
@@ -42,8 +42,7 @@ SecRule RESPONSE_BODY "@pmFromFile java-code-leakages.data" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
 #
 # -=[ Java Errors ]=-
@@ -69,31 +68,30 @@ SecRule RESPONSE_BODY "@pmFromFile java-errors.data" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:952013,phase:3,pass,nolog,skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:952014,phase:4,pass,nolog,skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:952013,phase:3,pass,nolog,skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:952014,phase:4,pass,nolog,skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
 #
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
-#
-
-
-
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:952015,phase:3,pass,nolog,skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:952016,phase:4,pass,nolog,skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
-#
-# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:952017,phase:3,pass,nolog,skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:952018,phase:4,pass,nolog,skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:952015,phase:3,pass,nolog,skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:952016,phase:4,pass,nolog,skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
 #
-# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
+#
+
+
+
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:952017,phase:3,pass,nolog,skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:952018,phase:4,pass,nolog,skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+#
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
 
 

--- a/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -14,10 +14,10 @@
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:953011,phase:3,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:953012,phase:4,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:953011,phase:3,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:953012,phase:4,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
 #
-# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 #
@@ -42,8 +42,7 @@ SecRule RESPONSE_BODY "@pmFromFile php-errors.data" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
 #
 # -=[ PHP source code leakage ]=-
@@ -69,8 +68,7 @@ SecRule RESPONSE_BODY "@rx (?:\b(?:f(?:tp_(?:nb_)?f?(?:ge|pu)t|get(?:s?s|c)|scan
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
 # Detect the presence of the PHP open tag "<? ", "<?= " or "<?php " in output.
 #
@@ -97,30 +95,29 @@ SecRule RESPONSE_BODY "@rx <\?(?:=|php)?\s+" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:953013,phase:3,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:953014,phase:4,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:953013,phase:3,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:953014,phase:4,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
 #
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
-#
-
-
-
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:953015,phase:3,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:953016,phase:4,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
-#
-# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:953017,phase:3,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:953018,phase:4,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:953015,phase:3,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:953016,phase:4,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
 #
-# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
+#
+
+
+
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:953017,phase:3,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:953018,phase:4,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+#
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
 
 

--- a/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+++ b/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
@@ -14,10 +14,10 @@
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:954011,phase:3,pass,nolog,skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:954012,phase:4,pass,nolog,skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:954011,phase:3,pass,nolog,skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:954012,phase:4,pass,nolog,skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
 #
-# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 # IIS default location
@@ -40,8 +40,7 @@ SecRule RESPONSE_BODY "@rx [a-z]:\x5cinetpub\b" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
 SecRule RESPONSE_BODY "@rx (?:Microsoft OLE DB Provider for SQL Server(?:</font>.{1,20}?error '800(?:04005|40e31)'.{1,40}?Timeout expired| \(0x80040e31\)<br>Timeout expired<br>)|<h1>internal server error</h1>.*?<h2>part of the server has crashed or it has a configuration error\.</h2>|cannot connect to the server: timed out)" \
     "id:954110,\
@@ -63,8 +62,7 @@ SecRule RESPONSE_BODY "@rx (?:Microsoft OLE DB Provider for SQL Server(?:</font>
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
 #
 # IIS Errors leakage
@@ -89,8 +87,7 @@ SecRule RESPONSE_BODY "@rx (?:\b(?:A(?:DODB\.Command\b.{0,100}?\b(?:Application 
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
 
 SecRule RESPONSE_STATUS "!@rx ^404$" \
@@ -117,31 +114,30 @@ SecRule RESPONSE_STATUS "!@rx ^404$" \
         "capture,\
         t:none,\
         ctl:auditLogParts=+E,\
-        setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+        setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:954013,phase:3,pass,nolog,skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:954014,phase:4,pass,nolog,skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:954013,phase:3,pass,nolog,skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:954014,phase:4,pass,nolog,skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
 #
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
-#
-
-
-
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:954015,phase:3,pass,nolog,skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:954016,phase:4,pass,nolog,skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
-#
-# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:954017,phase:3,pass,nolog,skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:954018,phase:4,pass,nolog,skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:954015,phase:3,pass,nolog,skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:954016,phase:4,pass,nolog,skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
 #
-# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
+#
+
+
+
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:954017,phase:3,pass,nolog,skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:954018,phase:4,pass,nolog,skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+#
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
 
 

--- a/rules/RESPONSE-955-WEB-SHELLS.conf
+++ b/rules/RESPONSE-955-WEB-SHELLS.conf
@@ -14,10 +14,10 @@
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:955011,phase:3,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:955012,phase:4,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:955011,phase:3,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:955012,phase:4,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
 #
-# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 # For performance reasons, most of the shells are matched using this rule.
@@ -39,8 +39,7 @@ SecRule RESPONSE_BODY "@pmFromFile web-shells-php.data" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # r57 web shell
 SecRule RESPONSE_BODY "@rx (<title>r57 Shell Version [0-9.]+</title>|<title>r57 shell</title>)" \
@@ -60,8 +59,7 @@ SecRule RESPONSE_BODY "@rx (<title>r57 Shell Version [0-9.]+</title>|<title>r57 
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # WSO web shell
 SecRule RESPONSE_BODY "@rx ^<html><head><meta http-equiv='Content-Type' content='text/html; charset=Windows-1251'><title>.*? - WSO [0-9.]+</title>" \
@@ -81,8 +79,7 @@ SecRule RESPONSE_BODY "@rx ^<html><head><meta http-equiv='Content-Type' content=
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # b4tm4n web shell (https://github.com/k4mpr3t/b4tm4n)
 SecRule RESPONSE_BODY "@rx B4TM4N SH3LL</title>.*<meta name='author' content='k4mpr3t'/>" \
@@ -102,8 +99,7 @@ SecRule RESPONSE_BODY "@rx B4TM4N SH3LL</title>.*<meta name='author' content='k4
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Mini Shell web shell
 SecRule RESPONSE_BODY "@rx <title>Mini Shell</title>.*Developed By LameHacker" \
@@ -123,8 +119,7 @@ SecRule RESPONSE_BODY "@rx <title>Mini Shell</title>.*Developed By LameHacker" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Ashiyane web shell
 SecRule RESPONSE_BODY "@rx <title>\.:: .* ~ Ashiyane V [0-9.]+ ::\.</title>" \
@@ -144,8 +139,7 @@ SecRule RESPONSE_BODY "@rx <title>\.:: .* ~ Ashiyane V [0-9.]+ ::\.</title>" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Symlink_Sa web shell
 SecRule RESPONSE_BODY "@rx <title>Symlink_Sa [0-9.]+</title>" \
@@ -165,8 +159,7 @@ SecRule RESPONSE_BODY "@rx <title>Symlink_Sa [0-9.]+</title>" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # CasuS web shell
 SecRule RESPONSE_BODY "@rx <title>CasuS [0-9.]+ by MafiABoY</title>" \
@@ -186,8 +179,7 @@ SecRule RESPONSE_BODY "@rx <title>CasuS [0-9.]+ by MafiABoY</title>" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # GRP WebShell
 SecRule RESPONSE_BODY "@rx ^<html>\r\n<head>\r\n<title>GRP WebShell [0-9.]+ " \
@@ -207,8 +199,7 @@ SecRule RESPONSE_BODY "@rx ^<html>\r\n<head>\r\n<title>GRP WebShell [0-9.]+ " \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # NGHshell web shell
 SecRule RESPONSE_BODY "@rx <small>NGHshell [0-9.]+ by Cr4sh</body></html>\n$" \
@@ -228,8 +219,7 @@ SecRule RESPONSE_BODY "@rx <small>NGHshell [0-9.]+ by Cr4sh</body></html>\n$" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # SimAttacker web shell
 SecRule RESPONSE_BODY "@rx <title>SimAttacker - (?:Version|Vrsion) : [0-9.]+ - " \
@@ -249,8 +239,7 @@ SecRule RESPONSE_BODY "@rx <title>SimAttacker - (?:Version|Vrsion) : [0-9.]+ - "
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Unknown web shell
 SecRule RESPONSE_BODY "@rx ^<!DOCTYPE html>\n<html>\n<!-- By Artyum .*<title>Web Shell</title>" \
@@ -270,8 +259,7 @@ SecRule RESPONSE_BODY "@rx ^<!DOCTYPE html>\n<html>\n<!-- By Artyum .*<title>Web
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # lama's'hell web shell
 SecRule RESPONSE_BODY "@rx <title>lama's'hell v. [0-9.]+</title>" \
@@ -291,8 +279,7 @@ SecRule RESPONSE_BODY "@rx <title>lama's'hell v. [0-9.]+</title>" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # lostDC web shell
 SecRule RESPONSE_BODY "@rx ^ *<html>\n[ ]+<head>\n[ ]+<title>lostDC - " \
@@ -312,8 +299,7 @@ SecRule RESPONSE_BODY "@rx ^ *<html>\n[ ]+<head>\n[ ]+<title>lostDC - " \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Unknown web shell
 SecRule RESPONSE_BODY "@rx ^<title>PHP Web Shell</title>\r\n<html>\r\n<body>\r\n    <!-- Replaces command with Base64-encoded Data -->" \
@@ -333,8 +319,7 @@ SecRule RESPONSE_BODY "@rx ^<title>PHP Web Shell</title>\r\n<html>\r\n<body>\r\n
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Unknown web shell
 SecRule RESPONSE_BODY "@rx ^<html>\n<head>\n<div align=\"left\"><font size=\"1\">Input command :</font></div>\n<form name=\"cmd\" method=\"POST\" enctype=\"multipart/form-data\">" \
@@ -354,8 +339,7 @@ SecRule RESPONSE_BODY "@rx ^<html>\n<head>\n<div align=\"left\"><font size=\"1\"
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Ru24PostWebShell web shell
 SecRule RESPONSE_BODY "@rx ^<html>\n<head>\n<title>Ru24PostWebShell - " \
@@ -375,8 +359,7 @@ SecRule RESPONSE_BODY "@rx ^<html>\n<head>\n<title>Ru24PostWebShell - " \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # s72 Shell web shell
 SecRule RESPONSE_BODY "@rx <title>s72 Shell v[0-9.]+ Codinf by Cr@zy_King</title>" \
@@ -396,8 +379,7 @@ SecRule RESPONSE_BODY "@rx <title>s72 Shell v[0-9.]+ Codinf by Cr@zy_King</title
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # PhpSpy web shell
 SecRule RESPONSE_BODY "@rx ^<html>\r\n<head>\r\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=gb2312\">\r\n<title>PhpSpy Ver [0-9]+</title>" \
@@ -417,8 +399,7 @@ SecRule RESPONSE_BODY "@rx ^<html>\r\n<head>\r\n<meta http-equiv=\"Content-Type\
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # g00nshell web shell
 SecRule RESPONSE_BODY "@rx ^ <html>\n\n<head>\n\n<title>g00nshell v[0-9.]+ " \
@@ -438,8 +419,7 @@ SecRule RESPONSE_BODY "@rx ^ <html>\n\n<head>\n\n<title>g00nshell v[0-9.]+ " \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # PuNkHoLic shell web shell
 # Various versions has this text written little differently so we need to do
@@ -461,8 +441,7 @@ SecRule RESPONSE_BODY "@contains <title>punkholicshell</title>" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # azrail web shell
 SecRule RESPONSE_BODY "@rx ^<html>\n      <head>\n             <title>azrail [0-9.]+ by C-W-M</title>" \
@@ -482,8 +461,7 @@ SecRule RESPONSE_BODY "@rx ^<html>\n      <head>\n             <title>azrail [0-
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # SmEvK_PaThAn Shell web shell
 SecRule RESPONSE_BODY "@rx >SmEvK_PaThAn Shell v[0-9]+ coded by <a href=" \
@@ -503,8 +481,7 @@ SecRule RESPONSE_BODY "@rx >SmEvK_PaThAn Shell v[0-9]+ coded by <a href=" \
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Shell I web shell
 SecRule RESPONSE_BODY "@rx ^<html>\n<title>.*? ~ Shell I</title>\n<head>\n<style>" \
@@ -524,8 +501,7 @@ SecRule RESPONSE_BODY "@rx ^<html>\n<title>.*? ~ Shell I</title>\n<head>\n<style
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # b374k m1n1 web shell
 SecRule RESPONSE_BODY "@rx ^ <html><head><title>:: b374k m1n1 [0-9.]+ ::</title>" \
@@ -545,15 +521,14 @@ SecRule RESPONSE_BODY "@rx ^ <html><head><title>:: b374k m1n1 [0-9.]+ ::</title>
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:955013,phase:3,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:955014,phase:4,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:955013,phase:3,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:955014,phase:4,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
 #
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 # webadmin.php file manager
@@ -575,21 +550,20 @@ SecRule RESPONSE_BODY "@contains <h1 style=\"margin-bottom: 0\">webadmin.php</h1
     ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.outbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.outbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:955015,phase:3,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:955016,phase:4,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:955015,phase:3,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:955016,phase:4,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
 #
-# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:955017,phase:3,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:955018,phase:4,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:955017,phase:3,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:955018,phase:4,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
 #
-# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
 
 

--- a/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
+++ b/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
@@ -23,164 +23,204 @@
 #
 
 
-# Skipping early blocking
+# Summing up the blocking and detection anomaly scores in phase 3
+# even when early blocking is disabled, we need to sum up the scores in phase 3
+# this prevents bugs in phase 5 if Apache skips phases because of error handling
+# See: https://github.com/coreruleset/coreruleset/issues/2319#issuecomment-1047503932
 
-SecRule TX:EARLY_BLOCKING "!@eq 1" \
-    "id:959050,\
-    phase:3,\
-    pass,\
-    t:none,\
-    nolog,\
-    skipAfter:EARLY_BLOCKING_ANOMALY_SCORING"
-
-SecRule TX:EARLY_BLOCKING "!@eq 1" \
-    "id:959051,\
-    phase:4,\
-    pass,\
-    t:none,\
-    nolog,\
-    skipAfter:EARLY_BLOCKING_ANOMALY_SCORING"
-
-# Summing up the anomaly score for early blocking
-
-SecRule TX:PARANOIA_LEVEL "@ge 1" \
+SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 1" \
     "id:959052,\
     phase:3,\
     pass,\
     t:none,\
     nolog,\
-    setvar:'tx.outbound_anomaly_score=+%{tx.anomaly_score_pl1}'"
+    setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl1}'"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 1" \
+    "id:959152,\
+    phase:3,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl1}'"
 
-SecRule TX:PARANOIA_LEVEL "@ge 2" \
+SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
     "id:959053,\
     phase:3,\
     pass,\
     t:none,\
     nolog,\
-    setvar:'tx.outbound_anomaly_score=+%{tx.anomaly_score_pl2}'"
+    setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl2}'"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 2" \
+    "id:959153,\
+    phase:3,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl2}'"
 
-SecRule TX:PARANOIA_LEVEL "@ge 3" \
+SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
     "id:959054,\
     phase:3,\
     pass,\
     t:none,\
     nolog,\
-    setvar:'tx.outbound_anomaly_score=+%{tx.anomaly_score_pl3}'"
+    setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl3}'"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 3" \
+    "id:959154,\
+    phase:3,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl3}'"
 
-SecRule TX:PARANOIA_LEVEL "@ge 4" \
+SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
     "id:959055,\
     phase:3,\
     pass,\
     t:none,\
     nolog,\
-    setvar:'tx.outbound_anomaly_score=+%{tx.anomaly_score_pl4}'"
+    setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl4}'"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
+    "id:959155,\
+    phase:3,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl4}'"
 
+# at start of phase 4, we reset the aggregate scores to 0 to prevent duplicate counting of per-PL scores
+# this is necessary because the per-PL scores are counted across phases
 SecAction "id:959059,\
     phase:4,\
     pass,\
     t:none,\
     nolog,\
-    setvar:'tx.outbound_anomaly_score=0'"
+    setvar:'tx.blocking_outbound_anomaly_score=0'"
+SecAction "id:959159,\
+    phase:4,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.detection_outbound_anomaly_score=0'"
 
 SecMarker "EARLY_BLOCKING_ANOMALY_SCORING"
 
-# NOTE: tx.anomaly_score should not be set initially, but masking would lead to difficult bugs.
-# So we add to it.
-SecRule TX:PARANOIA_LEVEL "@ge 1" \
+# Summing up the blocking and detection anomaly scores in phase 4
+
+SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 1" \
     "id:959060,\
     phase:4,\
     pass,\
     t:none,\
     nolog,\
-    setvar:'tx.outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl1}'"
+    setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl1}'"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 1" \
+    "id:959160,\
+    phase:4,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl1}'"
 
-SecRule TX:PARANOIA_LEVEL "@ge 2" \
+SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
     "id:959061,\
     phase:4,\
     pass,\
     t:none,\
     nolog,\
-    setvar:'tx.outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl2}'"
+    setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl2}'"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 2" \
+    "id:959161,\
+    phase:4,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl2}'"
 
-SecRule TX:PARANOIA_LEVEL "@ge 3" \
+SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
     "id:959062,\
     phase:4,\
     pass,\
     t:none,\
     nolog,\
-    setvar:'tx.outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl3}'"
+    setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl3}'"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 3" \
+    "id:959162,\
+    phase:4,\
+    pass,\
+    t:none,\
+    nolog,\
+    setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl3}'"
 
-SecRule TX:PARANOIA_LEVEL "@ge 4" \
+SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
     "id:959063,\
     phase:4,\
     pass,\
     t:none,\
     nolog,\
-    setvar:'tx.outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl4}'"
-
-
-# Alert and Block on High Anomaly Scores - this would block outbound data leakages
-#
-# Note: This rule also sets the 'tx.anomaly_score' variable.
-# That variable name was formerly used in CRS, but not any longer.
-# However, Jwall AuditConsole depends on this exact variable name.
-# Without setting it, the 'Outbound Score' in the AuditConsole GUI would always be 0.
-
-SecRule TX:OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
-    "id:959100,\
+    setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl4}'"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
+    "id:959163,\
     phase:4,\
-    deny,\
+    pass,\
     t:none,\
-    msg:'Outbound Anomaly Score Exceeded (Total Score: %{TX.OUTBOUND_ANOMALY_SCORE})',\
-    tag:'anomaly-evaluation',\
-    ver:'OWASP_CRS/3.4.0-dev',\
-    setvar:'tx.anomaly_score=+%{tx.outbound_anomaly_score}'"
+    nolog,\
+    setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl4}'"
 
-SecRule TX:EARLY_BLOCKING "@eq 1" \
+#
+# -=[ Anomaly Mode: Overall Transaction Anomaly Score ]=-
+#
+
+# if early blocking is active, check threshold in phase 3
+SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
     "id:959101,\
     phase:3,\
     deny,\
     t:none,\
-    msg:'Outbound Anomaly Score Exceeded in phase 3 (Total Score: %{TX.OUTBOUND_ANOMALY_SCORE})',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-multi',\
-    tag:'attack-generic',\
+    msg:'Outbound Anomaly Score Exceeded in phase 3 (Total Score: %{tx.blocking_outbound_anomaly_score})',\
+    tag:'anomaly-evaluation',\
     ver:'OWASP_CRS/3.4.0-dev',\
-    severity:'CRITICAL',\
     chain"
-    SecRule TX:OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
-        "setvar:'tx.anomaly_score=%{tx.outbound_anomaly_score}'"
+    SecRule TX:EARLY_BLOCKING "@eq 1"
 
+# always check threshold in phase 4
+SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
+    "id:959100,\
+    phase:4,\
+    deny,\
+    t:none,\
+    msg:'Outbound Anomaly Score Exceeded (Total Score: %{tx.blocking_outbound_anomaly_score})',\
+    tag:'anomaly-evaluation',\
+    ver:'OWASP_CRS/3.4.0-dev'"
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:959011,phase:3,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:959012,phase:4,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:959011,phase:3,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:959012,phase:4,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
 #
-# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
-#
-
-
-
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:959013,phase:3,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:959014,phase:4,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-#
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
-#
-
-
-
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:959015,phase:3,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:959016,phase:4,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-#
-# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:959017,phase:3,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:959018,phase:4,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:959013,phase:3,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:959014,phase:4,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
 #
-# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
+#
+
+
+
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:959015,phase:3,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:959016,phase:4,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+#
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
+#
+
+
+
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:959017,phase:3,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:959018,phase:4,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+#
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
 
 

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -65,9 +65,42 @@ SecRule &TX:'/AVAILABILITY\\\/APP_NOT_AVAIL/' "@ge 1" \
     chain"
     SecRule &TX:'/WEB_ATTACK/' "@ge 1" "t:none"
 
+SecMarker "END-CORRELATION"
 
 #
 # -=[ Anomaly Score Reporting ]=-
+#
+
+SecRule TX:REPORTING_LEVEL "@lt 1" "id:980201,phase:1,pass,nolog,skipAfter:END-REPORTING"
+#
+# -= Reporting Level 1 =- (apply only when tx.reporting_level is sufficiently high: 1 or higher)
+#
+
+# inbound - blocked
+SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
+    "id:980130,\
+    phase:5,\
+    pass,\
+    t:none,\
+    noauditlog,\
+    msg:'Inbound Anomaly Score Exceeded (Total Inbound Score (blocking/detection): %{tx.blocking_inbound_anomaly_score}/%{tx.detection_inbound_anomaly_score} - SQLI=%{tx.sql_injection_score},XSS=%{tx.xss_score},RFI=%{tx.rfi_score},LFI=%{tx.lfi_score},RCE=%{tx.rce_score},PHPI=%{tx.php_injection_score},HTTP=%{tx.http_violation_score},SESS=%{tx.session_fixation_score}): individual paranoia level scores: %{tx.inbound_anomaly_score_pl1}, %{tx.inbound_anomaly_score_pl2}, %{tx.inbound_anomaly_score_pl3}, %{tx.inbound_anomaly_score_pl4}',\
+    tag:'reporting',\
+    ver:'OWASP_CRS/3.4.0-dev'"
+
+# outbound - blocked
+SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
+    "id:980140,\
+    phase:5,\
+    pass,\
+    t:none,\
+    noauditlog,\
+    msg:'Outbound Anomaly Score Exceeded (Total Outbound Score (blocking/detection): %{tx.blocking_outbound_anomaly_score}/%{tx.detection_outbound_anomaly_score} - SQLI=%{tx.sql_injection_score},XSS=%{tx.xss_score},RFI=%{tx.rfi_score},LFI=%{tx.lfi_score},RCE=%{tx.rce_score},PHPI=%{tx.php_injection_score},HTTP=%{tx.http_violation_score},SESS=%{tx.session_fixation_score}): individual paranoia level scores: %{tx.outbound_anomaly_score_pl1}, %{tx.outbound_anomaly_score_pl2}, %{tx.outbound_anomaly_score_pl3}, %{tx.outbound_anomaly_score_pl4}',\
+    tag:'reporting',\
+    ver:'OWASP_CRS/3.4.0-dev'"
+
+SecRule TX:REPORTING_LEVEL "@lt 2" "id:980202,phase:5,pass,nolog,skipAfter:END-REPORTING"
+#
+# -= Reporting Level 2 =- (apply only when tx.reporting_level is sufficiently high: 2 or higher)
 #
 
 # inbound - scored but not blocked
@@ -83,17 +116,6 @@ SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@lt %{tx.inbound_anomaly_score_thresh
     chain"
     SecRule TX:DETECTION_INBOUND_ANOMALY_SCORE "@gt 0"
 
-# inbound - blocked
-SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
-    "id:980130,\
-    phase:5,\
-    pass,\
-    t:none,\
-    noauditlog,\
-    msg:'Inbound Anomaly Score Exceeded (Total Inbound Score (blocking/detection): %{tx.blocking_inbound_anomaly_score}/%{tx.detection_inbound_anomaly_score} - SQLI=%{tx.sql_injection_score},XSS=%{tx.xss_score},RFI=%{tx.rfi_score},LFI=%{tx.lfi_score},RCE=%{tx.rce_score},PHPI=%{tx.php_injection_score},HTTP=%{tx.http_violation_score},SESS=%{tx.session_fixation_score}): individual paranoia level scores: %{tx.inbound_anomaly_score_pl1}, %{tx.inbound_anomaly_score_pl2}, %{tx.inbound_anomaly_score_pl3}, %{tx.inbound_anomaly_score_pl4}',\
-    tag:'reporting',\
-    ver:'OWASP_CRS/3.4.0-dev'"
-
 # outbound - scored but not blocked
 SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@lt %{tx.outbound_anomaly_score_threshold}" \
     "id:980150,\
@@ -107,18 +129,34 @@ SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@lt %{tx.outbound_anomaly_score_thre
     chain"
     SecRule TX:DETECTION_OUTBOUND_ANOMALY_SCORE "@gt 0"
 
-# outbound - blocked
-SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
-    "id:980140,\
+SecRule TX:REPORTING_LEVEL "@lt 3" "id:980203,phase:5,pass,nolog,skipAfter:END-REPORTING"
+#
+# -= Reporting Level 3 =- (apply only when tx.reporting_level is sufficiently high: 3 or higher)
+#
+
+# inbound - any
+SecAction \
+    "id:980160,\
     phase:5,\
     pass,\
     t:none,\
     noauditlog,\
-    msg:'Outbound Anomaly Score Exceeded (Total Outbound Score (blocking/detection): %{tx.blocking_outbound_anomaly_score}/%{tx.detection_outbound_anomaly_score} - SQLI=%{tx.sql_injection_score},XSS=%{tx.xss_score},RFI=%{tx.rfi_score},LFI=%{tx.lfi_score},RCE=%{tx.rce_score},PHPI=%{tx.php_injection_score},HTTP=%{tx.http_violation_score},SESS=%{tx.session_fixation_score}): individual paranoia level scores: %{tx.outbound_anomaly_score_pl1}, %{tx.outbound_anomaly_score_pl2}, %{tx.outbound_anomaly_score_pl3}, %{tx.outbound_anomaly_score_pl4}',\
+    msg:'Inbound Anomaly Score (Total Inbound Score (blocking/detection): %{tx.blocking_inbound_anomaly_score}/%{tx.detection_inbound_anomaly_score} - SQLI=%{tx.sql_injection_score},XSS=%{tx.xss_score},RFI=%{tx.rfi_score},LFI=%{tx.lfi_score},RCE=%{tx.rce_score},PHPI=%{tx.php_injection_score},HTTP=%{tx.http_violation_score},SESS=%{tx.session_fixation_score}): individual paranoia level scores: %{tx.inbound_anomaly_score_pl1}, %{tx.inbound_anomaly_score_pl2}, %{tx.inbound_anomaly_score_pl3}, %{tx.inbound_anomaly_score_pl4}',\
     tag:'reporting',\
     ver:'OWASP_CRS/3.4.0-dev'"
 
-SecMarker "END-CORRELATION"
+# outbound - any
+SecAction \
+    "id:980170,\
+    phase:5,\
+    pass,\
+    t:none,\
+    noauditlog,\
+    msg:'Outbound Anomaly Score (Total Outbound Score (blocking/detection): %{tx.blocking_outbound_anomaly_score}/%{tx.detection_outbound_anomaly_score} - SQLI=%{tx.sql_injection_score},XSS=%{tx.xss_score},RFI=%{tx.rfi_score},LFI=%{tx.lfi_score},RCE=%{tx.rce_score},PHPI=%{tx.php_injection_score},HTTP=%{tx.http_violation_score},SESS=%{tx.session_fixation_score}): individual paranoia level scores: %{tx.outbound_anomaly_score_pl1}, %{tx.outbound_anomaly_score_pl2}, %{tx.outbound_anomaly_score_pl3}, %{tx.outbound_anomaly_score_pl4}',\
+    tag:'reporting',\
+    ver:'OWASP_CRS/3.4.0-dev'"
+
+SecMarker "END-REPORTING"
 
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:980011,phase:1,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -19,6 +19,22 @@
 # -= Paranoia Level 0 (empty) =- (apply unconditionally)
 #
 
+# combine inbound and outbound scores
+SecAction \
+    "id:980099,\
+    phase:5,\
+    pass,\
+    t:none,\
+    nolog,\
+    noauditlog,\
+    ver:'OWASP_CRS/3.4.0-dev',\
+    setvar:'tx.blocking_anomaly_score=%{tx.blocking_inbound_anomaly_score}',\
+    setvar:'tx.blocking_anomaly_score=+%{tx.blocking_outbound_anomaly_score}',\
+    setvar:'tx.detection_anomaly_score=%{tx.detection_inbound_anomaly_score}',\
+    setvar:'tx.detection_anomaly_score=+%{tx.detection_outbound_anomaly_score}',\
+    setvar:'tx.anomaly_score=%{tx.blocking_inbound_anomaly_score}',\
+    setvar:'tx.anomaly_score=+%{tx.blocking_outbound_anomaly_score}'"
+
 #
 # -=[ Correlated Successful Attack ]=-
 #
@@ -27,12 +43,11 @@ SecRule &TX:'/LEAKAGE\\\/ERRORS/' "@ge 1" \
     phase:5,\
     pass,\
     t:none,\
-    msg:'Correlated Successful Attack Identified: (Total Score: %{tx.anomaly_score}) Inbound Attack (Inbound Anomaly Score: %{TX.INBOUND_ANOMALY_SCORE}) + Outbound Data Leakage (Outbound Anomaly Score: %{TX.OUTBOUND_ANOMALY_SCORE})',\
+    msg:'Correlated Successful Attack Identified: (Total Score (blocking/detection): %{tx.blocking_anomaly_score}/%{tx.detection_anomaly_score}) = Inbound Attack (Inbound Anomaly Score (blocking/detection): %{tx.blocking_inbound_anomaly_score}/%{tx.detection_inbound_anomaly_score}) + Outbound Data Leakage (Outbound Anomaly Score (blocking/detection): %{tx.blocking_outbound_anomaly_score}/%{tx.detection_outbound_anomaly_score})',\
     tag:'event-correlation',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'EMERGENCY',\
-    chain,\
-    skipAfter:END-CORRELATION"
+    chain"
     SecRule &TX:'/WEB_ATTACK/' "@ge 1" "t:none"
 
 #
@@ -43,117 +58,97 @@ SecRule &TX:'/AVAILABILITY\\\/APP_NOT_AVAIL/' "@ge 1" \
     phase:5,\
     pass,\
     t:none,\
-    msg:'Correlated Attack Attempt Identified: (Total Score: %{tx.anomaly_score}) Inbound Attack (Inbound Anomaly Score: %{TX.INBOUND_ANOMALY_SCORE}) + Outbound Application Error (Outbound Anomaly Score: %{TX.OUTBOUND_ANOMALY_SCORE})',\
+    msg:'Correlated Attack Attempt Identified: (Total Score (blocking/detection): %{tx.blocking_anomaly_score}/%{tx.detection_anomaly_score}) = Inbound Attack (Inbound Anomaly Score (blocking/detection): %{tx.blocking_inbound_anomaly_score}/%{tx.detection_inbound_anomaly_score}) + Outbound Data Leakage (Outbound Anomaly Score (blocking/detection): %{tx.blocking_outbound_anomaly_score}/%{tx.detection_outbound_anomaly_score})',\
     tag:'event-correlation',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'ALERT',\
-    chain,\
-    skipAfter:END-CORRELATION"
+    chain"
     SecRule &TX:'/WEB_ATTACK/' "@ge 1" "t:none"
 
-# Creating a total sum of all triggered inbound rules, including the ones only being monitored
-SecAction \
-    "id:980115,\
-    phase:5,\
-    pass,\
-    t:none,\
-    nolog,\
-    noauditlog,\
-    ver:'OWASP_CRS/3.4.0-dev',\
-    setvar:'tx.executing_anomaly_score=%{tx.anomaly_score_pl1}',\
-    setvar:'tx.executing_anomaly_score=+%{tx.anomaly_score_pl2}',\
-    setvar:'tx.executing_anomaly_score=+%{tx.anomaly_score_pl3}',\
-    setvar:'tx.executing_anomaly_score=+%{tx.anomaly_score_pl4}'"
 
-SecRule TX:INBOUND_ANOMALY_SCORE "@lt %{tx.inbound_anomaly_score_threshold}" \
+#
+# -=[ Anomaly Score Reporting ]=-
+#
+
+# inbound - scored but not blocked
+SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@lt %{tx.inbound_anomaly_score_threshold}" \
     "id:980120,\
     phase:5,\
     pass,\
     t:none,\
     noauditlog,\
-    msg:'Inbound Anomaly Score (Total Inbound Score: %{TX.INBOUND_ANOMALY_SCORE} - SQLI=%{tx.sql_injection_score},XSS=%{tx.xss_score},RFI=%{tx.rfi_score},LFI=%{tx.lfi_score},RCE=%{tx.rce_score},PHPI=%{tx.php_injection_score},HTTP=%{tx.http_violation_score},SESS=%{tx.session_fixation_score}): individual paranoia level scores: %{TX.ANOMALY_SCORE_PL1}, %{TX.ANOMALY_SCORE_PL2}, %{TX.ANOMALY_SCORE_PL3}, %{TX.ANOMALY_SCORE_PL4}',\
-    tag:'event-correlation',\
+    msg:'Inbound Anomaly Score below threshold (Total Inbound Score (blocking/detection): %{tx.blocking_inbound_anomaly_score}/%{tx.detection_inbound_anomaly_score} - SQLI=%{tx.sql_injection_score},XSS=%{tx.xss_score},RFI=%{tx.rfi_score},LFI=%{tx.lfi_score},RCE=%{tx.rce_score},PHPI=%{tx.php_injection_score},HTTP=%{tx.http_violation_score},SESS=%{tx.session_fixation_score}): individual paranoia level scores: %{tx.inbound_anomaly_score_pl1}, %{tx.inbound_anomaly_score_pl2}, %{tx.inbound_anomaly_score_pl3}, %{tx.inbound_anomaly_score_pl4}',\
+    tag:'reporting',\
     ver:'OWASP_CRS/3.4.0-dev',\
     chain"
-    SecRule TX:EXECUTING_ANOMALY_SCORE "@gt 1"
+    SecRule TX:DETECTION_INBOUND_ANOMALY_SCORE "@gt 0"
 
-SecRule TX:INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
+# inbound - blocked
+SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
     "id:980130,\
     phase:5,\
     pass,\
     t:none,\
     noauditlog,\
-    msg:'Inbound Anomaly Score Exceeded (Total Inbound Score: %{TX.INBOUND_ANOMALY_SCORE} - SQLI=%{tx.sql_injection_score},XSS=%{tx.xss_score},RFI=%{tx.rfi_score},LFI=%{tx.lfi_score},RCE=%{tx.rce_score},PHPI=%{tx.php_injection_score},HTTP=%{tx.http_violation_score},SESS=%{tx.session_fixation_score}): individual paranoia level scores: %{TX.ANOMALY_SCORE_PL1}, %{TX.ANOMALY_SCORE_PL2}, %{TX.ANOMALY_SCORE_PL3}, %{TX.ANOMALY_SCORE_PL4}',\
-    tag:'event-correlation',\
+    msg:'Inbound Anomaly Score Exceeded (Total Inbound Score (blocking/detection): %{tx.blocking_inbound_anomaly_score}/%{tx.detection_inbound_anomaly_score} - SQLI=%{tx.sql_injection_score},XSS=%{tx.xss_score},RFI=%{tx.rfi_score},LFI=%{tx.lfi_score},RCE=%{tx.rce_score},PHPI=%{tx.php_injection_score},HTTP=%{tx.http_violation_score},SESS=%{tx.session_fixation_score}): individual paranoia level scores: %{tx.inbound_anomaly_score_pl1}, %{tx.inbound_anomaly_score_pl2}, %{tx.inbound_anomaly_score_pl3}, %{tx.inbound_anomaly_score_pl4}',\
+    tag:'reporting',\
     ver:'OWASP_CRS/3.4.0-dev'"
 
-SecRule TX:OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
-    "id:980140,\
-    phase:5,\
-    pass,\
-    t:none,\
-    noauditlog,\
-    msg:'Outbound Anomaly Score Exceeded (score %{TX.OUTBOUND_ANOMALY_SCORE}): individual paranoia level scores: %{TX.OUTBOUND_ANOMALY_SCORE_PL1}, %{TX.OUTBOUND_ANOMALY_SCORE_PL2}, %{TX.OUTBOUND_ANOMALY_SCORE_PL3}, %{TX.OUTBOUND_ANOMALY_SCORE_PL4}',\
-    tag:'event-correlation',\
-    ver:'OWASP_CRS/3.4.0-dev'"
-
-# Creating a total sum of all triggered outbound rules, including the ones only being monitored
-SecAction \
-    "id:980145,\
-    phase:5,\
-    pass,\
-    t:none,\
-    nolog,\
-    noauditlog,\
-    ver:'OWASP_CRS/3.4.0-dev',\
-    setvar:'tx.executing_anomaly_score=%{tx.outbound_anomaly_score_pl1}',\
-    setvar:'tx.executing_anomaly_score=+%{tx.outbound_anomaly_score_pl2}',\
-    setvar:'tx.executing_anomaly_score=+%{tx.outbound_anomaly_score_pl3}',\
-    setvar:'tx.executing_anomaly_score=+%{tx.outbound_anomaly_score_pl4}'"
-
-SecRule TX:OUTBOUND_ANOMALY_SCORE "@lt %{tx.outbound_anomaly_score_threshold}" \
+# outbound - scored but not blocked
+SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@lt %{tx.outbound_anomaly_score_threshold}" \
     "id:980150,\
     phase:5,\
     pass,\
     t:none,\
     noauditlog,\
-    msg:'Outbound Anomaly Score (Total Outbound Score: %{TX.OUTBOUND_ANOMALY_SCORE}): individual paranoia level scores: %{TX.OUTBOUND_ANOMALY_SCORE_PL1}, %{TX.OUTBOUND_ANOMALY_SCORE_PL2}, %{TX.OUTBOUND_ANOMALY_SCORE_PL3}, %{TX.OUTBOUND_ANOMALY_SCORE_PL4}',\
-    tag:'event-correlation',\
+    msg:'Outbound Anomaly Score below threshold (Total Outbound Score (blocking/detection): %{tx.blocking_outbound_anomaly_score}/%{tx.detection_outbound_anomaly_score} - SQLI=%{tx.sql_injection_score},XSS=%{tx.xss_score},RFI=%{tx.rfi_score},LFI=%{tx.lfi_score},RCE=%{tx.rce_score},PHPI=%{tx.php_injection_score},HTTP=%{tx.http_violation_score},SESS=%{tx.session_fixation_score}): individual paranoia level scores: %{tx.outbound_anomaly_score_pl1}, %{tx.outbound_anomaly_score_pl2}, %{tx.outbound_anomaly_score_pl3}, %{tx.outbound_anomaly_score_pl4}',\
+    tag:'reporting',\
     ver:'OWASP_CRS/3.4.0-dev',\
     chain"
-    SecRule TX:EXECUTING_ANOMALY_SCORE "@gt 1"
+    SecRule TX:DETECTION_OUTBOUND_ANOMALY_SCORE "@gt 0"
+
+# outbound - blocked
+SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
+    "id:980140,\
+    phase:5,\
+    pass,\
+    t:none,\
+    noauditlog,\
+    msg:'Outbound Anomaly Score Exceeded (Total Outbound Score (blocking/detection): %{tx.blocking_outbound_anomaly_score}/%{tx.detection_outbound_anomaly_score} - SQLI=%{tx.sql_injection_score},XSS=%{tx.xss_score},RFI=%{tx.rfi_score},LFI=%{tx.lfi_score},RCE=%{tx.rce_score},PHPI=%{tx.php_injection_score},HTTP=%{tx.http_violation_score},SESS=%{tx.session_fixation_score}): individual paranoia level scores: %{tx.outbound_anomaly_score_pl1}, %{tx.outbound_anomaly_score_pl2}, %{tx.outbound_anomaly_score_pl3}, %{tx.outbound_anomaly_score_pl4}',\
+    tag:'reporting',\
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 SecMarker "END-CORRELATION"
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:980011,phase:1,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:980012,phase:2,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:980011,phase:1,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:980012,phase:2,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"
 #
-# -= Paranoia Level 1 (default) =- (apply only when tx.executing_paranoia_level is sufficiently high: 1 or higher)
-#
-
-
-
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:980013,phase:1,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:980014,phase:2,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"
-#
-# -= Paranoia Level 2 =- (apply only when tx.executing_paranoia_level is sufficiently high: 2 or higher)
+# -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:980015,phase:1,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 3" "id:980016,phase:2,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:980013,phase:1,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:980014,phase:2,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"
 #
-# -= Paranoia Level 3 =- (apply only when tx.executing_paranoia_level is sufficiently high: 3 or higher)
+# -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:980017,phase:1,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"
-SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 4" "id:980018,phase:2,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:980015,phase:1,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:980016,phase:2,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"
 #
-# -= Paranoia Level 4 =- (apply only when tx.executing_paranoia_level is sufficiently high: 4 or higher)
+# -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
+#
+
+
+
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:980017,phase:1,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:980018,phase:2,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"
+#
+# -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
 
 

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -19,54 +19,6 @@
 # -= Paranoia Level 0 (empty) =- (apply unconditionally)
 #
 
-# combine inbound and outbound scores
-SecAction \
-    "id:980099,\
-    phase:5,\
-    pass,\
-    t:none,\
-    nolog,\
-    noauditlog,\
-    ver:'OWASP_CRS/3.4.0-dev',\
-    setvar:'tx.blocking_anomaly_score=%{tx.blocking_inbound_anomaly_score}',\
-    setvar:'tx.blocking_anomaly_score=+%{tx.blocking_outbound_anomaly_score}',\
-    setvar:'tx.detection_anomaly_score=%{tx.detection_inbound_anomaly_score}',\
-    setvar:'tx.detection_anomaly_score=+%{tx.detection_outbound_anomaly_score}',\
-    setvar:'tx.anomaly_score=%{tx.blocking_inbound_anomaly_score}',\
-    setvar:'tx.anomaly_score=+%{tx.blocking_outbound_anomaly_score}'"
-
-#
-# -=[ Correlated Successful Attack ]=-
-#
-SecRule &TX:'/LEAKAGE\\\/ERRORS/' "@ge 1" \
-    "id:980100,\
-    phase:5,\
-    pass,\
-    t:none,\
-    msg:'Correlated Successful Attack Identified: (Total Score (blocking/detection): %{tx.blocking_anomaly_score}/%{tx.detection_anomaly_score}) = Inbound Attack (Inbound Anomaly Score (blocking/detection): %{tx.blocking_inbound_anomaly_score}/%{tx.detection_inbound_anomaly_score}) + Outbound Data Leakage (Outbound Anomaly Score (blocking/detection): %{tx.blocking_outbound_anomaly_score}/%{tx.detection_outbound_anomaly_score})',\
-    tag:'event-correlation',\
-    ver:'OWASP_CRS/3.4.0-dev',\
-    severity:'EMERGENCY',\
-    chain"
-    SecRule &TX:'/WEB_ATTACK/' "@ge 1" "t:none"
-
-#
-# -=[ Correlated Attack Attempt ]=-
-#
-SecRule &TX:'/AVAILABILITY\\\/APP_NOT_AVAIL/' "@ge 1" \
-    "id:980110,\
-    phase:5,\
-    pass,\
-    t:none,\
-    msg:'Correlated Attack Attempt Identified: (Total Score (blocking/detection): %{tx.blocking_anomaly_score}/%{tx.detection_anomaly_score}) = Inbound Attack (Inbound Anomaly Score (blocking/detection): %{tx.blocking_inbound_anomaly_score}/%{tx.detection_inbound_anomaly_score}) + Outbound Data Leakage (Outbound Anomaly Score (blocking/detection): %{tx.blocking_outbound_anomaly_score}/%{tx.detection_outbound_anomaly_score})',\
-    tag:'event-correlation',\
-    ver:'OWASP_CRS/3.4.0-dev',\
-    severity:'ALERT',\
-    chain"
-    SecRule &TX:'/WEB_ATTACK/' "@ge 1" "t:none"
-
-SecMarker "END-CORRELATION"
-
 #
 # -=[ Anomaly Score Reporting ]=-
 #

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -71,7 +71,7 @@ SecMarker "END-CORRELATION"
 # -=[ Anomaly Score Reporting ]=-
 #
 
-SecRule TX:REPORTING_LEVEL "@lt 1" "id:980201,phase:5,pass,nolog,skipAfter:END-REPORTING"
+SecRule TX:REPORTING_LEVEL "@lt 1" "id:980041,phase:5,pass,nolog,skipAfter:END-REPORTING"
 #
 # -= Reporting Level 1 =- (apply only when tx.reporting_level is sufficiently high: 1 or higher)
 #
@@ -98,7 +98,7 @@ SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_thre
     tag:'reporting',\
     ver:'OWASP_CRS/3.4.0-dev'"
 
-SecRule TX:REPORTING_LEVEL "@lt 2" "id:980202,phase:5,pass,nolog,skipAfter:END-REPORTING"
+SecRule TX:REPORTING_LEVEL "@lt 2" "id:980042,phase:5,pass,nolog,skipAfter:END-REPORTING"
 #
 # -= Reporting Level 2 =- (apply only when tx.reporting_level is sufficiently high: 2 or higher)
 #
@@ -129,7 +129,7 @@ SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@lt %{tx.outbound_anomaly_score_thre
     chain"
     SecRule TX:DETECTION_OUTBOUND_ANOMALY_SCORE "@gt 0"
 
-SecRule TX:REPORTING_LEVEL "@lt 3" "id:980203,phase:5,pass,nolog,skipAfter:END-REPORTING"
+SecRule TX:REPORTING_LEVEL "@lt 3" "id:980043,phase:5,pass,nolog,skipAfter:END-REPORTING"
 #
 # -= Reporting Level 3 =- (apply only when tx.reporting_level is sufficiently high: 3 or higher)
 #

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -134,25 +134,14 @@ SecRule TX:REPORTING_LEVEL "@lt 3" "id:980043,phase:5,pass,nolog,skipAfter:END-R
 # -= Reporting Level 3 =- (apply only when tx.reporting_level is sufficiently high: 3 or higher)
 #
 
-# inbound - any
+# inbound and outbound - all requests
 SecAction \
     "id:980160,\
     phase:5,\
     pass,\
     t:none,\
     noauditlog,\
-    msg:'Inbound Anomaly Score (Total Inbound Score (blocking/detection): %{tx.blocking_inbound_anomaly_score}/%{tx.detection_inbound_anomaly_score} - SQLI=%{tx.sql_injection_score},XSS=%{tx.xss_score},RFI=%{tx.rfi_score},LFI=%{tx.lfi_score},RCE=%{tx.rce_score},PHPI=%{tx.php_injection_score},HTTP=%{tx.http_violation_score},SESS=%{tx.session_fixation_score}): individual paranoia level scores: %{tx.inbound_anomaly_score_pl1}, %{tx.inbound_anomaly_score_pl2}, %{tx.inbound_anomaly_score_pl3}, %{tx.inbound_anomaly_score_pl4}',\
-    tag:'reporting',\
-    ver:'OWASP_CRS/3.4.0-dev'"
-
-# outbound - any
-SecAction \
-    "id:980170,\
-    phase:5,\
-    pass,\
-    t:none,\
-    noauditlog,\
-    msg:'Outbound Anomaly Score (Total Outbound Score (blocking/detection): %{tx.blocking_outbound_anomaly_score}/%{tx.detection_outbound_anomaly_score} - SQLI=%{tx.sql_injection_score},XSS=%{tx.xss_score},RFI=%{tx.rfi_score},LFI=%{tx.lfi_score},RCE=%{tx.rce_score},PHPI=%{tx.php_injection_score},HTTP=%{tx.http_violation_score},SESS=%{tx.session_fixation_score}): individual paranoia level scores: %{tx.outbound_anomaly_score_pl1}, %{tx.outbound_anomaly_score_pl2}, %{tx.outbound_anomaly_score_pl3}, %{tx.outbound_anomaly_score_pl4}',\
+    msg:'Anomaly Scores (Total Inbound Score (blocking/detection): %{tx.blocking_inbound_anomaly_score}/%{tx.detection_inbound_anomaly_score} - Total Outbound Score (blocking/detection): %{tx.blocking_outbound_anomaly_score}/%{tx.detection_outbound_anomaly_score} - SQLI=%{tx.sql_injection_score},XSS=%{tx.xss_score},RFI=%{tx.rfi_score},LFI=%{tx.lfi_score},RCE=%{tx.rce_score},PHPI=%{tx.php_injection_score},HTTP=%{tx.http_violation_score},SESS=%{tx.session_fixation_score}): individual paranoia level scores: %{tx.inbound_anomaly_score_pl1}, %{tx.inbound_anomaly_score_pl2}, %{tx.inbound_anomaly_score_pl3}, %{tx.inbound_anomaly_score_pl4}',\
     tag:'reporting',\
     ver:'OWASP_CRS/3.4.0-dev'"
 

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -71,7 +71,7 @@ SecMarker "END-CORRELATION"
 # -=[ Anomaly Score Reporting ]=-
 #
 
-SecRule TX:REPORTING_LEVEL "@lt 1" "id:980201,phase:1,pass,nolog,skipAfter:END-REPORTING"
+SecRule TX:REPORTING_LEVEL "@lt 1" "id:980201,phase:5,pass,nolog,skipAfter:END-REPORTING"
 #
 # -= Reporting Level 1 =- (apply only when tx.reporting_level is sufficiently high: 1 or higher)
 #

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -28,6 +28,8 @@ services:
       - ./logs/modsec2-apache:/var/log:rw
       - ../rules:/opt/owasp-crs/rules:ro
       - ../plugins:/opt/owasp-crs/plugins:ro
+      - ../crs-setup.conf.example:/etc/modsecurity.d/owasp-crs/crs-setup.conf.example
+    entrypoint: ["/bin/sh", "-c", "/bin/cp /etc/modsecurity.d/owasp-crs/crs-setup.conf.example /etc/modsecurity.d/owasp-crs/crs-setup.conf && /docker-entrypoint.sh && apachectl -D FOREGROUND"]
     ports:
       - "80:80"
     depends_on:
@@ -58,6 +60,8 @@ services:
       - ./logs/modsec3-nginx:/var/log:rw
       - ../rules:/opt/owasp-crs/rules:ro
       - ../plugins:/opt/owasp-crs/plugins:ro
+      - ../crs-setup.conf.example:/etc/modsecurity.d/owasp-crs/crs-setup.conf.example
+    entrypoint: ["/bin/sh", "-c", "/bin/cp /etc/modsecurity.d/owasp-crs/crs-setup.conf.example /etc/modsecurity.d/owasp-crs/crs-setup.conf && /docker-entrypoint.sh && nginx -g 'daemon off;'"]
     ports:
       - "80:80"
     depends_on:

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       BACKEND: http://backend
       PORT: "80"
       MODSEC_RULE_ENGINE: DetectionOnly
-      PARANOIA: 4
+      BLOCKING_PARANOIA: 4
       TZ: "${TZ}"
       ERRORLOG: "/var/log/error.log"
       ACCESSLOG: "/var/log/access.log"
@@ -42,7 +42,7 @@ services:
       BACKEND: http://backend
       PORT: "80"
       MODSEC_RULE_ENGINE: DetectionOnly
-      PARANOIA: 4
+      BLOCKING_PARANOIA: 4
       TZ: "${TZ}"
       ERRORLOG: "/var/log/error.log"
       LOGLEVEL: "info"

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -32,7 +32,7 @@ SecAction "id:900005,\
   pass,\
   ctl:ruleEngine=DetectionOnly,\
   ctl:ruleRemoveById=910000,\
-  setvar:tx.paranoia_level=4,\
+  setvar:tx.blocking_paranoia_level=4,\
   setvar:tx.crs_validate_utf8_encoding=1,\
   setvar:tx.arg_name_length=100,\
   setvar:tx.arg_length=400,\

--- a/tests/regression/tests/REQUEST-949-BLOCKING-EVALUATION/949110.yaml
+++ b/tests/regression/tests/REQUEST-949-BLOCKING-EVALUATION/949110.yaml
@@ -88,4 +88,4 @@ tests:
               Host: localhost
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
           output:
-            log_contains: "Inbound Anomaly Score Exceeded [(]Total Inbound Score [(]blocking/detection[)]: 112/112 - SQLI=37,XSS=50,RFI=0,LFI=0,RCE=10,PHPI=5,HTTP=0,SESS=0[)]: individual paranoia level scores: 35, 48, 16, 13"
+            log_contains: "Inbound Anomaly Score Exceeded [(]Total Score: "

--- a/tests/regression/tests/REQUEST-949-BLOCKING-EVALUATION/949110.yaml
+++ b/tests/regression/tests/REQUEST-949-BLOCKING-EVALUATION/949110.yaml
@@ -74,3 +74,18 @@ tests:
             version: "HTTP/1.1"
           output:
             log_contains: "id \"949110\""
+  - test_title: 949110-4
+    desc: Test is basically identical to 949110-0 (see above) but here we assert that the scores are summed up and reported propperly
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            method: GET
+            port: 80
+            uri: '/demo/xss/xml/vuln.xml.php?input=<script+xmlns="http://www.w3.org/1999/xhtml">setTimeout("top.frame2.location="javascript:(function+()+{var+x+=+document.createElement(\\"script\\");x.src+=+\\"//sdl.me/popup.js?//\\";document.childNodes\\[0\\].appendChild(x);}());"",1000)</script>&//'
+            headers:
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Host: localhost
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          output:
+            log_contains: "Inbound Anomaly Score Exceeded [(]Total Inbound Score [(]blocking/detection[)]: 112/112 - SQLI=37,XSS=50,RFI=0,LFI=0,RCE=10,PHPI=5,HTTP=0,SESS=0[)]: individual paranoia level scores: 35, 48, 16, 13"

--- a/tests/regression/tests/REQUEST-949-BLOCKING-EVALUATION/949110.yaml
+++ b/tests/regression/tests/REQUEST-949-BLOCKING-EVALUATION/949110.yaml
@@ -1,0 +1,76 @@
+---
+meta:
+  author: "studersi"
+  enabled: true
+  name: "949110.yaml"
+  description: |
+    Test whether the inbound blocking mechanism works by testing whether rule 949110 is triggered.
+    For these tests, existing test are repurposed with different assertions. Instead of asserting that the original
+    rules are triggered that the tests are written for, we assert that triggering these rules causes the blocking
+    rule to be triggered.
+tests:
+  - test_title: 949110-0
+    desc: Test is basically identical to 941100-1 (XSS positive test in phase 2) but here we assert that the inbound blocking mechanism is triggered
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            method: GET
+            port: 80
+            uri: '/demo/xss/xml/vuln.xml.php?input=<script+xmlns="http://www.w3.org/1999/xhtml">setTimeout("top.frame2.location="javascript:(function+()+{var+x+=+document.createElement(\\"script\\");x.src+=+\\"//sdl.me/popup.js?//\\";document.childNodes\\[0\\].appendChild(x);}());"",1000)</script>&//'
+            headers:
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Host: localhost
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          output:
+            log_contains: id "949110"
+  - test_title: 949110-1
+    desc: Test is basically identical to 941100-4 (XSS negative test in phase 2) but here we assert that inbound blocking mechanism is not triggered
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            method: GET
+            port: 80
+            uri: /
+            headers:
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Referer: http://www.cnn.com
+              Host: localhost
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          output:
+            no_log_contains: id "949110"
+  - test_title: 949110-2
+    desc: Test is basically identical to 920100-9 (protocol enforcement negative test in phase 1) but here we assert that the inbound blocking mechanism is not triggered
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "OPTIONS"
+            port: 80
+            headers:
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            protocol: "http"
+            uri: "/"
+            version: "HTTP/1.1"
+          output:
+            no_log_contains: "id \"949110\""
+  - test_title: 949110-3
+    desc: Test is basically identical to 920100-10 (protocol enforcement positive test in phase 1) but here we assert that inbound blocking mechanism is triggered
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "REALLYLONGUNREALMETHOD"
+            port: 80
+            headers:
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            protocol: "http"
+            uri: "/"
+            version: "HTTP/1.1"
+          output:
+            log_contains: "id \"949110\""

--- a/tests/regression/tests/RESPONSE-959-BLOCKING-EVALUATION/959100.yaml
+++ b/tests/regression/tests/RESPONSE-959-BLOCKING-EVALUATION/959100.yaml
@@ -71,4 +71,4 @@ tests:
             uri: "/anything"
             data: <?php echo "Hello World!\n" ?>
           output:
-            log_contains: "Outbound Anomaly Score Exceeded [(]Total Outbound Score [(]blocking/detection[)]: 4/4 - SQLI=0,XSS=0,RFI=0,LFI=0,RCE=0,PHPI=0,HTTP=0,SESS=0[)]: individual paranoia level scores: 4, 0, 0, 0"
+            log_contains: "Outbound Anomaly Score Exceeded [(]Total Score: "

--- a/tests/regression/tests/RESPONSE-959-BLOCKING-EVALUATION/959100.yaml
+++ b/tests/regression/tests/RESPONSE-959-BLOCKING-EVALUATION/959100.yaml
@@ -1,0 +1,53 @@
+---
+meta:
+  author: "studersi"
+  enabled: true
+  name: "959100.yaml"
+  description: |
+    Test whether the outbound blocking mechanism works by testing whether rule 959100 is triggered.
+    For these tests, existing test are repurposed with different assertions. Instead of asserting that the original
+    rules are triggered that the tests are written for, we assert that triggering these rules causes the blocking
+    rule to be triggered.
+tests:
+  - test_title: 959100-0
+    desc: Test is basically identical to 953120-0 (PHP leakage positive test in phase 4) but here we assert that the outbound blocking mechanism is triggered
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Accept-Charset: "ISO-8859-1,utf-8;q=0.7,*;q=0.7"
+              Accept-Encoding: "gzip,deflate"
+              Accept-Language: "en-us,en;q=0.5"
+              Content-Type: "text/plain"
+            method: "GET"
+            version: "HTTP/1.0"
+            uri: "/anything"
+            data: <?php echo "Hello World!\n" ?>
+          output:
+            log_contains: "id \"959100\""
+  - test_title: 959100-1
+    desc: Test is basically identical to 953120-1 (PHP leakage negative test in phase 4) but here we assert that the outbound blocking mechanism is not triggered
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Accept-Charset: "ISO-8859-1,utf-8;q=0.7,*;q=0.7"
+              Accept-Encoding: "gzip,deflate"
+              Accept-Language: "en-us,en;q=0.5"
+              Content-Type: "text/plain"
+            method: "GET"
+            version: "HTTP/1.0"
+            uri: "/anything"
+            data: <?php12345
+          output:
+            no_log_contains: "id \"959100\""

--- a/tests/regression/tests/RESPONSE-959-BLOCKING-EVALUATION/959100.yaml
+++ b/tests/regression/tests/RESPONSE-959-BLOCKING-EVALUATION/959100.yaml
@@ -51,3 +51,24 @@ tests:
             data: <?php12345
           output:
             no_log_contains: "id \"959100\""
+  - test_title: 959100-2
+    desc: Test is basically identical to 959100-0 (see above) but here we assert that the scores are summed up and reported propperly
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Accept-Charset: "ISO-8859-1,utf-8;q=0.7,*;q=0.7"
+              Accept-Encoding: "gzip,deflate"
+              Accept-Language: "en-us,en;q=0.5"
+              Content-Type: "text/plain"
+            method: "GET"
+            version: "HTTP/1.0"
+            uri: "/anything"
+            data: <?php echo "Hello World!\n" ?>
+          output:
+            log_contains: "Outbound Anomaly Score Exceeded [(]Total Outbound Score [(]blocking/detection[)]: 4/4 - SQLI=0,XSS=0,RFI=0,LFI=0,RCE=0,PHPI=0,HTTP=0,SESS=0[)]: individual paranoia level scores: 4, 0, 0, 0"

--- a/tests/regression/tests/RESPONSE-980-CORRELATION/980120.yaml
+++ b/tests/regression/tests/RESPONSE-980-CORRELATION/980120.yaml
@@ -1,0 +1,43 @@
+---
+meta:
+  author: "studersi"
+  enabled: true
+  name: "980120.yaml"
+  description: |
+    Test whether level 2 inbound reporting in phase 5 works by testing whether rule 980120 is triggered.
+    For these tests, existing test are repurposed with different assertions. Instead of asserting that the original
+    rules are triggered that the tests are written for, we assert that triggering these rules causes the corresponding
+    reporting rules to be triggered.
+tests:
+  - test_title: 980120-0
+    desc: Test is basically identical to 920350-1 (host header positive test in phase 1) but here we assert that the level 2 inbound reporting is triggered
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Host: "127.0.0.1"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            protocol: "http"
+            uri: "/"
+          output:
+            log_contains: "id \"980120\""
+  - test_title: 980120-1
+    desc: Test is basically identical to 920350-2 (host header negative test in phase 1) but here we assert that the level 2 inbound reporting is not triggered
+    stages:
+      - stage:
+          input:
+            dest_addr: "localhost"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            protocol: "http"
+            uri: "/"
+          output:
+            no_log_contains: "id \"980120\""

--- a/tests/regression/tests/RESPONSE-980-CORRELATION/980130.yaml
+++ b/tests/regression/tests/RESPONSE-980-CORRELATION/980130.yaml
@@ -1,0 +1,76 @@
+---
+meta:
+  author: "studersi"
+  enabled: true
+  name: "980130.yaml"
+  description: |
+    Test whether level 1 inbound reporting in phase 5 works by testing whether rule 980130 is triggered.
+    For these tests, existing test are repurposed with different assertions. Instead of asserting that the original
+    rules are triggered that the tests are written for, we assert that triggering these rules causes the corresponding
+    reporting rules to be triggered.
+tests:
+  - test_title: 980130-0
+    desc: Test is basically identical to 941100-1 (XSS positive test in phase 2) but here we assert that the level 1 inbound reporting is triggered
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            method: GET
+            port: 80
+            uri: '/demo/xss/xml/vuln.xml.php?input=<script+xmlns="http://www.w3.org/1999/xhtml">setTimeout("top.frame2.location="javascript:(function+()+{var+x+=+document.createElement(\\"script\\");x.src+=+\\"//sdl.me/popup.js?//\\";document.childNodes\\[0\\].appendChild(x);}());"",1000)</script>&//'
+            headers:
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Host: localhost
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          output:
+            log_contains: id "980130"
+  - test_title: 980130-1
+    desc: Test is basically identical to 941100-4 (XSS negative test in phase 2) but here we assert that level 1 inbound reporting is not triggered
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            method: GET
+            port: 80
+            uri: /
+            headers:
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Referer: http://www.cnn.com
+              Host: localhost
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          output:
+            no_log_contains: id "980130"
+  - test_title: 980130-2
+    desc: Test is basically identical to 920100-9 (protocol enforcement negative test in phase 1) but here we assert that level 1 inbound reporting is not triggered
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "OPTIONS"
+            port: 80
+            headers:
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            protocol: "http"
+            uri: "/"
+            version: "HTTP/1.1"
+          output:
+            no_log_contains: "id \"980130\""
+  - test_title: 980130-3
+    desc: Test is basically identical to 920100-10 (protocol enforcement positive test in phase 1) but here we assert that level 1 inbound reporting is triggered
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "REALLYLONGUNREALMETHOD"
+            port: 80
+            headers:
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            protocol: "http"
+            uri: "/"
+            version: "HTTP/1.1"
+          output:
+            log_contains: "id \"980130\""

--- a/tests/regression/tests/RESPONSE-980-CORRELATION/980140.yaml
+++ b/tests/regression/tests/RESPONSE-980-CORRELATION/980140.yaml
@@ -1,0 +1,53 @@
+---
+meta:
+  author: "studersi"
+  enabled: true
+  name: "980140.yaml"
+  description: |
+    Test whether level 1 outbound reporting in phase 5 works by testing whether rule 980140 is triggered.
+    For these tests, existing test are repurposed with different assertions. Instead of asserting that the original
+    rules are triggered that the tests are written for, we assert that triggering these rules causes the corresponding
+    reporting rules to be triggered.
+tests:
+  - test_title: 980140-0
+    desc: Test is basically identical to 953120-0 (PHP leakage positive test in phase 4) but here we assert that level 1 outbound reporting is triggered
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Accept-Charset: "ISO-8859-1,utf-8;q=0.7,*;q=0.7"
+              Accept-Encoding: "gzip,deflate"
+              Accept-Language: "en-us,en;q=0.5"
+              Content-Type: "text/plain"
+            method: "GET"
+            version: "HTTP/1.0"
+            uri: "/anything"
+            data: <?php echo "Hello World!\n" ?>
+          output:
+            log_contains: "id \"980140\""
+  - test_title: 980140-1
+    desc: Test is basically identical to 953120-1 (PHP leakage negative test in phase 4) but here we assert that level 1 outbound reporting is not triggered
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Accept-Charset: "ISO-8859-1,utf-8;q=0.7,*;q=0.7"
+              Accept-Encoding: "gzip,deflate"
+              Accept-Language: "en-us,en;q=0.5"
+              Content-Type: "text/plain"
+            method: "GET"
+            version: "HTTP/1.0"
+            uri: "/anything"
+            data: <?php12345
+          output:
+            no_log_contains: "id \"980140\""

--- a/tests/regression/tests/RESPONSE-980-CORRELATION/980150.yaml
+++ b/tests/regression/tests/RESPONSE-980-CORRELATION/980150.yaml
@@ -1,0 +1,13 @@
+---
+meta:
+  author: "studersi"
+  enabled: false
+  name: "980150.yaml"
+  description: |
+    Test whether level 2 outbound reporting in phase 5 works by testing whether rule 980150 is triggered.
+    For these tests, existing test are repurposed with different assertions. Instead of asserting that the original
+    rules are triggered that the tests are written for, we assert that triggering these rules causes the corresponding
+    reporting rules to be triggered.
+# Disabled because there are no outbound rules that have regression tests that could be triggered without blocking the
+# request (which is necessary for rule 980150 to be triggered
+# TODO: add such a test

--- a/util/find-max-datalen-in-tests/README.md
+++ b/util/find-max-datalen-in-tests/README.md
@@ -13,7 +13,7 @@ SecAction "id:900005,\
   pass,\
   ctl:ruleEngine=DetectionOnly,\
   ctl:ruleRemoveById=910000,\
-  setvar:tx.paranoia_level=4,\
+  setvar:tx.blocking_paranoia_level=4,\
   setvar:tx.crs_validate_utf8_encoding=1,\
   setvar:tx.arg_name_length=100,\
   setvar:tx.arg_length=400,\

--- a/util/join-multiline-rules/join.py
+++ b/util/join-multiline-rules/join.py
@@ -20,16 +20,16 @@
 #
 # Example:
 #
-#   SecRule &TX:paranoia_level "@eq 0" \
+#   SecRule &TX:BLOCKING_PARANOIA_LEVEL "@eq 0" \
 #      "id:901120,\
 #      phase:1,\
 #      pass,\
 #      nolog,\
-#      setvar:tx.paranoia_level=1"
+#      setvar:tx.blocking_paranoia_level=1"
 #
 # will be outputted as:
 #
-#   SecRule &TX:paranoia_level "@eq 0" "id:901120,phase:1,pass,nolog,setvar:tx.paranoia_level=1"
+#   SecRule &TX:BLOCKING_PARANOIA_LEVEL "@eq 0" "id:901120,phase:1,pass,nolog,setvar:tx.blocking_paranoia_level=1"
 #
 
 import fileinput, sys

--- a/util/send-payload-pls.sh
+++ b/util/send-payload-pls.sh
@@ -24,14 +24,14 @@
 #
 # The anomaly score envvar can be set as follows:
 # SecAction "id:90101,phase:5,pass,nolog,\
-#     setenv:ModSecAnomalyScoreIn=%{TX.anomaly_score}"
+#     setenv:ModSecAnomalyScoreIn=%{TX.blocking_inbound_anomaly_score}"
 #
 # Sample rule to setup the PL dynamically from localhost"
 # SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,192.168.0.128" \
 #     "id:90102,phase:1,pass,capture,log,auditlog,\
 #     msg:'Setting engine to PL%{matched_var}',chain"
 #     SecRule REQUEST_HEADERS:PL "@rx ([1-4])" \
-#         "setvar:'tx.executing_paranoia_level=%{matched_var}'"
+#         "setvar:'tx.detection_paranoia_level=%{matched_var}'"
 
 # Path to CRS rule set and local files
 CRS="/usr/share/modsecurity-crs/rules"
@@ -154,10 +154,10 @@ for PL in 1 2 3 4; do
 
     echo "Tracking unique id: $uniq_id"
 
-    grep $uniq_id $errorlog | sed -e "s/.*\[id \"//" -e "s/\(......\).*\[msg \"/\1 /" -e "s/\"\].*//" -e "s/(Total .*/(Total ...) .../" -e "s/Incoming and Outgoing Score: [0-9]* [0-9]*/Incoming and Outgoing Score: .../" | sed -e "s/$PL1/& PL1/" -e "s/$PL2/& PL2/" -e "s/$PL3/& PL3/ " -e "s/$PL4/& PL4/" | sort -k2 | sed -r "s/^([0-9]+)$/\1 FOREIGN RULE NOT IN CRS/"
+    grep $uniq_id $errorlog | sed -e "s/.*\[id \"//" -e "s/\(......\).*\[msg \"/\1 /" -e "s/\"\].*//" -e "s/(Total .*/(Total ...) .../" -e "s/Inbound and Outbound Score: [0-9]* [0-9]*/Inbound and Outbound Score: .../" | sed -e "s/$PL1/& PL1/" -e "s/$PL2/& PL2/" -e "s/$PL3/& PL3/ " -e "s/$PL4/& PL4/" | sort -k2 | sed -r "s/^([0-9]+)$/\1 FOREIGN RULE NOT IN CRS/"
 
     echo
-    echo -n "Total Incoming Score: "
+    echo -n "Total Inbound Score: "
 
     # Here are two ways to get the transaction anomaly score,
     # the first one is Christian's format, second is Spartan's format


### PR DESCRIPTION
## Proposed changes

The variables to count the anomaly score suffer from inconsistencies in naming and use that make it difficult to understand how they work and even lead to problems in some cases. The problem is discussed in detail in [issue 2319](https://github.com/coreruleset/coreruleset/issues/2319).

This pull request cleans up these scoring variables according to the specifications proposed in [comment 1035032820](https://github.com/coreruleset/coreruleset/issues/2319#issuecomment-1035032820).

The behaviour of the ruleset should not change except for the messages that are logged. However, the refactoring affects the entire ruleset and should be checked very carefully. Maybe additional tests could be helpful to prevent regressions.

There are a number of observations to point out in particular:
* The Variable `anomaly_score` is set in phase 5 for legacy applications that rely on it. It sums up the values of `blocking_inbound_anomaly_score` and `blocking_outbound_anomaly_score`.
* The reporting rules in phase 5 have a new tag `reporting`
* The correlation rules have been ported to use the new scoring variables. However, as far as I can tell, they will never be activated as there are no rules that set the necessary tags. Maybe they could be fixed and moved to a separate plugin for those who would like to use them.
* The scores are always added up in phase 1 to prevent the problem described in [comment 1047503932](https://github.com/coreruleset/coreruleset/issues/2319#issuecomment-1047503932).
* IP reputation blocking does not need to interfere in score aggregation anymore as the scores are already aggregated for phase 1 anyway.
* IP reputation rules increase the anomaly score in rule 910000 but then skip to rule 949100 to block the request independently of other CRS rules and evaluation mechanisms. This is strange and it might be worth considering to move IP reputation rules to a separate plugin.
* The DoS protection rules do not make use of the scoring variables. Additionally, they do not have a custom blocking mechanism like the IP reputation rules. It is unclear to me whether they could actually block anything at all. Since they do not make use of the scoring variables, they could maybe also be moved to a separate plugin.
* The virtual patching scripts in `util/virtual-patching` contain references to the scoring variables but are left unchanged.
* The words _incoming_ and _outgoing_ have been changed to _inbound_ and _outbound_ in some auxilliary files as well. I hope I cought all of them.
* The messages of the reporting rules have been changed to include blocking and detection scores.
* New mechanism added to configure reporting levels using the `tx.reporting_level` variable.

Todo - Add regression tests for:
* [x] Do the bugs in [issue 1896](https://github.com/coreruleset/coreruleset/issues/1896) remain solved? -> problem does not exist with new reporting rules
* [x] Does early blocking still work? -> We cannot dynamically change CRS setting during tests
* [x] Does blocking in general still work? -> test added
* [x] Are the anomaly scores summed up correctly for the blocking and detection variables? -> added tests 949110-4 & 959100-2
* [x] Do reporting levels work as intended? -> test added
* [x] The skips have rule IDs in the 9802xx range. The PL skips we generally employ are usually placed in the 9xx0xx range. Here, this would be 9800xx.
* [x] 980160 + 980170 should be merged
* [x] Reword the description of the reporting rules.

Followup:
* [x] Fix correlation rules -> https://github.com/coreruleset/coreruleset/issues/2428
* [x] Move correlation rules to separate plugin? -> https://github.com/coreruleset/coreruleset/issues/2428
* [x] Move IP reputation rules to separate plugin? -> https://github.com/coreruleset/coreruleset/issues/2433
* [x] Fix DoS rules -> https://github.com/coreruleset/coreruleset/issues/2373
* [x] Move DoS rules to separate plugin? -> https://github.com/coreruleset/coreruleset/issues/2373
* [x] Configuring blocking paranoia level lower than detection paranoia level does not work with CRS container -> https://github.com/coreruleset/modsecurity-crs-docker/issues/69
* [x] Let's discuss an alternative approach: A single reporting rule reporting incoming score, outgoing score, SQLi score and friends. -> https://github.com/coreruleset/coreruleset/issues/2474
* [x] Solve problem described in [comment 1047503932](https://github.com/coreruleset/coreruleset/issues/2319#issuecomment-1047503932) -> https://github.com/coreruleset/coreruleset/issues/2475
* [x] the SQL-score and friends should only be reported once. -> https://github.com/coreruleset/coreruleset/issues/2474

## PR Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/coreruleset/coreruleset/blob/v3.4/dev/CONTRIBUTING.md) doc
- [x] I have added positive tests proving my fix/feature works as intended.
- [x] I have added negative tests that prove my fix/feature considers common cases that might end in false positives
- [x] In case you changed a regular expression, you are not adding a ReDOS for pcre. You can check this using [regexploit](https://github.com/doyensec/regexploit)
- [ ] My test use the `comment` field to write the expected behavior
- [x] I have added documentation for the rule or change (when appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... If there are no additional comments, you may remove this section. -->

## For the reviewer

<!-- Don't remove this part. Reviewers will use it as guidance for the review process. -->

- [ ] Positive and negative tests were added
- [ ] Tests cover the intended fix/feature properly
- [x] No usage of dangerous constructs like `ctl:requestBodyAccess=Off` were used in the rule
- [x] In case a regular expression was changed, [there is no ReDOS](https://github.com/coreruleset/coreruleset/wiki/Testing-for-Regular-Expresion-DoS)
- [ ] Documentation is clear for the rule/change