### PR TITLE
Backslashes 941190

### DIFF
--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -232,7 +232,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # Ref: http://blogs.technet.com/srd/archive/2008/08/18/ie-8-xss-filter-architecture-implementation.aspx
 # Ref: http://xss.cx/examples/ie/internet-exploror-ie9-xss-filter-rules-example-regexp-mshtmldll.txt
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:<style.*?>.*?(?:@[i\\\\]|(?:[:=]|&#x?0*(?:58|3A|61|3D);?).*?(?:[(\\\\]|&#x?0*(?:40|28|92|5C);?)))" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:<style.*?>.*?(?:@[i\x5c]|(?:[:=]|&#x?0*(?:58|3A|61|3D);?).*?(?:[(\x5c]|&#x?0*(?:40|28|92|5C);?)))" \
     "id:941190,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941190.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941190.yaml
@@ -65,7 +65,7 @@ tests:
             headers:
               User-Agent: OWASP ModSecurity Core Rule Set
               Host: localhost
-              Cookie: '<STYLE>@\\\\'
+              Cookie: 'My-Cookie=<STYLE>@\\\\'
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
           output:
             log_contains: id "941190"
@@ -81,7 +81,7 @@ tests:
             headers:
               User-Agent: OWASP ModSecurity Core Rule Set
               Host: localhost
-              Cookie: '<STYLE>=\\\\'
+              Cookie: 'My-Cookie=<STYLE>=\\\\'
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
           output:
             log_contains: id "941190"

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941190.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941190.yaml
@@ -65,7 +65,7 @@ tests:
             headers:
               User-Agent: OWASP ModSecurity Core Rule Set
               Host: localhost
-              Cookie: '<STYLE>@\'
+              Cookie: '<STYLE>@\\\\'
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
           output:
             log_contains: id "941190"
@@ -81,7 +81,7 @@ tests:
             headers:
               User-Agent: OWASP ModSecurity Core Rule Set
               Host: localhost
-              Cookie: '<STYLE>=\'
+              Cookie: '<STYLE>=\\\\'
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
           output:
             log_contains: id "941190"

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941190.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941190.yaml
@@ -53,3 +53,35 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
           output:
             log_contains: id "941190"
+  - test_title: 941190-4
+    desc: Test first replaced backslash match (\x5c)
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            method: GET
+            port: 80
+            uri: '/'
+            headers:
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Host: localhost
+              Cookie: '<STYLE>@\'
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          output:
+            log_contains: id "941190"
+  - test_title: 941190-5
+    desc: Test second replaced backslash match (\x5c)
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            method: GET
+            port: 80
+            uri: '/'
+            headers:
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Host: localhost
+              Cookie: '<STYLE>=\'
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          output:
+            log_contains: id "941190"


### PR DESCRIPTION
This PR moves rule 941190 to use the \x5c representation of the backslash character.

Two new tests are added to ensure that the backslash matches are working correctly.

This is part of ongoing issue https://github.com/coreruleset/coreruleset/issues/2332.