### PR TITLE
Add path traversal detection in file upload

### DIFF
--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -37,7 +37,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:930012,phase:2,pass,nolog,skipAf
 # SLASHES PATTERN before *and* after DOTS PATTERN):
 #   (?i)[SLASHES PATTERN][DOTS PATTERN][SLASHES PATTERN]
 #
-SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@rx (?i)(?:%(?:c(?:0%(?:[2aq]f|5c|9v)|1%(?:[19p]c|8s|af))|2(?:5(?:c(?:0%25af|1%259c)|2f|5c)|%46|f)|(?:(?:f(?:8%8)?0%8|e)0%80%a|bg%q)f|%3(?:2(?:%(?:%6|4)6|F)|5%%63)|u(?:221[56]|002f|EFC8|F025)|1u|5c)|0x(?:2f|5c)|\/|\x5c)(?:%(?:(?:f(?:(?:c%80|8)%8)?0%8|e)0%80%ae|2(?:(?:5(?:c0%25a|2))?e|%45)|u(?:(?:002|ff0)e|2024)|%32(?:%(?:%6|4)5|E)|c0(?:%[256aef]e|\.))|\.(?:%0[01]|\?)?|\?\.?|0x2e){2,3}(?:%(?:c(?:0%(?:[2aq]f|5c|9v)|1%(?:[19p]c|8s|af))|2(?:5(?:c(?:0%25af|1%259c)|2f|5c)|%46|f)|(?:(?:f(?:8%8)?0%8|e)0%80%a|bg%q)f|%3(?:2(?:%(?:%6|4)6|F)|5%%63)|u(?:221[56]|002f|EFC8|F025)|1u|5c)|0x(?:2f|5c)|\/|\x5c)" \
+SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|FILES|XML:/* "@rx (?i)(?:%(?:c(?:0%(?:[2aq]f|5c|9v)|1%(?:[19p]c|8s|af))|2(?:5(?:c(?:0%25af|1%259c)|2f|5c)|%46|f)|(?:(?:f(?:8%8)?0%8|e)0%80%a|bg%q)f|%3(?:2(?:%(?:%6|4)6|F)|5%%63)|u(?:221[56]|002f|EFC8|F025)|1u|5c)|0x(?:2f|5c)|\/|\x5c)(?:%(?:(?:f(?:(?:c%80|8)%8)?0%8|e)0%80%ae|2(?:(?:5(?:c0%25a|2))?e|%45)|u(?:(?:002|ff0)e|2024)|%32(?:%(?:%6|4)5|E)|c0(?:%[256aef]e|\.))|\.(?:%0[01]|\?)?|\?\.?|0x2e){2,3}(?:%(?:c(?:0%(?:[2aq]f|5c|9v)|1%(?:[19p]c|8s|af))|2(?:5(?:c(?:0%25af|1%259c)|2f|5c)|%46|f)|(?:(?:f(?:8%8)?0%8|e)0%80%a|bg%q)f|%3(?:2(?:%(?:%6|4)6|F)|5%%63)|u(?:221[56]|002f|EFC8|F025)|1u|5c)|0x(?:2f|5c)|\/|\x5c)" \
     "id:930100,\
     phase:2,\
     block,\
@@ -67,7 +67,7 @@ SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@r
 # - .../
 # - /...
 
-SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/* "@rx (?:(?:^|[\x5c/])\.{2,3}[\x5c/]|[\x5c/]\.{2,3}(?:[\x5c/]|$))" \
+SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|FILES|XML:/* "@rx (?:(?:^|[\x5c/])\.{2,3}[\x5c/]|[\x5c/]\.{2,3}(?:[\x5c/]|$))" \
     "id:930110,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930110.yaml
+++ b/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930110.yaml
@@ -166,3 +166,26 @@ tests:
               ------WebKitFormBoundaryABCDEFGIJKLMNOPQ--
           output:
             log_contains: id "930110"
+  - test_title: 930110-11
+    desc: 'Path Traversal Attack (..\) file upload'
+    stages:
+      - stage:
+          input:
+            dest_addr: "localhost"
+            method: "POST"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryABCDEFGIJKLMNOPQ
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+            uri: /
+            data: |
+              ------WebKitFormBoundaryABCDEFGIJKLMNOPQ
+              Content-Disposition: form-data; name="file"; filename="..\1.7z"
+              Content-Type: application/octet-stream
+
+              BINARYDATA
+              ------WebKitFormBoundaryABCDEFGIJKLMNOPQ--
+          output:
+            log_contains: id "930110"

--- a/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930110.yaml
+++ b/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930110.yaml
@@ -156,8 +156,6 @@ tests:
               User-Agent: OWASP ModSecurity Core Rule Set
               Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryABCDEFGIJKLMNOPQ
               Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
-            method: POST
-            port: 80
             uri: /
             data: |
               ------WebKitFormBoundaryABCDEFGIJKLMNOPQ

--- a/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930110.yaml
+++ b/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930110.yaml
@@ -143,3 +143,28 @@ tests:
             uri: '/?foo=.../.../WINDOWS/win.ini'
           output:
             log_contains: id "930110"
+  - test_title: 930110-10
+    desc: 'Path Traversal Attack (../) file upload'
+    stages:
+      - stage:
+          input:
+            dest_addr: "localhost"
+            method: "POST"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryABCDEFGIJKLMNOPQ
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+            method: POST
+            port: 80
+            uri: /
+            data: |
+              ------WebKitFormBoundaryABCDEFGIJKLMNOPQ
+              Content-Disposition: form-data; name="file"; filename="../1.7z"
+              Content-Type: application/octet-stream
+
+              BINARYDATA
+              ------WebKitFormBoundaryABCDEFGIJKLMNOPQ--
+          output:
+            log_contains: id "930110"


### PR DESCRIPTION
This PR is a proposal to solve issue #2446 by adding FILES to path traversal detection rules 930100 and 930110.
This PR also adds a test for rule 930110.