### PR TITLE
Remove FP on 942440 (JWT)

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1192,8 +1192,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
+    chain"
+    SecRule MATCHED_VARS "!@rx ^ey[A-Z-a-z0-9-_]+[.]ey[A-Z-a-z0-9-_]+[.][A-Z-a-z0-9-_]+$" "t:none,\
+        setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
+        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
 
 #

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942440.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942440.yaml
@@ -259,3 +259,19 @@ tests:
             data: "test=0/**/union/*!50000select*/table_name`foo`/**/"
           output:
             log_contains: id "942440"
+  - test_title: 942440-16
+    desc: "Avoid False Positive on JWT"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: "POST"
+            port: 80
+            version: "HTTP/1.0"
+            uri: "/post"
+            data: "token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMe--KKF2QT4fwpMeJf36POk6yJV_adQssw-5c"
+          output:
+            no_log_contains: id "942440"

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942440.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942440.yaml
@@ -304,6 +304,6 @@ tests:
             method: "GET"
             port: 80
             version: "HTTP/1.1"
-            uri: "/callback?token=token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMe--KKF2QT4fwpMeJf36POk6yJV_adQssw-5c"
+            uri: "/callback?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMe--KKF2QT4fwpMeJf36POk6yJV_adQssw-5c"
           output:
             no_log_contains: id "942440"

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942440.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942440.yaml
@@ -260,7 +260,7 @@ tests:
           output:
             log_contains: id "942440"
   - test_title: 942440-16
-    desc: "Avoid False Positive on JWT"
+    desc: "Avoid False Positive on JWT (body)"
     stages:
       - stage:
           input:
@@ -270,8 +270,40 @@ tests:
               User-Agent: OWASP ModSecurity Core Rule Set
             method: "POST"
             port: 80
-            version: "HTTP/1.0"
+            version: "HTTP/1.1"
             uri: "/post"
             data: "token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMe--KKF2QT4fwpMeJf36POk6yJV_adQssw-5c"
+          output:
+            no_log_contains: id "942440"
+  - test_title: 942440-17
+    desc: "Avoid False Positive on JWT (cookie)"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Cookie: "token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMe--KKF2QT4fwpMeJf36POk6yJV_adQssw-5c"
+            method: "POST"
+            port: 80
+            version: "HTTP/1.1"
+            uri: "/post"
+            data: "foo=bar"
+          output:
+            no_log_contains: id "942440"
+  - test_title: 942440-18
+    desc: "Avoid False Positive on JWT (querystring)"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: "GET"
+            port: 80
+            version: "HTTP/1.1"
+            uri: "/callback?token=token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMe--KKF2QT4fwpMeJf36POk6yJV_adQssw-5c"
           output:
             no_log_contains: id "942440"


### PR DESCRIPTION
often happens that a JWT has a "--something" string inside it. This triggers 942440 because "SQL Comment Syntax" that prevents something like `1+OR+1=1--comment`. An example of false positive:

```shell
curl -s -H 'x-format-output: txt-matched-rules' -H 'x-crs-paranoia-level: 2' "https://sandbox.coreruleset.org/?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMe--KKF2QT4fwpMeJf36POk6yJV_adQssw-5c"
```

With this PR I'm trying to add a chained rule that adds this condition:
match only if one of the listed variables don't match `^ey[A-Z-a-z0-9-_]+[.]ey[A-Z-a-z0-9-_]+[.][A-Z-a-z0-9-_]+$`

the regex should match all JWT token format assuming that `{"` should always be b64 encoded  to "ey..."

Do you see problems with this approach?