### PR TITLE
Reporting rules tweaks

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -320,29 +320,37 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 
 
 #
-# -- [[ Anomaly Score Reporting Level ]] ------------------------------
+# -- [[ Anomaly Score Reporting Level ]] ---------------------------------------
 #
-# When a request is being blocked due to the anomaly score meeting
-# the anomaly threshold, then the blocking rule will also report the
-# anomaly score. This applies to the separate inbound and outbound
-# anomaly score.
-# In phase 5, there are additional rules that can perform additional
-# reporting of anomaly scores with a verbosity that depends on
-# the reporting level defined below.
+# When a request is blocked due to the anomaly score meeting or exceeding the
+# anomaly threshold then the blocking rule will also report the anomaly score.
+# This applies to the separate inbound and outbound anomaly scores.
+#
+# In phase 5, there are additional rules that can perform additional reporting
+# of anomaly scores with a verbosity that depends on the reporting level defined
+# below.
+#
 # By setting the reporting level you control whether you want additional
-# reporting beyond the blocking rule or not and if yes, which requests should
-# be covered.
-# There are 4 reporting levels: 0, 1, 2, 3.
-# The higher the reporting level, the more verbose the reporting is.
+# reporting beyond the blocking rule or not and, if yes, which requests should
+# be covered. The higher the reporting level, the more verbose the reporting is.
+#
+# There are 6 reporting levels:
 #
 # 0 - Reporting disabled
-# 1 - Reporting for requests that were blocked due to anomaly score
-# 2 - Reporting for requests with an anomaly score larger than 0
-# 3 - Reporting for all requests
+# 1 - Reporting for requests with a blocking anomaly score >= a threshold
+# 2 - Reporting for requests with a detection anomaly score >= a threshold
+# 3 - Reporting for requests with a blocking anomaly score greater than 0
+# 4 - Reporting for requests with a detection anomaly score greater than 0
+# 5 - Reporting for all requests
 #
-# A value of 3 can be useful on platforms where you are interested
+# Note: Reporting levels 1 and 2 make it possible to differentiate between
+# requests that are blocked and requests that are *not* blocked but would have
+# been blocked if the blocking PL was equal to detection PL. This may be useful
+# for certain FP tuning methodologies, for example moving to a higher PL.
+#
+# A value of 5 can be useful on platforms where you are interested in logging
 # non-scoring requests, yet it is not possible to report this information in
-# the request / access log. This applies to NGINX for example.
+# the request/access log. This applies to Nginx, for example.
 #
 #SecAction \
 # "id:900115,\
@@ -350,7 +358,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  nolog,\
 #  pass,\
 #  t:none,\
-#  setvar:tx.reporting_level=2"
+#  setvar:tx.reporting_level=4"
 
 
 #

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -96,7 +96,7 @@ SecRule &TX:reporting_level "@eq 0" \
     pass,\
     nolog,\
     ver:'OWASP_CRS/3.4.0-dev',\
-    setvar:'tx.reporting_level=2'"
+    setvar:'tx.reporting_level=4'"
 
 # Default Early Blocking (rule 900120 in crs-setup.conf)
 SecRule &TX:early_blocking "@eq 0" \

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -63,7 +63,7 @@ SecRule TX:DETECTION_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_thr
 SecRule TX:REPORTING_LEVEL "@lt 3" "id:980049,phase:5,pass,nolog,skipAfter:END-REPORTING"
 
 # -= Blocking score greater than zero =- (Jump to reporting rule immediately when sum of inbound and outbound blocking score is greater than zero)
-SecRule TX:BLOCKING_ANOMALY_SCORE "@gt 0" "id:980050,phase:5,pass,nolog,skipAfter:END-REPORTING"
+SecRule TX:BLOCKING_ANOMALY_SCORE "@gt 0" "id:980050,phase:5,pass,nolog,skipAfter:LOG-REPORTING"
 
 # -= Reporting Level 4 =- (Continue only when tx.reporting_level is sufficiently high: 4 or higher)
 SecRule TX:REPORTING_LEVEL "@lt 4" "id:980051,phase:5,pass,nolog,skipAfter:END-REPORTING"

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -39,21 +39,38 @@ SecAction \
 # -=[ Anomaly Score Reporting ]=-
 #
 
