### PR TITLE
Fix false positive, issue number #2434

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -940,7 +940,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
 # - application/soap+xml; charset=utf-8; action="urn:localhost-hwh#getQuestions"
 # - application/*+json
 
-SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+*-]+(?:\s?;\s?(?:action|boundary|charset|start(?:-info)?|type|version)\s?=\s?['\"\w.()+,/:=?<>@#*-]+)*$" \
+SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+*-]+(?:\s?;\s?(?:action|boundary|charset|component|start(?:-info)?|type|version)\s?=\s?['\"\w.()+,/:=?<>@#*-]+)*$" \
     "id:920470,\
     phase:1,\
     block,\


### PR DESCRIPTION
Fix for rule 920470, Modified rule regex to allow Content-Type of the pattern `text/calendar; charset=utf-8; component=vevent`