### PR TITLE
Add octal notation to SSRF dataset 934110

### DIFF
--- a/rules/ssrf.data
+++ b/rules/ssrf.data
@@ -8,6 +8,8 @@ http://instance-data/latest/
 http://169.254.169.254/latest/
 # Common evasion techniques:
 http://2852039166/latest/
+http://025177524776/latest/
+http://0251.0376.0251.0376/latest/
 http://[::ffff:a9fe:a9fe]/latest/
 http://[0:0:0:0:0:ffff:a9fe:a9fe]/latest/
 http://[0:0:0:0:0:ffff:169.254.169.254]/latest/


### PR DESCRIPTION
Block octal notation (and octal dotless) for the AWS metadata endpoint.