### PR TITLE
fix(logging): move audit log part E if there is a chained rule

### DIFF
--- a/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
+++ b/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
@@ -120,13 +120,13 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?)://(?:[^@]+@)?([^/]+)" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/175/253',\
     tag:'paranoia-level/2',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_parameter_%{MATCHED_VAR_NAME}=.%{tx.1}',\
     chain"
     SecRule TX:/rfi_parameter_.*/ "!@endsWith .%{request_headers.host}" \
-        "setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
+        "ctl:auditLogParts=+E,\
+        setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -126,13 +126,13 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.933120_tx_0=%{tx.0}',\
     chain"
     SecRule MATCHED_VARS "@pm =" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -541,13 +541,13 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     tag:'paranoia-level/2',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.933151_tx_0=%{tx.0}',\
     chain"
     SecRule MATCHED_VARS "@pm (" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 

--- a/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
+++ b/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
@@ -65,7 +65,6 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/21/593/61',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     chain"
@@ -73,7 +72,8 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
         "capture,\
         chain"
         SecRule TX:1 "!@endsWith %{request_headers.host}" \
-            "setvar:'tx.session_fixation_score=+%{tx.critical_anomaly_score}',\
+            "ctl:auditLogParts=+E,\
+            setvar:'tx.session_fixation_score=+%{tx.critical_anomaly_score}',\
             setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
@@ -92,12 +92,12 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/21/593/61',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     chain"
     SecRule &REQUEST_HEADERS:Referer "@eq 0" \
-        "setvar:'tx.session_fixation_score=+%{tx.critical_anomaly_score}',\
+        "ctl:auditLogParts=+E,\
+        setvar:'tx.session_fixation_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -57,12 +57,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:JET Database Engine|Access Database Engine|\[Microsoft\]\[ODBC Microsoft Access Driver\])" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -81,12 +81,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:ORA-[0-9][0-9][0-9][0-9]|java\.sql\.SQLException|Oracle error|Oracle.*Driver|Warning.*oci_.*|Warning.*ora_.*)" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -105,12 +105,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:DB2 SQL error:|\[IBM\]\[CLI Driver\]\[DB2/6000\]|CLI Driver.*DB2|DB2 SQL error|db2_\w+\()" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -129,12 +129,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:\[DM_QUERY_E_SYNTAX\]|has occurred in the vicinity of:)" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -153,12 +153,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)Dynamic SQL Error" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -178,12 +178,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)Exception (?:condition )?\d+\. Transaction rollback\." \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -202,12 +202,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)org\.hsqldb\.jdbc" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -226,12 +226,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:An illegal character has been found in the statement|com\.informix\.jdbc|Exception.*Informix)" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -251,12 +251,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:Warning.*ingres_|Ingres SQLSTATE|Ingres\W.*Driver)" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -276,12 +276,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:<b>Warning</b>: ibase_|Unexpected end of command in statement)" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -300,12 +300,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:SQL error.*POS[0-9]+.*|Warning.*maxdb.*)" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -324,12 +324,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)(?:System\.Data\.OleDb\.OleDbException|\[Microsoft\]\[ODBC SQL Server Driver\]|\[Macromedia\]\[SQLServer JDBC Driver\]|\[SqlException|System\.Data\.SqlClient\.SqlException|Unclosed quotation mark after the character string|'80040e14'|mssql_query\(\)|Microsoft OLE DB Provider for ODBC Drivers|Microsoft OLE DB Provider for SQL Server|Incorrect syntax near|Sintaxis incorrecta cerca de|Syntax error in string in query expression|Procedure or function .* expects parameter|Unclosed quotation mark before the character string|Syntax error .* in query expression|Data type mismatch in criteria expression\.|ADODB\.Field \(0x800A0BCD\)|the used select statements have different number of columns|OLE DB.*SQL Server|Warning.*mssql_.*|Driver.*SQL[ _-]*Server|SQL Server.*Driver|SQL Server.*[0-9a-fA-F]{8}|Exception.*\WSystem\.Data\.SqlClient\.)" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -353,12 +353,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)(?:MyS(?:QL server version for the right syntax to use|qlClient\.)|(?:supplied argument is not a valid |SQL syntax.*)MySQL|Column count doesn't match(?: value count at row)?|(?:Table '[^']+' doesn't exis|valid MySQL resul)t|You have an error in your SQL syntax(?: near|;)|Warning.{1,10}mysql_(?:[a-z_()]{1,26})?|ERROR [0-9]{4} \([a-z0-9]{5}\):|mysql_fetch_array\(\)|on MySQL result index|\[MySQL\]\[ODBC)" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -377,12 +377,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:PostgreSQL query failed:|pg_query\(\) \[:|pg_exec\(\) \[:|PostgreSQL.{1,20}ERROR|Warning.*\bpg_.*|valid PostgreSQL result|Npgsql\.|PG::[a-zA-Z]*Error|Supplied argument is not a valid PostgreSQL .*? resource|Unable to connect to PostgreSQL server)" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -401,12 +401,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)(?:Warning.*sqlite_.*|Warning.*SQLite3::|SQLite/JDBCDriver|SQLite\.Exception|System\.Data\.SQLite\.SQLiteException)" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -425,12 +425,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)(?:Sybase message:|Warning.{2,20}sybase|Sybase.*Server message.*)" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 


### PR DESCRIPTION
This pull request addresses the bug described in https://github.com/coreruleset/coreruleset/issues/2530 by moving the `ctl:auditLogParts=+E` to the chained rules where there are chained rules.