### PR TITLE
fix(sqli): additional regular expressions for SQL auth bypass

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -930,7 +930,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # Note that part of 942340.data is already optimized, to avoid a
 # Regexp::Assemble behaviour, where the regex is not optimized very nicely.
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:[\"'`](?:\s*?(?:is\s*?(?:[\d.]+\s*?\W.*?[\"'`]|\d.+[\"'`]?\w)|\d\s*?(?:--|#))|\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s*array\s*\[|(?:\W+[\w+-]+\s*?=\s*?\d\W+|\|?[\w-]{3,}[^\w\s.,]+)[\"'`]|[\%&<>^=]+\d\s*?(?:between|like|x?or|and|div|=))|(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+[\s\w+]+(?:sounds\s+like\s*?[\"'`]|regexp\s*?\(|[=\d]+x)|\bexcept\s+(?:values\s*?\(|select\b)|in\s*?\(+\s*?select)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:[\"'`](?:\s*?(?:is\s*?(?:[\d.]+\s*?\W.*?[\"'`]|\d.+[\"'`]?\w)|\d\s*?(?:--|#))|\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+array\s*\[|(?:\W+[\w+-]+\s*?=\s*?\d\W+|\|?[\w-]{3,}[^\w\s.,]+)[\"'`]|[\%&<>^=]+\d\s*?(?:between|like|x?or|and|div|=))|(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+[\s\w+]+(?:sounds\s+like\s*?[\"'`]|regexp\s*?\(|[=\d]+x)|\bexcept\s+(?:values\s*?\(|select\b)|in\s*?\(+\s*?select)" \
     "id:942340,\
     phase:2,\
     block,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -930,7 +930,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # Note that part of 942340.data is already optimized, to avoid a
 # Regexp::Assemble behaviour, where the regex is not optimized very nicely.
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:[\"'`](?:\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+(?:[\w]+(?:\s+(?:not\s+)?similar\s+to\s+|\s*!?~)|array\s*\[)|\s*?(?:is\s*?(?:[\d.]+\s*?\W.*?[\"'`]|\d.+[\"'`]?\w)|\d\s*?(?:--|#))|(?:\W+[\w+-]+\s*?=\s*?\d\W+|\|?[\w-]{3,}[^\w\s.,]+)[\"'`]|[\%&<>^=]+\d\s*?(?:between|like|x?or|and|div|=))|(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+[\s\w+]+(?:sounds\s+like\s*?[\"'`]|regexp\s*?\(|[=\d]+x)|\bexcept\s+(?:values\s*?\(|select\b)|in\s*?\(+\s*?select)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:[\"'`](?:\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+(?:[\w]+(?:\s+(?:not\s+)?similar\s+to\s+|\s*!?~)|(?:true|false)\b|array\s*\[)|\s*?(?:is\s*?(?:[\d.]+\s*?\W.*?[\"'`]|\d.+[\"'`]?\w)|\d\s*?(?:--|#))|(?:\W+[\w+-]+\s*?=\s*?\d\W+|\|?[\w-]{3,}[^\w\s.,]+)[\"'`]|[\%&<>^=]+\d\s*?(?:between|like|x?or|and|div|=))|(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+[\s\w+]+(?:sounds\s+like\s*?[\"'`]|regexp\s*?\(|[=\d]+x)|\bexcept\s+(?:values\s*?\(|select\b)|in\s*?\(+\s*?select)" \
     "id:942340,\
     phase:2,\
     block,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -930,7 +930,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # Note that part of 942340.data is already optimized, to avoid a
 # Regexp::Assemble behaviour, where the regex is not optimized very nicely.
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:[\"'`](?:\s*?(?:is\s*?(?:[\d.]+\s*?\W.*?[\"'`]|\d.+[\"'`]?\w)|\d\s*?(?:--|#))|\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+array\s*\[|(?:\W+[\w+-]+\s*?=\s*?\d\W+|\|?[\w-]{3,}[^\w\s.,]+)[\"'`]|[\%&<>^=]+\d\s*?(?:between|like|x?or|and|div|=))|(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+[\s\w+]+(?:sounds\s+like\s*?[\"'`]|regexp\s*?\(|[=\d]+x)|\bexcept\s+(?:values\s*?\(|select\b)|in\s*?\(+\s*?select)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:[\"'`](?:\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+(?:[\w]+\s*!?~|array\s*\[)|\s*?(?:is\s*?(?:[\d.]+\s*?\W.*?[\"'`]|\d.+[\"'`]?\w)|\d\s*?(?:--|#))|(?:\W+[\w+-]+\s*?=\s*?\d\W+|\|?[\w-]{3,}[^\w\s.,]+)[\"'`]|[\%&<>^=]+\d\s*?(?:between|like|x?or|and|div|=))|(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+[\s\w+]+(?:sounds\s+like\s*?[\"'`]|regexp\s*?\(|[=\d]+x)|\bexcept\s+(?:values\s*?\(|select\b)|in\s*?\(+\s*?select)" \
     "id:942340,\
     phase:2,\
     block,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -930,7 +930,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # Note that part of 942340.data is already optimized, to avoid a
 # Regexp::Assemble behaviour, where the regex is not optimized very nicely.
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:[\"'`](?:\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+(?:[\w]+(?:\s+(?:not\s+)?similar\s+to\s+|\s*!?~)|(?:true|false)\b|array\s*\[)|\s*?(?:is\s*?(?:[\d.]+\s*?\W.*?[\"'`]|\d.+[\"'`]?\w)|\d\s*?(?:--|#))|(?:\W+[\w+-]+\s*?=\s*?\d\W+|\|?[\w-]{3,}[^\w\s.,]+)[\"'`]|[\%&<>^=]+\d\s*?(?:between|like|x?or|and|div|=))|(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+[\s\w+]+(?:sounds\s+like\s*?[\"'`]|regexp\s*?\(|[=\d]+x)|\bexcept\s+(?:values\s*?\(|select\b)|in\s*?\(+\s*?select)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:[\"'`](?:\s*(?i:(?:n?and|x?x?or|div|like|between|not)\s+|(?:\|\||\&\&)\s*)(?:[\w]+(?:\s+(?:not\s+)?similar\s+to\s+|\s*!?~)|(?:true|false)\b|array\s*\[)|\s*?(?:is\s*?(?:[\d.]+\s*?\W.*?[\"'`]|\d.+[\"'`]?\w)|\d\s*?(?:--|#))|(?:\W+[\w+-]+\s*?=\s*?\d\W+|\|?[\w-]{3,}[^\w\s.,]+)[\"'`]|[\%&<>^=]+\d\s*?(?:between|like|x?or|and|div|=))|(?i:(?:n?and|x?x?or|div|like|between|not)\s+|(?:\|\||\&\&)\s*)[\s\w+]+(?:sounds\s+like\s*?[\"'`]|regexp\s*?\(|[=\d]+x)|\bexcept\s+(?:values\s*?\(|select\b)|in\s*?\(+\s*?select)" \
     "id:942340,\
     phase:2,\
     block,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -930,7 +930,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # Note that part of 942340.data is already optimized, to avoid a
 # Regexp::Assemble behaviour, where the regex is not optimized very nicely.
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:[\"'`](?:\s*?(?:is\s*?(?:[\d.]+\s*?\W.*?[\"'`]|\d.+[\"'`]?\w)|\d\s*?(?:--|#))|(?:\W+[\w+-]+\s*?=\s*?\d\W+|\|?[\w-]{3,}[^\w\s.,]+)[\"'`]|[\%&<>^=]+\d\s*?(?:between|like|x?or|and|div|=))|(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+[\s\w+]+(?:sounds\s+like\s*?[\"'`]|regexp\s*?\(|[=\d]+x)|\bexcept\s+(?:values\s*?\(|select\b)|in\s*?\(+\s*?select)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:[\"'`](?:\s*?(?:is\s*?(?:[\d.]+\s*?\W.*?[\"'`]|\d.+[\"'`]?\w)|\d\s*?(?:--|#))|\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s*array\s*\[|(?:\W+[\w+-]+\s*?=\s*?\d\W+|\|?[\w-]{3,}[^\w\s.,]+)[\"'`]|[\%&<>^=]+\d\s*?(?:between|like|x?or|and|div|=))|(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+[\s\w+]+(?:sounds\s+like\s*?[\"'`]|regexp\s*?\(|[=\d]+x)|\bexcept\s+(?:values\s*?\(|select\b)|in\s*?\(+\s*?select)" \
     "id:942340,\
     phase:2,\
     block,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -930,7 +930,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # Note that part of 942340.data is already optimized, to avoid a
 # Regexp::Assemble behaviour, where the regex is not optimized very nicely.
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:[\"'`](?:\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+(?:[\w]+\s*!?~|array\s*\[)|\s*?(?:is\s*?(?:[\d.]+\s*?\W.*?[\"'`]|\d.+[\"'`]?\w)|\d\s*?(?:--|#))|(?:\W+[\w+-]+\s*?=\s*?\d\W+|\|?[\w-]{3,}[^\w\s.,]+)[\"'`]|[\%&<>^=]+\d\s*?(?:between|like|x?or|and|div|=))|(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+[\s\w+]+(?:sounds\s+like\s*?[\"'`]|regexp\s*?\(|[=\d]+x)|\bexcept\s+(?:values\s*?\(|select\b)|in\s*?\(+\s*?select)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:[\"'`](?:\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+(?:[\w]+(?:\s+(?:not\s+)?similar\s+to\s+|\s*!?~)|array\s*\[)|\s*?(?:is\s*?(?:[\d.]+\s*?\W.*?[\"'`]|\d.+[\"'`]?\w)|\d\s*?(?:--|#))|(?:\W+[\w+-]+\s*?=\s*?\d\W+|\|?[\w-]{3,}[^\w\s.,]+)[\"'`]|[\%&<>^=]+\d\s*?(?:between|like|x?or|and|div|=))|(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+[\s\w+]+(?:sounds\s+like\s*?[\"'`]|regexp\s*?\(|[=\d]+x)|\bexcept\s+(?:values\s*?\(|select\b)|in\s*?\(+\s*?select)" \
     "id:942340,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942340.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942340.yaml
@@ -107,3 +107,20 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942340"
+  - test_title: 942340-20
+    desc: "basic SQL authentication bypass attempts 3/3"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            data: "email='%20and%20email%20not%20similar%20to%20id--"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942340"

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942340.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942340.yaml
@@ -124,3 +124,34 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942340"
+  - test_title: 942340-21
+    desc: "basic SQL authentication bypass attempts 3/3"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            data: "email='%20or%20true;%20foo"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942340"
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            data: "email='%20or%20false;%20foo"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942340"

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942340.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942340.yaml
@@ -73,7 +73,7 @@ tests:
             version: HTTP/1.0
           output:
             no_log_contains: id "942340"
-  - test_title: 942340-18
+  - test_title: 942340-5
     desc: "basic SQL authentication bypass attempts 3/3"
     stages:
       - stage:
@@ -90,7 +90,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942340"
-  - test_title: 942340-19
+  - test_title: 942340-6
     desc: "basic SQL authentication bypass attempts 3/3"
     stages:
       - stage:
@@ -107,7 +107,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942340"
-  - test_title: 942340-20
+  - test_title: 942340-7
     desc: "basic SQL authentication bypass attempts 3/3"
     stages:
       - stage:
@@ -124,7 +124,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942340"
-  - test_title: 942340-21
+  - test_title: 942340-8
     desc: "basic SQL authentication bypass attempts 3/3"
     stages:
       - stage:
@@ -155,7 +155,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942340"
-  - test_title: 942340-22
+  - test_title: 942340-9
     desc: "basic SQL authentication bypass attempts 3/3 (no whitespace between operator)"
     stages:
       - stage:
@@ -172,7 +172,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942340"
-  - test_title: 942340-23
+  - test_title: 942340-10
     desc: "SQL Auth Bypass FP test (invalid operator without whitespace)"
     stages:
       - stage:

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942340.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942340.yaml
@@ -90,3 +90,20 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942340"
+  - test_title: 942340-19
+    desc: "basic SQL authentication bypass attempts 3/3"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            data: "email=x'%20or%20email~all(array[email]);analyze--"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942340"

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942340.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942340.yaml
@@ -155,3 +155,37 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942340"
+  - test_title: 942340-22
+    desc: "basic SQL authentication bypass attempts 3/3 (no whitespace between operator)"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            data: "email='||true"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942340"
+  - test_title: 942340-23
+    desc: "SQL Auth Bypass FP test (invalid operator without whitespace)"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            data: "email='ortrue"
+            version: HTTP/1.0
+          output:
+            no_log_contains: id "942340"

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942340.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942340.yaml
@@ -73,3 +73,20 @@ tests:
             version: HTTP/1.0
           output:
             no_log_contains: id "942340"
+  - test_title: 942340-18
+    desc: "basic SQL authentication bypass attempts 3/3"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            data: "email=x'%20or%20array[id]%20is%20not%20null--"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942340"

--- a/util/regexp-assemble/data/942340.data
+++ b/util/regexp-assemble/data/942340.data
@@ -4,9 +4,9 @@
 ##!+ i
 
 in\s*?\(+\s*?select
-(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+[\s\w+]+regexp\s*?\(
-(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+[\s\w+]+sounds\s+like\s*?[\"'`]
-(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+[\s\w+]+[=\d]+x
+(?i:(?:n?and|x?x?or|div|like|between|not)\s+|(?:\|\||\&\&)\s*)[\s\w+]+regexp\s*?\(
+(?i:(?:n?and|x?x?or|div|like|between|not)\s+|(?:\|\||\&\&)\s*)[\s\w+]+sounds\s+like\s*?[\"'`]
+(?i:(?:n?and|x?x?or|div|like|between|not)\s+|(?:\|\||\&\&)\s*)[\s\w+]+[=\d]+x
 [\"'`]\s*?\d\s*?--
 [\"'`]\s*?\d\s*?#
 [\"'`][\%&<>^=]+\d\s*?=
@@ -22,7 +22,7 @@ in\s*?\(+\s*?select
 [\"'`]\s*?is\s*?[\d.]+\s*?\W.*?[\"'`]
 \bexcept\s+select\b
 \bexcept\s+values\s*?\(
-[\"'`]\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+array\s*\[
-[\"'`]\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+[\w]+\s*!?~
-[\"'`]\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+[\w]+\s+(?:not\s+)?similar\s+to\s+
-[\"'`]\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+(?:true|false)\b
+[\"'`]\s*(?i:(?:n?and|x?x?or|div|like|between|not)\s+|(?:\|\||\&\&)\s*)array\s*\[
+[\"'`]\s*(?i:(?:n?and|x?x?or|div|like|between|not)\s+|(?:\|\||\&\&)\s*)[\w]+\s*!?~
+[\"'`]\s*(?i:(?:n?and|x?x?or|div|like|between|not)\s+|(?:\|\||\&\&)\s*)[\w]+\s+(?:not\s+)?similar\s+to\s+
+[\"'`]\s*(?i:(?:n?and|x?x?or|div|like|between|not)\s+|(?:\|\||\&\&)\s*)(?:true|false)\b

--- a/util/regexp-assemble/data/942340.data
+++ b/util/regexp-assemble/data/942340.data
@@ -24,3 +24,4 @@ in\s*?\(+\s*?select
 \bexcept\s+values\s*?\(
 [\"'`]\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+array\s*\[
 [\"'`]\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+[\w]+\s*!?~
+[\"'`]\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+[\w]+\s+(?:not\s+)?similar\s+to\s+

--- a/util/regexp-assemble/data/942340.data
+++ b/util/regexp-assemble/data/942340.data
@@ -25,3 +25,4 @@ in\s*?\(+\s*?select
 [\"'`]\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+array\s*\[
 [\"'`]\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+[\w]+\s*!?~
 [\"'`]\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+[\w]+\s+(?:not\s+)?similar\s+to\s+
+[\"'`]\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+(?:true|false)\b

--- a/util/regexp-assemble/data/942340.data
+++ b/util/regexp-assemble/data/942340.data
@@ -22,4 +22,4 @@ in\s*?\(+\s*?select
 [\"'`]\s*?is\s*?[\d.]+\s*?\W.*?[\"'`]
 \bexcept\s+select\b
 \bexcept\s+values\s*?\(
-[\"'`]\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s*array\s*\[
+[\"'`]\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+array\s*\[

--- a/util/regexp-assemble/data/942340.data
+++ b/util/regexp-assemble/data/942340.data
@@ -22,3 +22,4 @@ in\s*?\(+\s*?select
 [\"'`]\s*?is\s*?[\d.]+\s*?\W.*?[\"'`]
 \bexcept\s+select\b
 \bexcept\s+values\s*?\(
+[\"'`]\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s*array\s*\[

--- a/util/regexp-assemble/data/942340.data
+++ b/util/regexp-assemble/data/942340.data
@@ -23,3 +23,4 @@ in\s*?\(+\s*?select
 \bexcept\s+select\b
 \bexcept\s+values\s*?\(
 [\"'`]\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+array\s*\[
+[\"'`]\s*(?i:n?and|x?x?or|div|like|between|not|\|\||\&\&)\s+[\w]+\s*!?~


### PR DESCRIPTION
This PR contains new regular expressions for different kinds of auth bypasses. In an ideal world, these would be inside the operator dataset, but unfortunately, they look too much like normal sentences to accurately block.

Edit:
 * Contains fixes to bypasses found by me (`DV2UKLP4`, `2AUWUOVF`, `RICGZH4Q`)
 * Contains fixes to bypasses found by @wfinn (`YPWZU6PD` and `Q6FBUFOD`)