### PR TITLE
fix(932311): remove double m,n in regexp

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -607,7 +607,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 
 # This is a stricter sibling of rule 932130.
 #
-# It applies the same regular expression to the 
+# It applies the same regular expression to the
 # User-Agent and Referer HTTP headers.
 #
 # Unlike the sibling rule, this rule runs in phase 1.
@@ -947,7 +947,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #   cd util/regexp-assemble
 #   ./regexp-assemble.py data/932311.data
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?is)\r\n\w{1,50}\b\ (?:S(?:E(?:ARCH(?: CHARSET [\w\-_\.]{1,40})? (?:(KEYWORD \x5c)?(?:ALL|ANSWERED|BCC|DELETED|DRAFT|FLAGGED|RECENT|SEEN|UNANSWERED|UNDELETED|UNDRAFT|UNFLAGGED|UNSEEN|NEW|OLD)|(?:TEXT .{1,255}|TO .{1,255}|UID [0-9,:\*]+?|UNKEYWORD (?:\x5c(Seen|Answered|Flagged|Deleted|Draft|Recent)))|(?:BEFORE|ON|SENTBEFORE|SENTON|SENTSINCE|SINCE) \"?\d{1,2}-\w{3}-\d{4}\"?|(?:OR .{1,255} .{1,255}|SMALLER \d{1,20}|SUBJECT .{1,255})|(?:(?:BODY|CC|FROM)|HEADER .{1,100}) .{1,255}|(?:LARGER \d{1,20}|NOT .{1,255}|[0-9,:\*]+))|LECT [\w\"\.\-\x5c\/%\*&#]+)|T(?:ORE [0-9,:\*]+? [+-]?FLAGS(?:\.SILENT)? (?:\(\x5c[A-Za-z]{1,20}\)){0,100}|ARTTLS)|UBSCRIBE [\w\"\.\-\x5c\/%\*&#]+)|L(?:IST [\w\"~\-\x5c\/\*#\.]+? [\w\"\.\-\x5c\/%\*&#]+|OG(?:IN [A-Z0-9-_\.\@]{1,40} .*? |OUT))|C(?:(?:OPY [0-9,:\*]+|REATE) [\w\"\.\-\x5c\/%\*&#]+|APABILITY|HECK|LOSE)|RENAME [\w\"\.\-\x5c\/%\*&#]+? [\w\"\.\-\x5c\/%\*&#]+|UN(?:SUBSCRIBE [\w\"\.\-\x5c\/%\*&#]+|AUTHENTICATE)|EX(?:AMINE [\w\"\.\-\x5c%\*&#]+|PUNGE)|DELETE [\w\"\.\-\x5c%\*&#]+|FETCH [0-9,:\*]+|NOOP)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?is)\r\n\w{1,50}\b[ ](?:S(?:E(?:ARCH(?: CHARSET [\w\-_\.]{1,40})? (?:(KEYWORD \x5c)?(?:ALL|ANSWERED|BCC|DELETED|DRAFT|FLAGGED|RECENT|SEEN|UNANSWERED|UNDELETED|UNDRAFT|UNFLAGGED|UNSEEN|NEW|OLD)|(?:TEXT .{1,255}|TO .{1,255}|UID [0-9,:\*]+?|UNKEYWORD (?:\x5c(Seen|Answered|Flagged|Deleted|Draft|Recent)))|(?:BEFORE|ON|SENTBEFORE|SENTON|SENTSINCE|SINCE) \"?\d{1,2}-\w{3}-\d{4}\"?|(?:OR .{1,255} .{1,255}|SMALLER \d{1,20}|SUBJECT .{1,255})|(?:(?:BODY|CC|FROM)|HEADER .{1,100}) .{1,255}|(?:LARGER \d{1,20}|NOT .{1,255}|[0-9,:\*]+))|LECT [\w\"\.\-\x5c\/%\*&#]+)|T(?:ORE [0-9,:\*]+? [+-]?FLAGS(?:\.SILENT)? (?:\(\x5c[A-Za-z]{1,20}\))?|ARTTLS)|UBSCRIBE [\w\"\.\-\x5c\/%\*&#]+)|L(?:IST [\w\"~\-\x5c\/\*#\.]+? [\w\"\.\-\x5c\/%\*&#]+|OG(?:IN [A-Z0-9-_\.\@]{1,40} .*?|OUT))|C(?:(?:OPY [0-9,:\*]+|REATE) [\w\"\.\-\x5c\/%\*&#]+|APABILITY|HECK|LOSE)|RENAME [\w\"\.\-\x5c\/%\*&#]+? [\w\"\.\-\x5c\/%\*&#]+|UN(?:SUBSCRIBE [\w\"\.\-\x5c\/%\*&#]+|AUTHENTICATE)|EX(?:AMINE [\w\"\.\-\x5c%\*&#]+|PUNGE)|DELETE [\w\"\.\-\x5c%\*&#]+|FETCH [0-9,:\*]+|NOOP)" \
     "id:932311,\
     phase:2,\
     block,\

--- a/util/regexp-assemble/data/932311.data
+++ b/util/regexp-assemble/data/932311.data
@@ -1,13 +1,13 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
-##! 
+##!
 ##! Five special comments are at your disposal to influence the assembled expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
@@ -20,7 +20,7 @@
 
 ##! TDB: representing charset and language (if needed)
 
-##!^ (?is)\r\n\w{1,50}\b\ 
+##!^ (?is)\r\n\w{1,50}\b[ ]
 
 ##! - IMAP4 Commands - PL3
 
@@ -31,10 +31,10 @@ DELETE [\w\"\.\-\x5c%\*&#]+
 EXAMINE [\w\"\.\-\x5c%\*&#]+
 FETCH [0-9,:\*]+
 LIST [\w\"~\-\x5c\/\*#\.]+? [\w\"\.\-\x5c\/%\*&#]+
-LOGIN [A-Z0-9-_\.\@]{1,40} .*? 
+LOGIN [A-Z0-9-_\.\@]{1,40} .*?
 RENAME [\w\"\.\-\x5c\/%\*&#]+? [\w\"\.\-\x5c\/%\*&#]+
 SELECT [\w\"\.\-\x5c\/%\*&#]+
-STORE [0-9,:\*]+? [+-]?FLAGS(?:\.SILENT)? (?:\(\x5c[A-Za-z]{1,20}\)){0,100}
+STORE [0-9,:\*]+? [+-]?FLAGS(?:\.SILENT)? (?:\(\x5c[A-Za-z]{1,20}\))?
 SUBSCRIBE [\w\"\.\-\x5c\/%\*&#]+
 UNSUBSCRIBE [\w\"\.\-\x5c\/%\*&#]+
 ##! Search has plenty of variants


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

After doing a pass for re2 compat we found that this regexp was failing with `error parsing regexp: invalid repeat count: "{0,100}"`.

After reviewing it, I don't think we need to be that precise in this match, for STORE there might be additional flags, but it suffice to match one or not.

Also updated the prefix to be a `[ ]` space instead of an escaped one, because editors might get confused and rip it off because is is a space a the end.
