### PR TITLE
944140: deny uploading .jsp and .jspx files

### DIFF
--- a/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -148,7 +148,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
 # Block file uploads with filenames ending in Java scripts (.jsp, .jspx)
 #
 # Many application contain Unrestricted File Upload vulnerabilities.
-# https://www.owasp.org/index.php/Unrestricted_File_Upload
+# https://owasp.org/www-community/vulnerabilities/Unrestricted_File_Upload
 #
 # Attackers may use such a vulnerability to achieve remote code execution
 # by uploading a script file. If the upload storage location is predictable

--- a/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -142,6 +142,45 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
+#
+# [ Java Script Uploads ]
+#
+# Block file uploads with filenames ending in Java scripts (.jsp, .jspx)
+#
+# Many application contain Unrestricted File Upload vulnerabilities.
+# https://www.owasp.org/index.php/Unrestricted_File_Upload
+#
+# Attackers may use such a vulnerability to achieve remote code execution
+# by uploading a script file. If the upload storage location is predictable
+# and not adequately protected, the attacker may then request the uploaded
+# file and have the code within it executed on the server.
+#
+# Some AJAX uploaders use the nonstandard request headers X-Filename,
+# X_Filename, or X-File-Name to transmit the file name to the server;
+# scan these request headers as well as multipart/form-data file names.
+#
+SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEADERS:X.Filename|REQUEST_HEADERS:X-File-Name "@rx .*\.(?:jsp|jspx)\.*$" \
+    "id:944140,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:lowercase,\
+    msg:'Java Injection Attack: Java Script File Upload Found',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-java',\
+    tag:'platform-multi',\
+    tag:'attack-injection-java',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/242',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/3.4.0-dev',\
+    severity:'CRITICAL',\
+    setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:944013,phase:1,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
 SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:944014,phase:2,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
 #

--- a/tests/regression/tests/REQUEST-944-APPLICATION-ATTACK-JAVA/944140.yaml
+++ b/tests/regression/tests/REQUEST-944-APPLICATION-ATTACK-JAVA/944140.yaml
@@ -1,0 +1,141 @@
+---
+meta:
+  author: lifeforms
+  description: None
+  enabled: true
+  name: 944140.yaml
+tests:
+  - test_title: 944140-1
+    desc: Java script uploads
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /
+          output:
+            no_log_contains: id "944140"
+  - test_title: 944140-2
+    desc: Java script uploads
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              X-Filename: a.jsp
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /upload1
+          output:
+            log_contains: id "944140"
+  - test_title: 944140-3
+    desc: Java script uploads
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              X_Filename: B.jsp
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /upload2
+          output:
+            log_contains: id "944140"
+  - test_title: 944140-4
+    desc: Java script uploads
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              X-File-Name: a.jspx
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /upload3
+          output:
+            log_contains: id "944140"
+  - test_title: 944140-5
+    desc: Java script uploads
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              X-Filename: a.jsp..
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /upload4
+          output:
+            log_contains: id "944140"
+  - test_title: 944140-6
+    desc: Java script uploads
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              X-Filename: a.jspx..
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /upload
+          output:
+            log_contains: id "944140"
+  - test_title: 944140-7
+    desc: Java script uploads
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              X-File-Name: foo.jspx...
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /upload
+          output:
+            log_contains: id "944140"
+  - test_title: 944140-8
+    desc: Java script uploads
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              X_Filename: foo.jspx.
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /upload7
+          output:
+            log_contains: id "944140"
+  - test_title: 944140-9
+    desc: Java script uploads
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              X-File-Name: foo.html
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /upload8
+          output:
+            no_log_contains: id "944140"


### PR DESCRIPTION
This is a Java version of rule 933110 (blocked uploading .php files), that blocks uploading of .jsp and .jspx files, which may be leveraged to achieve RCE.