### PR TITLE
Removed special handling of \x5c in 930100-slashes.data

### DIFF
--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -31,11 +31,13 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:930012,phase:2,pass,nolog,skipAf
 # util/regexp-assemble/data/930100-dots.data using Regexp::Assemble.
 # To rebuild the regexp:
 #   cd util/regexp-assemble
-#   echo "(?i)"$(./regexp-assemble.py 930100-slashes)$(./regexp-assemble.py 930100-dots)$(./regexp-assemble.py 930100-slashes)
-# The above command sandwiches together the final regular expression, like so:
+#   ./regexp-assemble.py 930100-slashes # SLASHES PATTERN
+#   ./regexp-assemble.py 930100-dots # DOTS PATTERN
+# Prepend `(?i)` to the two patterns above to produce the following sequence
+# SLASHES PATTERN before *and* after DOTS PATTERN):
 #   (?i)[SLASHES PATTERN][DOTS PATTERN][SLASHES PATTERN]
 #
-SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@rx (?i)(?:\x5c|(?:%(?:c(?:0%(?:[2aq]f|5c|9v)|1%(?:[19p]c|8s|af))|2(?:5(?:c(?:0%25af|1%259c)|2f|5c)|%46|f)|(?:(?:f(?:8%8)?0%8|e)0%80%a|bg%q)f|%3(?:2(?:%(?:%6|4)6|F)|5%%63)|u(?:221[56]|002f|EFC8|F025)|1u|5c)|0x(?:2f|5c)|\/))(?:%(?:(?:f(?:(?:c%80|8)%8)?0%8|e)0%80%ae|2(?:(?:5(?:c0%25a|2))?e|%45)|u(?:(?:002|ff0)e|2024)|%32(?:%(?:%6|4)5|E)|c0(?:%[256aef]e|\.))|\.(?:%0[01]|\?)?|\?\.?|0x2e){2,3}(?:\x5c|(?:%(?:c(?:0%(?:[2aq]f|5c|9v)|1%(?:[19p]c|8s|af))|2(?:5(?:c(?:0%25af|1%259c)|2f|5c)|%46|f)|(?:(?:f(?:8%8)?0%8|e)0%80%a|bg%q)f|%3(?:2(?:%(?:%6|4)6|F)|5%%63)|u(?:221[56]|002f|EFC8|F025)|1u|5c)|0x(?:2f|5c)|\/))" \
+SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@rx (?i)(?:%(?:c(?:0%(?:[2aq]f|5c|9v)|1%(?:[19p]c|8s|af))|2(?:5(?:c(?:0%25af|1%259c)|2f|5c)|%46|f)|(?:(?:f(?:8%8)?0%8|e)0%80%a|bg%q)f|%3(?:2(?:%(?:%6|4)6|F)|5%%63)|u(?:221[56]|002f|EFC8|F025)|1u|5c)|0x(?:2f|5c)|\/|\x5c)(?:%(?:(?:f(?:(?:c%80|8)%8)?0%8|e)0%80%ae|2(?:(?:5(?:c0%25a|2))?e|%45)|u(?:(?:002|ff0)e|2024)|%32(?:%(?:%6|4)5|E)|c0(?:%[256aef]e|\.))|\.(?:%0[01]|\?)?|\?\.?|0x2e){2,3}(?:%(?:c(?:0%(?:[2aq]f|5c|9v)|1%(?:[19p]c|8s|af))|2(?:5(?:c(?:0%25af|1%259c)|2f|5c)|%46|f)|(?:(?:f(?:8%8)?0%8|e)0%80%a|bg%q)f|%3(?:2(?:%(?:%6|4)6|F)|5%%63)|u(?:221[56]|002f|EFC8|F025)|1u|5c)|0x(?:2f|5c)|\/|\x5c)" \
     "id:930100,\
     phase:2,\
     block,\

--- a/util/regexp-assemble/data/930100-slashes.data
+++ b/util/regexp-assemble/data/930100-slashes.data
@@ -40,21 +40,7 @@
 ##! the value for “9” (57) to “v” (118); if the result is greater than 127, then
 ##! subtract 128—hint, the final result should be 47.
 
-##! Prepend the "\x5c" pattern manually because Regexp::Assemble will
-##! automatically convert it into a "\" character if it's fed in with the other
-##! pattern lines below. We want to maintain the original form of "\x5c" because
-##! a.) that maintains the original regular expression, and b.) using "\x5c"
-##! works as intended with both ModSecurity 2 and libmodsecurity (i.e. it works
-##! around the issue of representing a literal backslash character, using tricks
-##! like [\\\\], etc.).
-
-##!^ (?:\x5c|
-
-##! Manually append the closing bracket to match the manually prepended opening
-##! one.
-
-##!$ )
-
+\x5c
 ##! URI encoded
 %2f
 %5c


### PR DESCRIPTION
This special handling is no longer required since regexp-assemble was updated

Also fixed the regex creation comment since the shell doesn't reliably produce the regex (backslashes are stripped, depending on the tool and shell)