### PR TITLE
Backslashes 932100, 932110

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -72,7 +72,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 1" "id:932012,phase:2,pass,nolog,skipAf
 #
 # 4. Paths
 #
-# [\?\*\[\]\(\)\-\|+\w'\"\./\\\\]+/   /sbin/ifconfig, /s?in/./ifconfig, /s[a-b]in/ifconfig etc.
+# [\?\*\[\]\(\)\-\|+\w'\"\./\x5c]+/   /sbin/ifconfig, /s?in/./ifconfig, /s[a-b]in/ifconfig etc.
 #
 # This rule is case-sensitive to prevent FP ("Cat" vs. "cat").
 #
@@ -190,8 +190,8 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # 3. Paths
 #
 # [\w'\"\./]+/                          /path/cmd
-# [\\\\'\"\^]*\w[\\\\'\"\^]*:.*\\\\     C:\Program Files\cmd
-# [\^\.\w '\"/\\\\]*\\\\)?[\"\^]*       \\net\share\dir\cmd
+# [\x5c'\"\^]*\w[\x5c'\"\^]*:.*\x5c     C:\Program Files\cmd
+# [\^\.\w '\"/\x5c]*\x5c)?[\"\^]*       \\net\share\dir\cmd
 #
 # 4. Quoting
 #


### PR DESCRIPTION
This PR updates the comments for rules 932100 and 932110 to use the \x5c representation of the backslash character.

This is part of ongoing issue https://github.com/coreruleset/coreruleset/issues/2332.