### PR TITLE
fix(942440): remove unneded space symbols from regex

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1174,7 +1174,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
 #   cd util/regexp-assemble
 #   ./regexp-assemble.py 942440
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:--(?:[\s\r\n\v\f]|[^-]*?-)|[^&-]#.*?[\s\r\n\v\f]|;?\x00|[';]--|\/\*!?|\*\/)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:--(?:[^-]*?-|\s)|[^&-]#.*?\s|;?\x00|[';]--|\/\*!?|\*\/)" \
     "id:942440,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942440.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942440.yaml
@@ -17,7 +17,7 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             method: GET
             port: 80
-            uri: "/?var=DROP%20sampletable%3b--"
+            uri: "/post?var=DROP%20sampletable%3b--"
             version: HTTP/1.0
           output:
             log_contains: id "942440"
@@ -34,6 +34,228 @@ tests:
             method: "POST"
             port: 80
             version: "HTTP/1.0"
+            uri: "/post"
             data: "test=' or 1=1;%00"
+          output:
+            log_contains: id "942440"
+  - test_title: 942440-3
+    desc: "SQL Comment Sequence"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: "POST"
+            port: 80
+            version: "HTTP/1.0"
+            uri: "/post"
+            data: "test=OR 1# "
+          output:
+            log_contains: id "942440"
+  - test_title: 942440-4
+    desc: "SQL Comment Sequence"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: "POST"
+            port: 80
+            version: "HTTP/1.0"
+            uri: "/post"
+            data: "test=admin'--"
+          output:
+            log_contains: id "942440"
+  - test_title: 942440-5
+    desc: "SQL Comment Sequence"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: "POST"
+            port: 80
+            version: "HTTP/1.0"
+            uri: "/post"
+            data: "test=DROP/*comment*/sampletable"
+          output:
+            log_contains: id "942440"
+  - test_title: 942440-6
+    desc: "SQL Comment Sequence"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: "POST"
+            port: 80
+            version: "HTTP/1.0"
+            uri: "/post"
+            data: "test=DR/**/OP/*bypass deny listing*/sampletable"
+          output:
+            log_contains: id "942440"
+  - test_title: 942440-7
+    desc: "SQL Comment Sequence"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: "POST"
+            port: 80
+            version: "HTTP/1.0"
+            uri: "/post"
+            data: "test=SELECT/*avoid-spaces*/password/**/FROM/**/Members"
+          output:
+            log_contains: id "942440"
+  - test_title: 942440-8
+    desc: "SQL Comment Sequence"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: "POST"
+            port: 80
+            version: "HTTP/1.0"
+            uri: "/post"
+            data: "test=SELECT /*!32302 1/0, */ 1 FROM tablename"
+          output:
+            log_contains: id "942440"
+  - test_title: 942440-9
+    desc: "SQL Comment Sequence"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: "POST"
+            port: 80
+            version: "HTTP/1.0"
+            uri: "/post"
+            data: "test=' or 1=1# "
+          output:
+            log_contains: id "942440"
+  - test_title: 942440-10
+    desc: "SQL Comment Sequence"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: "POST"
+            port: 80
+            version: "HTTP/1.0"
+            uri: "/post"
+            data: "test=‘ or 1=1-- -"
+          output:
+            log_contains: id "942440"
+  - test_title: 942440-11
+    desc: "SQL Comment Sequence"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: "POST"
+            port: 80
+            version: "HTTP/1.0"
+            uri: "/post"
+            data: "test=‘ or 1=1/*"
+          output:
+            log_contains: id "942440"
+  - test_title: 942440-12
+    desc: "SQL Comment Sequence"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: "POST"
+            port: 80
+            version: "HTTP/1.0"
+            uri: "/post"
+            data: "test=1='1' or-- -"
+          output:
+            log_contains: id "942440"
+  - test_title: 942440-13
+    desc: "SQL Comment Sequence"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: "POST"
+            port: 80
+            version: "HTTP/1.0"
+            uri: "/post"
+            data: "test=' /*!50000or*/1='1"
+          output:
+            log_contains: id "942440"
+  - test_title: 942440-14
+    desc: "SQL Comment Sequence"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: "POST"
+            port: 80
+            version: "HTTP/1.0"
+            uri: "/post"
+            data: "test=' /*!or*/1='1"
+          output:
+            log_contains: id "942440"
+  - test_title: 942440-15
+    desc: "SQL Comment Sequence"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: "POST"
+            port: 80
+            version: "HTTP/1.0"
+            uri: "/post"
+            data: "test=0/**/union/*!50000select*/table_name`foo`/**/"
           output:
             log_contains: id "942440"

--- a/util/regexp-assemble/data/942440.data
+++ b/util/regexp-assemble/data/942440.data
@@ -1,15 +1,15 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
 ##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
+##!
 ##! Five special comments are at your disposal to influence the assembled expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
@@ -24,7 +24,7 @@
 /\*!?
 \*/
 [';]--
---[\s\r\n\v\f]
+--\s
 --[^-]*?-
-[^&-]#.*?[\s\r\n\v\f]
+[^&-]#.*?\s
 ;?\x00


### PR DESCRIPTION
- "\s" already covers all other symbols
- add tests for every declared detected payload

Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>