-# -= Reporting Level 0 =- (Skip over reporting when tx.reporting_level is below 1)
-SecRule TX:REPORTING_LEVEL "@lt 1" "id:980041,phase:5,pass,nolog,skipAfter:END-REPORTING"
+# -= Reporting Level 0 =- (Skip over reporting when tx.reporting_level is 0)
+SecRule TX:REPORTING_LEVEL "@eq 0" "id:980041,phase:5,pass,nolog,skipAfter:END-REPORTING"
 
-# -= Reporting Level 3 =- (Jump to reporting rule immediately when tx.reporting_level is 3 or higher)
-SecRule TX:REPORTING_LEVEL "@ge 3" "id:980042,phase:5,pass,nolog,skipAfter:LOG-REPORTING"
+# -= Reporting Level 5 =- (Jump to reporting rule immediately when tx.reporting_level is 5 or greater)
+SecRule TX:REPORTING_LEVEL "@ge 5" "id:980042,phase:5,pass,nolog,skipAfter:LOG-REPORTING"
 
-# -= No score =- (Skip over reporting when sum of inbound and outbound score is equal to 0)
-SecRule TX:BLOCKING_ANOMALY_SCORE "@eq 0" "id:980043,phase:5,pass,nolog,skipAfter:END-REPORTING"
+# -= Zero detection score =- (Skip over reporting when sum of inbound and outbound detection score is equal to 0)
+SecRule TX:DETECTION_ANOMALY_SCORE "@eq 0" "id:980043,phase:5,pass,nolog,skipAfter:END-REPORTING"
 
-# -= Threshold exceeded =- (Jump to reporting rule immediately if a threshold is exceeded)
+# -= Blocking score exceeds threshold =- (Jump to reporting rule immediately if a blocking score exceeds a threshold)
 SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" "id:980044,phase:5,pass,nolog,skipAfter:LOG-REPORTING"
 SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" "id:980045,phase:5,pass,nolog,skipAfter:LOG-REPORTING"
 
-# -= Level too low =- (Skip reporting if level too low)
+# -= Reporting Level 2 =- (Continue only when tx.reporting_level is sufficiently high: 2 or higher)
 SecRule TX:REPORTING_LEVEL "@lt 2" "id:980046,phase:5,pass,nolog,skipAfter:END-REPORTING"
+
+# -= Detection score exceeds threshold =- (Jump to reporting rule immediately if a detection score exceeds a threshold)
+SecRule TX:DETECTION_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" "id:980047,phase:5,pass,nolog,skipAfter:LOG-REPORTING"
+SecRule TX:DETECTION_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" "id:980048,phase:5,pass,nolog,skipAfter:LOG-REPORTING"
+
+# -= Reporting Level 3 =- (Continue only when tx.reporting_level is sufficiently high: 3 or higher)
+SecRule TX:REPORTING_LEVEL "@lt 3" "id:980049,phase:5,pass,nolog,skipAfter:END-REPORTING"
+
+# -= Blocking score greater than zero =- (Jump to reporting rule immediately when sum of inbound and outbound blocking score is greater than zero)
+SecRule TX:BLOCKING_ANOMALY_SCORE "@gt 0" "id:980050,phase:5,pass,nolog,skipAfter:END-REPORTING"
+
+# -= Reporting Level 4 =- (Continue only when tx.reporting_level is sufficiently high: 4 or higher)
+SecRule TX:REPORTING_LEVEL "@lt 4" "id:980051,phase:5,pass,nolog,skipAfter:END-REPORTING"
+
+# At this point, the reporting level is 4 and there's a non-zero detection
+# score (already established by rule 980043) so fall through to the reporting
+# rule.
 
 # TODO: Explain which requests land here and how
 SecMarker "LOG-REPORTING"

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -52,20 +52,20 @@ SecRule TX:DETECTION_ANOMALY_SCORE "@eq 0" "id:980043,phase:5,pass,nolog,skipAft
 SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" "id:980044,phase:5,pass,nolog,skipAfter:LOG-REPORTING"
 SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" "id:980045,phase:5,pass,nolog,skipAfter:LOG-REPORTING"
 
