### PR TITLE
920470: allow * in Content-Type to fix 'application/*+json' FP

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -937,8 +937,9 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
 # - text/plain; charset="UTF-8"
 # - multipart/form-data; boundary=----WebKitFormBoundary12345
 # - application/soap+xml; charset=utf-8; action="urn:localhost-hwh#getQuestions"
-#
-SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+-]+(?:\s?;\s?(?:action|boundary|charset|start(?:-info)?|type|version)\s?=\s?['\"\w.()+,/:=?<>@#-]+)*$" \
+# - application/*+json
+
+SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+-]+(?:\s?;\s?(?:action|boundary|charset|start(?:-info)?|type|version)\s?=\s?['\"\w.()+,/:=?<>@#-\*]+)*$" \
     "id:920470,\
     phase:1,\
     block,\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -939,7 +939,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
 # - application/soap+xml; charset=utf-8; action="urn:localhost-hwh#getQuestions"
 # - application/*+json
 
-SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+-]+(?:\s?;\s?(?:action|boundary|charset|start(?:-info)?|type|version)\s?=\s?['\"\w.()+,/:=?<>@#-\*]+)*$" \
+SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+-\*]+(?:\s?;\s?(?:action|boundary|charset|start(?:-info)?|type|version)\s?=\s?['\"\w.()+,/:=?<>@#-\*]+)*$" \
     "id:920470,\
     phase:1,\
     block,\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -939,7 +939,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
 # - application/soap+xml; charset=utf-8; action="urn:localhost-hwh#getQuestions"
 # - application/*+json
 
-SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+-\*]+(?:\s?;\s?(?:action|boundary|charset|start(?:-info)?|type|version)\s?=\s?['\"\w.()+,/:=?<>@#-\*]+)*$" \
+SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+*-]+(?:\s?;\s?(?:action|boundary|charset|start(?:-info)?|type|version)\s?=\s?['\"\w.()+,/:=?<>@#*-]+)*$" \
     "id:920470,\
     phase:1,\
     block,\

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920470.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920470.yaml
@@ -241,3 +241,18 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
           output:
             no_log_contains: "id \"920470\""
+  - test_title: 920470-17
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            port: 80
+            method: POST
+            headers:
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Host: "localhost"
+              Content-Type: 'application/*+json'
+              Content-Length: 0
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          output:
+            no_log_contains: "id \"920470\""


### PR DESCRIPTION
In #2438 a FP was reported on `Content-Type: application/*+json`.

It may be rare but it is allowed according to the RFCs.

The `*` character is added to the allowed characters.