### PR TITLE
fix(regexp-assemble): Fix some remaining issues

### DIFF
--- a/util/regexp-assemble/lib/context.py
+++ b/util/regexp-assemble/lib/context.py
@@ -15,7 +15,9 @@ class Context(object):
             self.regexp_assemble_directory, "lib", "regexp-assemble.pl"
         )
         self.single_rule_id = namespace.rule_id if namespace else None
-        self.single_chain_offset = namespace.chain_offset if namespace else None
+        self.single_chain_offset = None
+        if namespace and "chain_offset" in namespace:
+            self.single_chain_offset = namespace.chain_offset
 
         assert (
             os.path.exists(self.rules_directory)

--- a/util/regexp-assemble/lib/operators/assembler.py
+++ b/util/regexp-assemble/lib/operators/assembler.py
@@ -20,7 +20,7 @@ SIMPLE_COMMENT_REGEX = re.compile(rf'{COMMENT_REGEX_PREFIX}[^{SPECIAL_COMMENT_MA
 
 class NestingError(Exception):
     def __init__(self, line: int, depth: int):
-        super().__init__()
+        super().__init__(f"Nesting error on line {line}, nesting level {depth}")
 
         self.line = line
         self.depth = depth

--- a/util/regexp-assemble/regexp-assemble.py
+++ b/util/regexp-assemble/regexp-assemble.py
@@ -124,7 +124,7 @@ def build_compare_args_parser(subparsers: S):
 
 
 def handle_generate(namespace: argparse.Namespace):
-    context = create_context()
+    context = create_context(namespace)
     assembler = Assembler(context)
 
     if namespace.rule_id:
@@ -143,7 +143,7 @@ def handle_generate(namespace: argparse.Namespace):
 
 
 def handle_update(namespace: argparse.Namespace):
-    updater = Updater(create_context(namespace.rule_id))
+    updater = Updater(create_context(namespace))
     if namespace.rule_id:
         updater.run(False)
     elif namespace.all:


### PR DESCRIPTION
* Properly pass and handle the argparse namespace.
* Improve informational and error output
* Don't cache assembler to prevent mixing state
* Fix false warning when updating chain rule where the starter rule
  does not use @rx