### PR TITLE
Add missing @rx operators to 932 rules, in v4.1/dev branch

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -748,7 +748,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # (consult util/regexp-assemble/README.md for details):
 #   util/regexp-assemble/regexp-assemble.py update 932300
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?is)\r\n.*?\b(?:AUTH [A-Z0-9-_]{1,20} (?:=|(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=))|R(?:CPT TO:(?:<.{1,64}@.{1,255}>|(?: ))?<.{1,64}>|SET\b)|VRFY (?:.{1,64} <.{1,64}@.{1,255}>|.{1,64}@.{1,255})|E(?:HLO [a-zA-Z-\.]{1,255}|XPN (?:.{1,64}))|MAIL FROM:<.{1,64}@.{1,255}>|HELO [a-zA-Z-\.]{1,255}|NOOP\b(?: .{1,255})?|STARTTLS\b)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?is)\r\n.*?\b(?:AUTH [A-Z0-9-_]{1,20} (?:=|(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=))|R(?:CPT TO:(?:<.{1,64}@.{1,255}>|(?: ))?<.{1,64}>|SET\b)|VRFY (?:.{1,64} <.{1,64}@.{1,255}>|.{1,64}@.{1,255})|E(?:HLO [a-zA-Z-\.]{1,255}|XPN (?:.{1,64}))|MAIL FROM:<.{1,64}@.{1,255}>|HELO [a-zA-Z-\.]{1,255}|NOOP\b(?: .{1,255})?|STARTTLS\b)" \
     "id:932300,\
     phase:2,\
     block,\
@@ -781,7 +781,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # (consult util/regexp-assemble/README.md for details):
 #   util/regexp-assemble/regexp-assemble.py update 932310
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?is)\r\n\w{1,50}\b[ ](?:A(?:PPEND (?:[\w\"\.\-\x5c\/%\*&#]+)?(?: \((?:[a-z\x5c\ ])+\))?(?: \"?\d{1,2}-\w{3}-\d{4} \d{2}:\d{2}:\d{2} [+-]\d{4}\"?)? \{\d{1,20}\+?}|UTHENTICATE [a-z0-9-_]{1,20}\r\n)|S(?:TATUS (?:[\w\"\.\-\x5c\/%\*&]+)? \((?:UNSEEN|UIDNEXT|MESSAGES|UIDVALIDITY|RECENT| )+\)|ETACL (?:[\w\"\.\-\x5c\/%\*&]+)? [+-][lrswipckdxtea]+?)|L(?:SUB (?:[\w\"~\/\*#\.]+)? (?:[\w\"\.\x5c\/%\*&]+)?|ISTRIGHTS (?:[\w\"\.\-\x5c\/%\*&]+)?)|(?:(?:DELETE|GET)ACL|MYRIGHTS) (?:[\w\"\.\-\x5c\/%\*&]+)?|UID (?:COPY|FETCH|STORE) (?:[0-9,:\*]+)?)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?is)\r\n\w{1,50}\b[ ](?:A(?:PPEND (?:[\w\"\.\-\x5c\/%\*&#]+)?(?: \((?:[a-z\x5c\ ])+\))?(?: \"?\d{1,2}-\w{3}-\d{4} \d{2}:\d{2}:\d{2} [+-]\d{4}\"?)? \{\d{1,20}\+?}|UTHENTICATE [a-z0-9-_]{1,20}\r\n)|S(?:TATUS (?:[\w\"\.\-\x5c\/%\*&]+)? \((?:UNSEEN|UIDNEXT|MESSAGES|UIDVALIDITY|RECENT| )+\)|ETACL (?:[\w\"\.\-\x5c\/%\*&]+)? [+-][lrswipckdxtea]+?)|L(?:SUB (?:[\w\"~\/\*#\.]+)? (?:[\w\"\.\x5c\/%\*&]+)?|ISTRIGHTS (?:[\w\"\.\-\x5c\/%\*&]+)?)|(?:(?:DELETE|GET)ACL|MYRIGHTS) (?:[\w\"\.\-\x5c\/%\*&]+)?|UID (?:COPY|FETCH|STORE) (?:[0-9,:\*]+)?)" \
     "id:932310,\
     phase:2,\
     block,\
@@ -816,7 +816,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # (consult util/regexp-assemble/README.md for details):
 #   util/regexp-assemble/regexp-assemble.py update 932320
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?si)\r\n.*?\b(?:A(?:UTH [A-Z0-9-_]{1,20} (?:=|(?:[\w+/]{4})*(?:[\w+/]{2}==|[\w+/]{3}=))|POP [\w]+ [a-f0-9]{32})|(?:TOP \d+|LIST)(?: \d+)?|U(?:IDL(?: \d+)?|SER .+?)|(?:DELE|RETR) \d+?|PASS .+?)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?si)\r\n.*?\b(?:A(?:UTH [A-Z0-9-_]{1,20} (?:=|(?:[\w+/]{4})*(?:[\w+/]{2}==|[\w+/]{3}=))|POP [\w]+ [a-f0-9]{32})|(?:TOP \d+|LIST)(?: \d+)?|U(?:IDL(?: \d+)?|SER .+?)|(?:DELE|RETR) \d+?|PASS .+?)" \
     "id:932320,\
     phase:2,\
     block,\
@@ -927,7 +927,7 @@ SecRule ARGS "@rx /(?:[?*]+[a-z/]+|[a-z/]+[?*]+)" \
 # (consult util/regexp-assemble/README.md for details):
 #   util/regexp-assemble/regexp-assemble.py update 932301
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?s)\r\n.*?\b(?:HELP(?: .{1,255})?|DATA|QUIT)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?s)\r\n.*?\b(?:HELP(?: .{1,255})?|DATA|QUIT)" \
     "id:932301,\
     phase:2,\
     block,\
