### PR TITLE
Backslashes 933100

### DIFF
--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -44,7 +44,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:933012,phase:2,pass,nolog,skipAf
 # Therefore, that pattern is now checked by rule 933190 in paranoia levels
 # 3 or higher.
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:<\?(?:[^x]|x[^m]|xm[^l]|xml[^\s]|xml$|$)|<\?php|\[(?:/|\\\\)?php\])" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:<\?(?:[^x]|x[^m]|xm[^l]|xml[^\s]|xml$|$)|<\?php|\[(?:/|\x5c)?php\])" \
     "id:933100,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933100.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933100.yaml
@@ -47,3 +47,35 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "933100"
+  - test_title: 933100-3
+    desc: "PHP injection attack: looking for [/php] closing tag"
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: OWASP ModSecurity Core Rule Set
+          method: GET
+          port: 80
+          uri: /?foo=somePhpWouldGoHere%5B%2Fphp%5D
+          version: HTTP/1.0
+        output:
+          log_contains: id "933100"
+  - test_title: 933100-4
+    desc: "PHP injection attack: looking for [\php] closing tag"
+    stages:
+    - stage:
+        input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: OWASP ModSecurity Core Rule Set
+          method: GET
+          port: 80
+          uri: /?foo=somePhpWouldGoHere%5B%5Cphp%5D
+          version: HTTP/1.0
+        output:
+          log_contains: id "933100"

--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933100.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933100.yaml
@@ -64,7 +64,7 @@ tests:
         output:
           log_contains: id "933100"
   - test_title: 933100-4
-    desc: "PHP injection attack: looking for [\php] closing tag"
+    desc: 'PHP injection attack: looking for [\php] closing tag'
     stages:
     - stage:
         input:


### PR DESCRIPTION
This PR moves rule 933100 to use the \x5c representation of the backslash character.

Two new tests are added to ensure that the backslash matches are working correctly (for the patterns `[\php]` and `[/php]`).

This is part of ongoing issue https://github.com/coreruleset/coreruleset/issues/2332.