### PR TITLE
Added some files in LFI restricted list

### DIFF
--- a/rules/lfi-os-files.data
+++ b/rules/lfi-os-files.data
@@ -866,6 +866,9 @@ var/log/mail.info
 var/log/mail.warn
 var/log/ufw.log
 var/log/boot.log
+var/log/btmp
+var/log/utmp
+var/log/wtmp
 var/log/syslog
 var/log/syslog.1
 tmp/access.log

--- a/rules/lfi-os-files.data
+++ b/rules/lfi-os-files.data
@@ -38,6 +38,7 @@
 .node_repl_history
 .nsr
 .pearrc
+.pgpass
 .php_history
 .pinerc
 .pki/
@@ -866,9 +867,6 @@ var/log/mail.info
 var/log/mail.warn
 var/log/ufw.log
 var/log/boot.log
-var/log/btmp
-var/log/utmp
-var/log/wtmp
 var/log/syslog
 var/log/syslog.1
 tmp/access.log

--- a/rules/lfi-os-files.data
+++ b/rules/lfi-os-files.data
@@ -911,6 +911,9 @@ etc/kernel-pkg.conf
 etc/ld.so.conf
 etc/ltrace.conf
 etc/mail/sendmail.conf
+etc/freshclam.conf
+etc/mongod.conf
+etc/nuxeo.conf
 etc/manpath.config
 etc/kbd/config
 etc/ldap/ldap.conf
@@ -935,6 +938,12 @@ etc/motd
 etc/hosts
 etc/group
 etc/group-
+etc/subuid
+etc/subuid-
+etc/subgid
+etc/subgid-
+etc/gshadow
+etc/gshadow-
 etc/alias
 etc/crontab
 etc/crypttab
@@ -958,6 +967,9 @@ etc/debian_version
 etc/fedora-release
 etc/mandrake-release
 etc/slackware-release
+etc/system-release-cpe
+etc/centos-release-upstream
+etc/scw-release
 etc/suse-release
 etc/security/group
 etc/security/passwd
@@ -970,6 +982,11 @@ boot/grub/menu.lst
 root/.ksh_history
 root/.xauthority
 usr/lib/security/mkuser.default
+usr/lib/rpm/rpm.log
+var/log/yum.log
+var/log/freshclam.log
+var/log/logstash/logstash-plain.log
+var/log/logstash/logstash-slowlog-plain.log
 var/log/squirrelmail.log
 var/log/apache2/squirrelmail.log
 var/log/apache2/squirrelmail.err.log

--- a/rules/restricted-files.data
+++ b/rules/restricted-files.data
@@ -38,7 +38,6 @@
 .node_repl_history
 .nsr
 .pearrc
-.pgpass
 .php_history
 .pinerc
 .pki/

--- a/rules/restricted-files.data
+++ b/rules/restricted-files.data
@@ -38,6 +38,7 @@
 .node_repl_history
 .nsr
 .pearrc
+.pgpass
 .php_history
 .pinerc
 .pki/


### PR DESCRIPTION
Reports: C4AKMJX5 , ZITHAVYB , EH5C5EUO


(from real tests on production servers)

```
etc/subuid
etc/subuid-
etc/subgid
etc/subgid-
etc/gshadow
etc/gshadow-
etc/system-release-cpe
etc/centos-release-upstream
etc/scw-release
etc/freshclam.conf
etc/mongod.conf
etc/nuxeo.conf
usr/lib/rpm/rpm.log
var/log/yum.log
var/log/freshclam.log
var/log/logstash/logstash-plain.log
var/log/logstash/logstash-slowlog-plain.log
```

I also identified some directories but looks like you try to avoid that so currently reviewing the list, thanks :)