### PR TITLE
Hardening Content-Type header

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -959,6 +959,27 @@ SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+*-]+(?:\s?;\s?(?:action|bounda
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
+# Catching Content-Type header with multiple identic parameters. Example:
+# Content-Type: application/json; charset=UTF-8; charset=UTF-7
+SecRule REQUEST_HEADERS:Content-Type "@rx ^[\w/.+*-]+(?:\s?;\s?(action|boundary|charset|component|start[^-]|start-info|type|version).*\1\s?=\s?['\"\w.()+,/:=?<>@#*-]+)+$" \
+    "id:920471,\
+    phase:1,\
+    block,\
+    t:none,t:lowercase,\
+    msg:'Illegal Content-Type header',\
+    logdata:'%{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/255/153',\
+    tag:'PCI/12.1',\
+    ver:'OWASP_CRS/4.0.0-rc1',\
+    severity:'CRITICAL',\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
 # In case Content-Type header can be parsed, check the mime-type against
 # the policy defined in the 'allowed_request_content_type' variable.
 # To change your policy, edit crs-setup.conf and activate rule 900220.

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920471.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920471.yaml
@@ -5,7 +5,7 @@ meta:
   name: "920471.yaml"
   description: "Content-Type header format checks"
 tests:
-  - test_title: 920470-1
+  - test_title: 920471-1
     stages:
       - stage:
           input:
@@ -19,7 +19,7 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
           output:
             log_contains: "id \"920471\""
-  - test_title: 920470-2
+  - test_title: 920471-2
     stages:
       - stage:
           input:

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920471.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920471.yaml
@@ -1,0 +1,36 @@
+---
+meta:
+  author: "azurit"
+  enabled: true
+  name: "920471.yaml"
+  description: "Content-Type header format checks"
+tests:
+  - test_title: 920470-1
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            port: 80
+            headers:
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Host: "localhost"
+              Content-Type: "application/json;charset=UTF-8;charset=UTF-7"
+              Content-Length: 0
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          output:
+            log_contains: "id \"920471\""
+  - test_title: 920470-2
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            port: 80
+            method: POST
+            headers:
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Host: "localhost"
+              Content-Type: "application/json; charset=UTF-8; action=test; boundary=test; component=test; start=test; start-info=test; type=test; version=test"
+              Content-Length: 0
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          output:
+            no_log_contains: "id \"920471\""


### PR DESCRIPTION
Introducing new rule which is catching `Content-Type` header containing multiple identic parameters. See [here](https://owasp.slack.com/archives/G01K88J8SDB/p1651445380736999).

Example:
`Content-Type: application/json; charset=UTF-8; charset=UTF-7`