-# -= Reporting Level 2 =- (Continue only when tx.reporting_level is sufficiently high: 2 or higher)
+# -= Reporting Level 2 =- (Skip over reporting when tx.reporting_level is less than 2)
 SecRule TX:REPORTING_LEVEL "@lt 2" "id:980046,phase:5,pass,nolog,skipAfter:END-REPORTING"
 
 # -= Detection score exceeds threshold =- (Jump to reporting rule immediately if a detection score exceeds a threshold)
 SecRule TX:DETECTION_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" "id:980047,phase:5,pass,nolog,skipAfter:LOG-REPORTING"
 SecRule TX:DETECTION_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" "id:980048,phase:5,pass,nolog,skipAfter:LOG-REPORTING"
 
-# -= Reporting Level 3 =- (Continue only when tx.reporting_level is sufficiently high: 3 or higher)
+# -= Reporting Level 3 =- (Skip over reporting when tx.reporting_level is less than 3)
 SecRule TX:REPORTING_LEVEL "@lt 3" "id:980049,phase:5,pass,nolog,skipAfter:END-REPORTING"
 
 # -= Blocking score greater than zero =- (Jump to reporting rule immediately when sum of inbound and outbound blocking score is greater than zero)
 SecRule TX:BLOCKING_ANOMALY_SCORE "@gt 0" "id:980050,phase:5,pass,nolog,skipAfter:LOG-REPORTING"
 
-# -= Reporting Level 4 =- (Continue only when tx.reporting_level is sufficiently high: 4 or higher)
+# -= Reporting Level 4 =- (Skip over reporting when tx.reporting_level is less than 4)
 SecRule TX:REPORTING_LEVEL "@lt 4" "id:980051,phase:5,pass,nolog,skipAfter:END-REPORTING"
 
 # At this point, the reporting level is 4 and there's a non-zero detection

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -72,7 +72,13 @@ SecRule TX:REPORTING_LEVEL "@lt 4" "id:980051,phase:5,pass,nolog,skipAfter:END-R
 # score (already established by rule 980043) so fall through to the reporting
 # rule.
 
-# TODO: Explain which requests land here and how
+
+# Requests that land on the following SecMarker:
+# - At reporting level 5 (unconditional reporting)
+# - At reporting levels 1-4 when a blocking score exceeds a threshold
+# - At reporting levels 2-4 when a detection score exceeds a threshold
+# - At reporting levels 3-4 when the total blocking score is greater than zero
+# - At reporting level 4 when the total detection score is greater than zero
 SecMarker "LOG-REPORTING"
 
 # Inbound and outbound - all requests

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -39,22 +39,23 @@ SecAction \
 # -=[ Anomaly Score Reporting ]=-
 #
 
-# -= Reporting Level 0 =- (skip over reporting when tx.reporting_level is below 1)
+# -= Reporting Level 0 =- (Skip over reporting when tx.reporting_level is below 1)
 SecRule TX:REPORTING_LEVEL "@lt 1" "id:980041,phase:5,pass,nolog,skipAfter:END-REPORTING"
 
-# -= Reporting Level 3 =- (jump to reporting rule immediately when tx.reporting_level is 3 or higher)
-SecRule TX:REPORTING_LEVEL "!@lt 3" "id:980042,phase:5,pass,nolog,skipAfter:LOG-REPORTING"
+# -= Reporting Level 3 =- (Jump to reporting rule immediately when tx.reporting_level is 3 or higher)
+SecRule TX:REPORTING_LEVEL "@ge 3" "id:980042,phase:5,pass,nolog,skipAfter:LOG-REPORTING"
 
-# -= No score =- (skip over reporting when sum of inbound and outbound score is not greater than 0)
-SecRule TX:BLOCKING_ANOMALY_SCORE "!@gt 0" "id:980043,phase:5,pass,nolog,skipAfter:END-REPORTING"
+# -= No score =- (Skip over reporting when sum of inbound and outbound score is equal to 0)
+SecRule TX:BLOCKING_ANOMALY_SCORE "@eq 0" "id:980043,phase:5,pass,nolog,skipAfter:END-REPORTING"
 
-# -= Threshold exceeded =- (jump to reporting rule immediately if a threshold is exceeded)
+# -= Threshold exceeded =- (Jump to reporting rule immediately if a threshold is exceeded)
 SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" "id:980044,phase:5,pass,nolog,skipAfter:LOG-REPORTING"
 SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" "id:980045,phase:5,pass,nolog,skipAfter:LOG-REPORTING"
 
