### PR TITLE
XenForo: add more exclusions to fix FP's and fix phase

### DIFF
--- a/rules/REQUEST-903.9006-XENFORO-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9006-XENFORO-EXCLUSION-RULES.conf
@@ -297,6 +297,7 @@ SecRule REQUEST_FILENAME "@endsWith /account/account-details" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=931130;ARGS:custom_fields[picture],\
+    ctl:ruleRemoveTargetById=931130;ARGS:profile[website],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:about_html,\
     ver:'OWASP_CRS/3.4.0-dev'"
 
@@ -335,6 +336,8 @@ SecRule REQUEST_FILENAME "@endsWith /search/search" \
     ctl:ruleRemoveTargetById=942260;ARGS:constraints,\
     ctl:ruleRemoveTargetById=942340;ARGS:constraints,\
     ctl:ruleRemoveTargetById=942370;ARGS:constraints,\
+    ctl:ruleRemoveTargetById=942120;ARGS:c[users],\
+    ctl:ruleRemoveTargetById=942370;ARGS:c[users],\
     ver:'OWASP_CRS/3.4.0-dev'"
 
 # Search within thread
@@ -482,7 +485,7 @@ SecRule REQUEST_FILENAME "!@endsWith /admin.php" \
 
 SecRule REQUEST_FILENAME "!@endsWith /admin.php" \
     "id:9006901,\
-    phase:1,\
+    phase:2,\
     pass,\
     t:none,\
     nolog,\
@@ -520,6 +523,17 @@ SecRule REQUEST_URI "@rx /admin\.php\?users/.*\.\d+/save$" \
     ctl:ruleRemoveTargetById=931130;ARGS:profile[website],\
     ver:'OWASP_CRS/3.4.0-dev'"
 
+# Admin mass send messages
+# POST /xf/admin.php?users/message/send
+# POST /xf/admin.php?users/foo.12345/send
+SecRule REQUEST_URI "@rx /admin\.php\?users/(?:message|.*\.\d+)/send$" \
+    "id:9006925,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json_criteria,\
+    ver:'OWASP_CRS/3.4.0-dev'"
 
 # Admin edit forum notice
 # POST /xf/admin.php?notices/0/save
@@ -576,6 +590,8 @@ SecRule REQUEST_URI "@rx /admin\.php\?options/update$" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:options[allowedCodeLanguages],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:options[boardInactiveMessage],\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:options[spamPhrases][phrases],\
+    ctl:ruleRemoveTargetById=931130;ARGS:options[ipInfoUrl],\
     ver:'OWASP_CRS/3.4.0-dev'"
 
 # Edit pages/templates
@@ -603,14 +619,26 @@ SecRule REQUEST_URI "@rx /admin\.php\?templates/.*/merge-outdated$" \
     ver:'OWASP_CRS/3.4.0-dev'"
 
 # User groups
-# POST POST /xf/admin.php?user-groups/foo.20/save
+# POST /xf/admin.php?user-groups/foo.20/save
 SecRule REQUEST_URI "@rx /admin\.php\?user-groups/.*\.\d+/save$" \
     "id:9006990,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
+    ctl:ruleRemoveTargetById=941320;ARGS:user_title,\
     ctl:ruleRemoveTargetById=942130;ARGS:user_title,\
+    ver:'OWASP_CRS/3.4.0-dev'"
+
+# Donation
+# POST /xf/admin.php?navigation/Donations/save
+SecRule REQUEST_URI "@endsWith /admin.php?navigation/Donations/save" \
+    "id:9006991,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetById=931130;ARGS:config[basic][link],\
     ver:'OWASP_CRS/3.4.0-dev'"
 
 SecMarker "END-XENFORO-ADMIN"


### PR DESCRIPTION
- Add support for admin functions: mass send messages and donations feature
- Fix various false positives
- In rule 9006901, fix a phase:1 in a skip that should be a phase:2, so that both phases skip over the admin.php rules.