### PR TITLE
Change documentation git module link to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "docs/OWASP-CRS-Documentation"]
 	path = docs/OWASP-CRS-Documentation
-	url = git@github.com:coreruleset/documentation.git
+	url = https://github.com/coreruleset/documentation.git
 	branch = main
 [submodule "util/regexp-assemble/lib/lib"]
         path = util/regexp-assemble/lib/lib


### PR DESCRIPTION
The PR #2260 got merged without counting anonymous git clones in; as ssh clones only work with an authenticated GitHub account.

This commit changes the git protocol of the documentation submodule from ssh to https.