### PR TITLE
Use type hints in a way that are compatible with Python 3.7+

### DIFF
--- a/util/regexp-assemble/lib/operators/assembler.py
+++ b/util/regexp-assemble/lib/operators/assembler.py
@@ -1,6 +1,6 @@
 import re, sys
 from subprocess import Popen, PIPE, TimeoutExpired
-from typing import TextIO, TypeVar
+from typing import TextIO, List
 import logging
 
 from lib.context import Context
@@ -79,7 +79,7 @@ class Assembler(object):
     def _is_simple_comment(self, line: str) -> bool:
         return self.simple_comment_regex.match(line) is not None
 
-    def preprocess(self, lines: list[str]) -> list[str]:
+    def preprocess(self, lines: List[str]) -> List[str]:
         iterator = lines.__iter__()
         final_lines = []
         for processor_type in (LinePreprocessor, BlockPreprocessor, FilePreprocessor):
@@ -101,7 +101,7 @@ class Assembler(object):
             iterator = final_lines.__iter__()
         return final_lines
 
-    def assemble(self, lines: list[str]) -> str:
+    def assemble(self, lines: List[str]) -> str:
         args = [self.context.regexp_assemble_pl_path]
         outs = None
         errs = None

--- a/util/regexp-assemble/lib/processors/cmdline.py
+++ b/util/regexp-assemble/lib/processors/cmdline.py
@@ -19,7 +19,7 @@
 # Refer to rule 932100, 932110, 932150 for documentation.
 #
 
-from typing import TypeVar, Type
+from typing import TypeVar, List
 
 from lib.processors.processor import Processor
 
@@ -27,7 +27,7 @@ T = TypeVar("T", bound="CmdLine")
 
 
 class CmdLine(Processor):
-    lines: list[bytes] = []
+    lines: List[bytes] = []
 
     def __init__(self, evasion_pattern, suffix_evasion_pattern):
         self.evasion_pattern = evasion_pattern
@@ -55,7 +55,7 @@ class CmdLine(Processor):
         self.logger.debug("cmdline out: %s", processed)
 
     # overrride
-    def complete(self) -> list[bytes]:
+    def complete(self) -> List[bytes]:
         try:
             return self.lines
         finally:


### PR DESCRIPTION
@lifeforms Sorry, this is urgent and needs to go into v4.