### PR TITLE
Fix FP in MySQL data leakage

### DIFF
--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -333,6 +333,10 @@ SecRule TX:sql_error_match "@eq 1" \
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
+# Regular expression generated from util/regexp-assemble/data/932100.data.
+# To update the regular expression run the following shell script
+# (consult util/regexp-assemble/README.md for details):
+#   util/regexp-assemble/regexp-assemble.py update 951230
 SecRule TX:sql_error_match "@eq 1" \
     "id:951230,\
     phase:4,\

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -352,7 +352,7 @@ SecRule TX:sql_error_match "@eq 1" \
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
-    SecRule RESPONSE_BODY "@rx (?i)(?:supplied argument is not a valid MySQL|Column count doesn't match value count at row|mysql_fetch_array\(\)|on MySQL result index|You have an error in your SQL syntax;|You have an error in your SQL syntax near|MySQL server version for the right syntax to use|\[MySQL\]\[ODBC|Column count doesn't match|Table '[^']+' doesn't exist|SQL syntax.*MySQL|Warning.*mysql_.*|valid MySQL result|MySqlClient\.|ERROR [0-9]{4} \([A-Z0-9]{5}\):)" \
+    SecRule RESPONSE_BODY "@rx (?i)(?:MyS(?:QL server version for the right syntax to use|qlClient\.)|(?:supplied argument is not a valid |SQL syntax.*)MySQL|Column count doesn't match(?: value count at row)?|(?:Table '[^']+' doesn't exis|valid MySQL resul)t|You have an error in your SQL syntax(?: near|;)|Warning.{1,10}mysql_(?:[a-z_()]{1,26})?|ERROR [0-9]{4} \([A-Z0-9]{5}\):|mysql_fetch_array\(\)|on MySQL result index|\[MySQL\]\[ODBC)" \
         "capture,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -333,10 +333,11 @@ SecRule TX:sql_error_match "@eq 1" \
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
-# Regular expression generated from util/regexp-assemble/data/932100.data.
+# Regular expression generated from util/regexp-assemble/data/952230.data.
 # To update the regular expression run the following shell script
 # (consult util/regexp-assemble/README.md for details):
-#   util/regexp-assemble/regexp-assemble.py update 951230
+#   util/regexp-assemble/regexp-assemble.py generate 951230
+# Copy the output and replace the regular expression in the chain rule with it.
 SecRule TX:sql_error_match "@eq 1" \
     "id:951230,\
     phase:4,\

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -357,7 +357,7 @@ SecRule TX:sql_error_match "@eq 1" \
     ver:'OWASP_CRS/3.4.0-dev',\
     severity:'CRITICAL',\
     chain"
-    SecRule RESPONSE_BODY "@rx (?i)(?:MyS(?:QL server version for the right syntax to use|qlClient\.)|(?:supplied argument is not a valid |SQL syntax.*)MySQL|Column count doesn't match(?: value count at row)?|(?:Table '[^']+' doesn't exis|valid MySQL resul)t|You have an error in your SQL syntax(?: near|;)|Warning.{1,10}mysql_(?:[a-z_()]{1,26})?|ERROR [0-9]{4} \([A-Z0-9]{5}\):|mysql_fetch_array\(\)|on MySQL result index|\[MySQL\]\[ODBC)" \
+    SecRule RESPONSE_BODY "@rx (?i)(?:MyS(?:QL server version for the right syntax to use|qlClient\.)|(?:supplied argument is not a valid |SQL syntax.*)MySQL|Column count doesn't match(?: value count at row)?|(?:Table '[^']+' doesn't exis|valid MySQL resul)t|You have an error in your SQL syntax(?: near|;)|Warning.{1,10}mysql_(?:[a-z_()]{1,26})?|ERROR [0-9]{4} \([a-z0-9]{5}\):|mysql_fetch_array\(\)|on MySQL result index|\[MySQL\]\[ODBC)" \
         "capture,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"