@@ -961,7 +961,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # (consult util/regexp-assemble/README.md for details):
 #   util/regexp-assemble/regexp-assemble.py update 932311
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?is)\r\n\w{1,50}\b[ ](?:S(?:E(?:ARCH(?: CHARSET [\w\-_\.]{1,40})? (?:(KEYWORD \x5c)?(?:ALL|ANSWERED|BCC|DELETED|DRAFT|FLAGGED|RECENT|SEEN|UNANSWERED|UNDELETED|UNDRAFT|UNFLAGGED|UNSEEN|NEW|OLD)|(?:TEXT .{1,255}|TO .{1,255}|UID [0-9,:\*]+?|UNKEYWORD (?:\x5c(Seen|Answered|Flagged|Deleted|Draft|Recent)))|(?:BEFORE|ON|SENTBEFORE|SENTON|SENTSINCE|SINCE) \"?\d{1,2}-\w{3}-\d{4}\"?|(?:OR .{1,255} .{1,255}|SMALLER \d{1,20}|SUBJECT .{1,255})|(?:(?:BODY|CC|FROM)|HEADER .{1,100}) .{1,255}|(?:LARGER \d{1,20}|NOT .{1,255}|[0-9,:\*]+))|LECT [\w\"\.\-\x5c\/%\*&#]+)|T(?:ORE [0-9,:\*]+? [+-]?FLAGS(?:\.SILENT)? (?:\(\x5c[a-z]{1,20}\))?|ARTTLS)|UBSCRIBE [\w\"\.\-\x5c\/%\*&#]+)|L(?:IST [\w\"~\-\x5c\/\*#\.]+? [\w\"\.\-\x5c\/%\*&#]+|OG(?:IN [a-z0-9-_\.\@]{1,40} .*?|OUT))|C(?:(?:OPY [0-9,:\*]+|REATE) [\w\"\.\-\x5c\/%\*&#]+|APABILITY|HECK|LOSE)|RENAME [\w\"\.\-\x5c\/%\*&#]+? [\w\"\.\-\x5c\/%\*&#]+|UN(?:SUBSCRIBE [\w\"\.\-\x5c\/%\*&#]+|AUTHENTICATE)|EX(?:AMINE [\w\"\.\-\x5c%\*&#]+|PUNGE)|DELETE [\w\"\.\-\x5c%\*&#]+|FETCH [0-9,:\*]+|NOOP)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?is)\r\n\w{1,50}\b[ ](?:S(?:E(?:ARCH(?: CHARSET [\w\-_\.]{1,40})? (?:(KEYWORD \x5c)?(?:ALL|ANSWERED|BCC|DELETED|DRAFT|FLAGGED|RECENT|SEEN|UNANSWERED|UNDELETED|UNDRAFT|UNFLAGGED|UNSEEN|NEW|OLD)|(?:TEXT .{1,255}|TO .{1,255}|UID [0-9,:\*]+?|UNKEYWORD (?:\x5c(Seen|Answered|Flagged|Deleted|Draft|Recent)))|(?:BEFORE|ON|SENTBEFORE|SENTON|SENTSINCE|SINCE) \"?\d{1,2}-\w{3}-\d{4}\"?|(?:OR .{1,255} .{1,255}|SMALLER \d{1,20}|SUBJECT .{1,255})|(?:(?:BODY|CC|FROM)|HEADER .{1,100}) .{1,255}|(?:LARGER \d{1,20}|NOT .{1,255}|[0-9,:\*]+))|LECT [\w\"\.\-\x5c\/%\*&#]+)|T(?:ORE [0-9,:\*]+? [+-]?FLAGS(?:\.SILENT)? (?:\(\x5c[a-z]{1,20}\))?|ARTTLS)|UBSCRIBE [\w\"\.\-\x5c\/%\*&#]+)|L(?:IST [\w\"~\-\x5c\/\*#\.]+? [\w\"\.\-\x5c\/%\*&#]+|OG(?:IN [a-z0-9-_\.\@]{1,40} .*?|OUT))|C(?:(?:OPY [0-9,:\*]+|REATE) [\w\"\.\-\x5c\/%\*&#]+|APABILITY|HECK|LOSE)|RENAME [\w\"\.\-\x5c\/%\*&#]+? [\w\"\.\-\x5c\/%\*&#]+|UN(?:SUBSCRIBE [\w\"\.\-\x5c\/%\*&#]+|AUTHENTICATE)|EX(?:AMINE [\w\"\.\-\x5c%\*&#]+|PUNGE)|DELETE [\w\"\.\-\x5c%\*&#]+|FETCH [0-9,:\*]+|NOOP)" \
     "id:932311,\
     phase:2,\
     block,\
@@ -995,7 +995,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # (consult util/regexp-assemble/README.md for details):
 #   util/regexp-assemble/regexp-assemble.py update 932321
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "(?si)\r\n.*?\b(?:(?:QUI|RSE|STA)T|CAPA|NOOP)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?si)\r\n.*?\b(?:(?:QUI|RSE|STA)T|CAPA|NOOP)" \
     "id:932321,\
     phase:2,\
     block,\


### PR DESCRIPTION
Same PR as #2536 but to the `v4.1/dev` branch