-# -= Level too low =- (skip reporting if level too low)
+# -= Level too low =- (Skip reporting if level too low)
 SecRule TX:REPORTING_LEVEL "@lt 2" "id:980046,phase:5,pass,nolog,skipAfter:END-REPORTING"
 
+# TODO: Explain which requests land here and how
 SecMarker "LOG-REPORTING"
 
 # Inbound and outbound - all requests

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -19,7 +19,7 @@
 # -= Paranoia Level 0 (empty) =- (apply unconditionally)
 #
 
-# combine inbound and outbound scores
+# Combine inbound and outbound scores
 SecAction \
     "id:980099,\
     phase:5,\
@@ -57,7 +57,7 @@ SecRule TX:REPORTING_LEVEL "@lt 2" "id:980046,phase:5,pass,nolog,skipAfter:END-R
 
 SecMarker "LOG-REPORTING"
 
-# inbound and outbound - all requests
+# Inbound and outbound - all requests
 SecAction \
     "id:980170,\
     phase:5,\

--- a/tests/regression/tests/RESPONSE-980-CORRELATION/980170.yaml
+++ b/tests/regression/tests/RESPONSE-980-CORRELATION/980170.yaml
@@ -4,13 +4,13 @@ meta:
   enabled: true
   name: "980170.yaml"
   description: |
-    Test whether level 2 inbound reporting in phase 5 works by testing whether rule 980170 is triggered.
+    Test whether level 4 inbound reporting in phase 5 works by testing whether rule 980170 is triggered.
     For these tests, existing test are repurposed with different assertions. Instead of asserting that the original
     rules are triggered that the tests are written for, we assert that triggering these rules causes the corresponding
     reporting rules to be triggered.
 tests:
   - test_title: 980170-0
-    desc: Test is similar to 920350-1 but here we check if at reporting level 2 a request is logged that was blocked
+    desc: Test is similar to 920350-1 but here we check if at reporting level 4 a request is logged that was blocked
     stages:
       - stage:
           input:
@@ -26,7 +26,7 @@ tests:
           output:
             log_contains: "id \"980170\""
   - test_title: 980170-1
-    desc: Test is similar to 920350-1 but here we check if at reporting level 2 a request is logged that scored but was not blocked
+    desc: Test is similar to 920350-1 but here we check if at reporting level 4 a request is logged that scored but was not blocked
     stages:
       - stage:
           input:
@@ -42,7 +42,7 @@ tests:
           output:
             log_contains: "id \"980170\""
   - test_title: 980170-2
-    desc: Test is similar to 920350-1 but here we check if at reporting level 2 a request is not logged that did not score
+    desc: Test is similar to 920350-1 but here we check if at reporting level 4 a request is not logged that did not score
     stages:
       - stage:
           input:


### PR DESCRIPTION
This PR will address the additional issues and comments raised in #2482.

## Outstanding Issues Copy-Pasted from #2482

### 980042

Could we express the operator as `@ge 2` like the comment describes? The negation twists my brain.

### 980043

Dito. `@eq 0` would be easier. Here the comment is also twisted.

### SecMarker "LOG-REPORTING"


I think it would be useful to add a comment in front of this marker to describe how Reporting-Level 1 and requests with positive score land here.

### Msg: Brackets?

Why do you put the scores in brackets?

-> `Anomaly Scores: (Inbound Scores: blocking=10, detection=15, per_pl=10-0-0-5, threshold=1) - (Outbound Scores: blocking=0, detection=0, per_pl=0-0-0-0, threshold=10) - (SQLI=0, XSS=0, RFI=0, LFI=5, RCE=5, PHPI=0, HTTP=0, SESS=0)`


### Question

Is there a need for a reporting level between the current 1 and 2? This blocking score not yet at threshold, but detection score is already hitting it. I can think of a FP tuning methodology that would profit from such a reporting level.

This could look as follows (also adding one between right below the highest level):

```
# 0 - Reporting disabled
# 1 - Reporting for requests with blocking score >= threshold (-> blocked)
# 2 - Reporting for requests with detection score >= threshold (-> not blocked, but it would have been blocked if blocking PL was equal to detection PL)
# 3 - Reporting for requests with blocking anomaly score larger than 0
# 4 - Reporting for requests with detection anomaly score larger than 0
# 5 - Reporting for all requests
```

All in all simply more granular control over reporting.