--- a/util/regexp-assemble/data/951230.data
+++ b/util/regexp-assemble/data/951230.data
@@ -1,0 +1,41 @@
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
+##! util/regexp-assemble/regexp-assemble.py.
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
+##! script in util/regexp-assemble/README.md.
+##!
+##! Lines starting with `##!` are comments and will be skipped,
+##! empty lines will be ignored completely.
+##! In addition, the quote character `'` at the beginning of a line will
+##! cause the line to be interpreted as literal by the cmdline preprocessor only.
+##!
+##! Five special comments are at your disposal to influence the assembled expression:
+##! - `##!+`: the flag comment
+##! - `##!^`: the prefix comment
+##! - `##!$`: the suffix comment
+##! - `##!>`: the preprocessor comment
+##! - `##!<`: the block preprocessor end comment
+##!
+##! Currently supported preprocessors:
+##! - cmdline [windows|unix] (file scope)
+##! Please refer to util/regexp-assemble/README.md for a full explanation
+
+##!+ i
+
+supplied argument is not a valid MySQL
+Column count doesn't match value count at row
+mysql_fetch_array\(\)
+on MySQL result index
+You have an error in your SQL syntax;
+You have an error in your SQL syntax near
+MySQL server version for the right syntax to use
+\[MySQL\]\[ODBC
+Column count doesn't match
+Table '[^']+' doesn't exist
+SQL syntax.*MySQL
+##! Because of the bug in RE2 (golang), we cannot use {0,n} (a range started at 0), so it was replaced with (?:...{1,n})?
+Warning.{1,10}mysql_(?:[a-z_()]{1,26})?
+valid MySQL result
+MySqlClient\.
+ERROR [0-9]{4} \([A-Z0-9]{5}\):

--- a/util/regexp-assemble/data/951230.data
+++ b/util/regexp-assemble/data/951230.data
@@ -38,4 +38,4 @@ SQL syntax.*MySQL
 Warning.{1,10}mysql_(?:[a-z_()]{1,26})?
 valid MySQL result
 MySqlClient\.
-ERROR [0-9]{4} \([A-Z0-9]{5}\):
+ERROR [0-9]{4} \([a-z0-9]{5}\):


### PR DESCRIPTION
FP is doing this pattern:
`Warning.*mysql_.*`

I'm not sure what error message is this supposed to match but while trying to google it, i found only PHP error messages (see below), so i assume it's for PHP errors.

To lower FPs, i made pattern more tighter:
`Warning.{1,10}mysql_[a-z_()]{0,26}`

For the first part of the pattern (`Warning.{1,10}`), i saw multiple versions of the error message:
```
Warninig: mysql_...
Warninig:mysql_...
Warninig : mysql_...
Warninig:   mysql_...
```

For the second part (`mysql_[a-z_()]{0,26}`), i assume we are trying to catch a function name (list: https://www.php.net/manual/en/ref.mysql.php ) and longest function name (`mysql_real_escape_string`) has 24 characters (+2 for brackets). Limiting length of matched data will also create nicer error messages.


Various error messages matching problematic pattern:
```
Warning: mysql_close(): 5 is not a valid MySQL-Link resource

Warning: mysql_fetch_array(): supplied argument is not a valid MySQL result

Warning: mysql_query() [function.mysql-query]: Access denied for user 'root'@'localhost' (using password: NO) in /home/adamjudk/public_html/airlinesimulator/login.php on line 18

Warning: mysql_num_rows(): supplied argument is not a valid MySQL result resource

MYSQL PHP Warning: mysql_query() expects parameter 1 to be string

Warning: mysql_query() [function.mysql-query]: A link to the server could not be established in /home/adamjudk/public_html/airlinesimulator/login.php on line 18

Warning: mysql_ functions are deprecated as of PHP 5.5.0, and will be removed in the future. Instead, the MySQLi or PDO_MySQL extension should be used.

```