### PR TITLE
feat(regexp-assemble): Update data file comment

### DIFF
--- a/util/regexp-assemble/data/920100.data
+++ b/util/regexp-assemble/data/920100.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/920100.data
+++ b/util/regexp-assemble/data/920100.data
@@ -1,24 +1,29 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
+##! - assemble
+##! - cmdline [windows|unix]
+##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i

--- a/util/regexp-assemble/data/920120.data
+++ b/util/regexp-assemble/data/920120.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/920120.data
+++ b/util/regexp-assemble/data/920120.data
@@ -1,24 +1,29 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
+##! - assemble
+##! - cmdline [windows|unix]
+##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##! The HTML entities included in the expression are a best guess selection of frequently

--- a/util/regexp-assemble/data/920521.data
+++ b/util/regexp-assemble/data/920521.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/920521.data
+++ b/util/regexp-assemble/data/920521.data
@@ -1,24 +1,29 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
-##! Currently supported preoprocessors:
-##! - cmdline [windows|unix] (file scope)
+##! Currently supported preprocessors:
+##! - assemble
+##! - cmdline [windows|unix]
+##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##! Current Accept-Encoding headers

--- a/util/regexp-assemble/data/930100.data
+++ b/util/regexp-assemble/data/930100.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/930100.data
+++ b/util/regexp-assemble/data/930100.data
@@ -1,24 +1,29 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
+##! - assemble
+##! - cmdline [windows|unix]
+##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##! Source: https://github.com/wireghoul/dotdotpwn/blob/master/DotDotPwn/TraversalEngine.pm

--- a/util/regexp-assemble/data/932100.data
+++ b/util/regexp-assemble/data/932100.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/932100.data
+++ b/util/regexp-assemble/data/932100.data
@@ -1,24 +1,29 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
+##! - assemble
+##! - cmdline [windows|unix]
+##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##! Word list for rule 932100 (RCE Unix command injection part 1/4)

--- a/util/regexp-assemble/data/932101.data
+++ b/util/regexp-assemble/data/932101.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/932101.data
+++ b/util/regexp-assemble/data/932101.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##! Word list for rule 932101 (RCE Unix command injection part 3/4)
 ##!

--- a/util/regexp-assemble/data/932105.data
+++ b/util/regexp-assemble/data/932105.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/932105.data
+++ b/util/regexp-assemble/data/932105.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##! Word list for rule 932105 (RCE Unix command injection part 2/4)
 ##!

--- a/util/regexp-assemble/data/932106.data
+++ b/util/regexp-assemble/data/932106.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/932106.data
+++ b/util/regexp-assemble/data/932106.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##! Word list for rule 932106 (RCE Unix command injection part 4/4)
 ##!

--- a/util/regexp-assemble/data/932110.data
+++ b/util/regexp-assemble/data/932110.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/932110.data
+++ b/util/regexp-assemble/data/932110.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##! Word list for rule 932110 (RCE Windows command injection part 1/2)
 ##!

--- a/util/regexp-assemble/data/932115.data
+++ b/util/regexp-assemble/data/932115.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/932115.data
+++ b/util/regexp-assemble/data/932115.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##! Word list for rule 932115 (RCE Windows command injection part 2/2)
 ##!

--- a/util/regexp-assemble/data/932130.data
+++ b/util/regexp-assemble/data/932130.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/932130.data
+++ b/util/regexp-assemble/data/932130.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 \$\(.*\)
 \$\{.*\}

--- a/util/regexp-assemble/data/932140.data
+++ b/util/regexp-assemble/data/932140.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/932140.data
+++ b/util/regexp-assemble/data/932140.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 \bfor(?:/[dflr].*)? %+[^ ]+ in\(.*\)\s?do
 \bif(?:/i)?(?: not)?(?: exist\b| defined\b| errorlevel\b| cmdextversion\b|(?: |\().*(?:\bgeq\b|\bequ\b|\bneq\b|\bleq\b|\bgtr\b|\blss\b|==))

--- a/util/regexp-assemble/data/932150.data
+++ b/util/regexp-assemble/data/932150.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/932150.data
+++ b/util/regexp-assemble/data/932150.data
@@ -8,17 +8,22 @@
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
 ##!
-##! Five special comments are at your disposal to influence the assembled expression:
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
+##! - assemble
+##! - cmdline [windows|unix]
+##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##! Word list for rule 932150 (RCE Unix command injection)

--- a/util/regexp-assemble/data/932210.data
+++ b/util/regexp-assemble/data/932210.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/932210.data
+++ b/util/regexp-assemble/data/932210.data
@@ -1,19 +1,29 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! In addition, the quote character `'` at the beginning of a line will
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
+##!
+##! Currently supported preprocessors:
+##! - assemble
+##! - cmdline [windows|unix]
+##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!^ ;\s*\.\s*

--- a/util/regexp-assemble/data/932300.data
+++ b/util/regexp-assemble/data/932300.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/932300.data
+++ b/util/regexp-assemble/data/932300.data
@@ -1,19 +1,29 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! In addition, the quote character `'` at the beginning of a line will
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
+##!
+##! Currently supported preprocessors:
+##! - assemble
+##! - cmdline [windows|unix]
+##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!^ (?is)\r\n.*?\b

--- a/util/regexp-assemble/data/932301.data
+++ b/util/regexp-assemble/data/932301.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/932301.data
+++ b/util/regexp-assemble/data/932301.data
@@ -1,19 +1,29 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! In addition, the quote character `'` at the beginning of a line will
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
+##!
+##! Currently supported preprocessors:
+##! - assemble
+##! - cmdline [windows|unix]
+##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!^ (?s)\r\n.*?\b

--- a/util/regexp-assemble/data/932310.data
+++ b/util/regexp-assemble/data/932310.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/932310.data
+++ b/util/regexp-assemble/data/932310.data
@@ -7,13 +7,23 @@
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
+##! In addition, the quote character `'` at the beginning of a line will
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
 ##!
-##! Five special comments are at your disposal to influence the assembled expression:
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
+##!
+##! Currently supported preprocessors:
+##! - assemble
+##! - cmdline [windows|unix]
+##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##! All IMAP4 commands start with a "tag"

--- a/util/regexp-assemble/data/932311.data
+++ b/util/regexp-assemble/data/932311.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/932311.data
+++ b/util/regexp-assemble/data/932311.data
@@ -7,13 +7,23 @@
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
+##! In addition, the quote character `'` at the beginning of a line will
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
 ##!
-##! Five special comments are at your disposal to influence the assembled expression:
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
+##!
+##! Currently supported preprocessors:
+##! - assemble
+##! - cmdline [windows|unix]
+##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##! All IMAP4 commands start with a "tag"

--- a/util/regexp-assemble/data/932320.data
+++ b/util/regexp-assemble/data/932320.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/932320.data
+++ b/util/regexp-assemble/data/932320.data
@@ -1,19 +1,29 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! In addition, the quote character `'` at the beginning of a line will
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
+##!
+##! Currently supported preprocessors:
+##! - assemble
+##! - cmdline [windows|unix]
+##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##! POP3 Commands - PL2

--- a/util/regexp-assemble/data/932321.data
+++ b/util/regexp-assemble/data/932321.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/932321.data
+++ b/util/regexp-assemble/data/932321.data
@@ -1,19 +1,29 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! In addition, the quote character `'` at the beginning of a line will
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
+##!
+##! Currently supported preprocessors:
+##! - assemble
+##! - cmdline [windows|unix]
+##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!^ (?si)\r\n.*?\b

--- a/util/regexp-assemble/data/933131.data
+++ b/util/regexp-assemble/data/933131.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/933131.data
+++ b/util/regexp-assemble/data/933131.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 AUTH_TYPE
 HTTP_ACCEPT

--- a/util/regexp-assemble/data/933160.data
+++ b/util/regexp-assemble/data/933160.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/933160.data
+++ b/util/regexp-assemble/data/933160.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+i
 ##!^\b

--- a/util/regexp-assemble/data/933161.data
+++ b/util/regexp-assemble/data/933161.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/933161.data
+++ b/util/regexp-assemble/data/933161.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+i
 ##!^\b

--- a/util/regexp-assemble/data/934100.data
+++ b/util/regexp-assemble/data/934100.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/934100.data
+++ b/util/regexp-assemble/data/934100.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 
 _\$\$ND_FUNC\$\$_

--- a/util/regexp-assemble/data/934120.data
+++ b/util/regexp-assemble/data/934120.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/934120.data
+++ b/util/regexp-assemble/data/934120.data
@@ -1,17 +1,29 @@
 ##! This is a data file used to generate a regular expression for a CRS rule.
 ##! The generation of the regular expression happens with the help of
-##! util/regexp-assemble/regexp-assemble.pl.
+##! util/regexp-assemble/regexp-assemble.py.
 ##! The ID of the rule in question is part of the file name of this data file.
 ##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
+##! In addition, the quote character `'` at the beginning of a line will
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
 ##!
-##! Three special comments are at your disposal to influence the assembled expression:
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
+##! - `##!>`: the preprocessor comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
+##!
+##! Currently supported preprocessors:
+##! - assemble
+##! - cmdline [windows|unix]
+##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##! Plenty of schemes/protocols to catch here (from https://en.wikipedia.org/wiki/List_of_URI_schemes):

--- a/util/regexp-assemble/data/941130.data
+++ b/util/regexp-assemble/data/941130.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/941130.data
+++ b/util/regexp-assemble/data/941130.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 ##!$ \b

--- a/util/regexp-assemble/data/941160.data
+++ b/util/regexp-assemble/data/941160.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/941160.data
+++ b/util/regexp-assemble/data/941160.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 

--- a/util/regexp-assemble/data/942120.data
+++ b/util/regexp-assemble/data/942120.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942120.data
+++ b/util/regexp-assemble/data/942120.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 

--- a/util/regexp-assemble/data/942130.data
+++ b/util/regexp-assemble/data/942130.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942130.data
+++ b/util/regexp-assemble/data/942130.data
@@ -8,18 +8,23 @@
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
 ##!
-##! Five special comments are at your disposal to influence the assembled expression:
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 
@@ -57,4 +62,3 @@ sounds\s+like[\s'\"`()]*?\b([\d\w]+)\b
 ##! String based regexp. These don't use % as wildcard.
 rlike[\s'\"`()]*?\b([\d\w]+)\b
 regexp[\s'\"`()]*?\b([\d\w]+)\b
-

--- a/util/regexp-assemble/data/942131.data
+++ b/util/regexp-assemble/data/942131.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942131.data
+++ b/util/regexp-assemble/data/942131.data
@@ -8,18 +8,23 @@
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
 ##!
-##! Five special comments are at your disposal to influence the assembled expression:
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 
 ##! General comments:

--- a/util/regexp-assemble/data/942140.data
+++ b/util/regexp-assemble/data/942140.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942140.data
+++ b/util/regexp-assemble/data/942140.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 ##!^ \b

--- a/util/regexp-assemble/data/942150.data
+++ b/util/regexp-assemble/data/942150.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942150.data
+++ b/util/regexp-assemble/data/942150.data
@@ -8,18 +8,23 @@
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
 ##!
-##! Five special comments are at your disposal to influence the assembled expression:
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 ##!^ \b

--- a/util/regexp-assemble/data/942151.data
+++ b/util/regexp-assemble/data/942151.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942151.data
+++ b/util/regexp-assemble/data/942151.data
@@ -8,18 +8,23 @@
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
 ##!
-##! Five special comments are at your disposal to influence the assembled expression:
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 ##!^ \b

--- a/util/regexp-assemble/data/942170.data
+++ b/util/regexp-assemble/data/942170.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942170.data
+++ b/util/regexp-assemble/data/942170.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 

--- a/util/regexp-assemble/data/942180.data
+++ b/util/regexp-assemble/data/942180.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942180.data
+++ b/util/regexp-assemble/data/942180.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 

--- a/util/regexp-assemble/data/942190.data
+++ b/util/regexp-assemble/data/942190.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942190.data
+++ b/util/regexp-assemble/data/942190.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 

--- a/util/regexp-assemble/data/942200.data
+++ b/util/regexp-assemble/data/942200.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942200.data
+++ b/util/regexp-assemble/data/942200.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 

--- a/util/regexp-assemble/data/942210.data
+++ b/util/regexp-assemble/data/942210.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942210.data
+++ b/util/regexp-assemble/data/942210.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 

--- a/util/regexp-assemble/data/942230.data
+++ b/util/regexp-assemble/data/942230.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942230.data
+++ b/util/regexp-assemble/data/942230.data
@@ -1,24 +1,29 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
+##! - assemble
+##! - cmdline [windows|unix]
+##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i

--- a/util/regexp-assemble/data/942240.data
+++ b/util/regexp-assemble/data/942240.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942240.data
+++ b/util/regexp-assemble/data/942240.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 

--- a/util/regexp-assemble/data/942260.data
+++ b/util/regexp-assemble/data/942260.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942260.data
+++ b/util/regexp-assemble/data/942260.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 

--- a/util/regexp-assemble/data/942280.data
+++ b/util/regexp-assemble/data/942280.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942280.data
+++ b/util/regexp-assemble/data/942280.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 

--- a/util/regexp-assemble/data/942300.data
+++ b/util/regexp-assemble/data/942300.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942300.data
+++ b/util/regexp-assemble/data/942300.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 

--- a/util/regexp-assemble/data/942310.data
+++ b/util/regexp-assemble/data/942310.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942310.data
+++ b/util/regexp-assemble/data/942310.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 

--- a/util/regexp-assemble/data/942320.data
+++ b/util/regexp-assemble/data/942320.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942320.data
+++ b/util/regexp-assemble/data/942320.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 

--- a/util/regexp-assemble/data/942330.data
+++ b/util/regexp-assemble/data/942330.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942330.data
+++ b/util/regexp-assemble/data/942330.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 

--- a/util/regexp-assemble/data/942340.data
+++ b/util/regexp-assemble/data/942340.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942340.data
+++ b/util/regexp-assemble/data/942340.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 

--- a/util/regexp-assemble/data/942350.data
+++ b/util/regexp-assemble/data/942350.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942350.data
+++ b/util/regexp-assemble/data/942350.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 

--- a/util/regexp-assemble/data/942360.data
+++ b/util/regexp-assemble/data/942360.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942360.data
+++ b/util/regexp-assemble/data/942360.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 

--- a/util/regexp-assemble/data/942362.data
+++ b/util/regexp-assemble/data/942362.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942362.data
+++ b/util/regexp-assemble/data/942362.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 

--- a/util/regexp-assemble/data/942370.data
+++ b/util/regexp-assemble/data/942370.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942370.data
+++ b/util/regexp-assemble/data/942370.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 

--- a/util/regexp-assemble/data/942380.data
+++ b/util/regexp-assemble/data/942380.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942380.data
+++ b/util/regexp-assemble/data/942380.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+i
 

--- a/util/regexp-assemble/data/942390.data
+++ b/util/regexp-assemble/data/942390.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942390.data
+++ b/util/regexp-assemble/data/942390.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 

--- a/util/regexp-assemble/data/942400.data
+++ b/util/regexp-assemble/data/942400.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942400.data
+++ b/util/regexp-assemble/data/942400.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 

--- a/util/regexp-assemble/data/942410.data
+++ b/util/regexp-assemble/data/942410.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942410.data
+++ b/util/regexp-assemble/data/942410.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 ##!^ \b

--- a/util/regexp-assemble/data/942440.data
+++ b/util/regexp-assemble/data/942440.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942440.data
+++ b/util/regexp-assemble/data/942440.data
@@ -8,18 +8,23 @@
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
 ##!
-##! Five special comments are at your disposal to influence the assembled expression:
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 /\*!?
 \*/

--- a/util/regexp-assemble/data/942470.data
+++ b/util/regexp-assemble/data/942470.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942470.data
+++ b/util/regexp-assemble/data/942470.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 

--- a/util/regexp-assemble/data/942480.data
+++ b/util/regexp-assemble/data/942480.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/942480.data
+++ b/util/regexp-assemble/data/942480.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 

--- a/util/regexp-assemble/data/944140.data
+++ b/util/regexp-assemble/data/944140.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/944140.data
+++ b/util/regexp-assemble/data/944140.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
-##! Currently supported preoprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! Currently supported preprocessors:
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##! The following is an expansion of
 ##! (?:\${[^}]{0,15}\${|\${(?:jndi|ctx))

--- a/util/regexp-assemble/data/944141.data
+++ b/util/regexp-assemble/data/944141.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/944141.data
+++ b/util/regexp-assemble/data/944141.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
-##! Currently supported preoprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! Currently supported preprocessors:
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##! The following is an expansion of
 ##! (?:\$\{[^}]*\$\{|\$\{(?:jndi|ctx))

--- a/util/regexp-assemble/data/944142.data
+++ b/util/regexp-assemble/data/944142.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/944142.data
+++ b/util/regexp-assemble/data/944142.data
@@ -1,25 +1,30 @@
-##! This is a data file used to generate a regular expression for a CRS rule. 
-##! The generation of the regular expression happens with the help of 
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
 ##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file. 
-##! Read more about the format of this data file and the use of the assembly 
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
 ##! script in util/regexp-assemble/README.md.
 ##!
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##! 
-##! Five special comments are at your disposal to influence the assembled expression:
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
+##!
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
-##! Currently supported preoprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! Currently supported preprocessors:
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##! The following is an expansion of
 ##! (?:\${[^}]{0,15}\${|\${(?:jndi|ctx))

--- a/util/regexp-assemble/data/951230.data
+++ b/util/regexp-assemble/data/951230.data
@@ -22,7 +22,9 @@
 ##!
 ##! Currently supported preprocessors:
 ##! - assemble
-##! - cmdline [windows|unix]
+##! - cmdline
+##! - template
+##! - include
 ##!
 ##! Please refer to util/regexp-assemble/README.md for a full explanation.
 

--- a/util/regexp-assemble/data/951230.data
+++ b/util/regexp-assemble/data/951230.data
@@ -8,18 +8,23 @@
 ##! Lines starting with `##!` are comments and will be skipped,
 ##! empty lines will be ignored completely.
 ##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
+##! cause the line to be interpreted literally by the cmdline preprocessor only.
 ##!
-##! Five special comments are at your disposal to influence the assembled expression:
+##! Seven special comments are at your disposal to influence the assembly of the
+##! expression:
 ##! - `##!+`: the flag comment
 ##! - `##!^`: the prefix comment
 ##! - `##!$`: the suffix comment
 ##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
+##! - `##!<`: the preprocessor end comment
+##! - `##!=>`: the concatenation output comment
+##! - `##!=<`: the concatenation input comment
 ##!
 ##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
+##! - assemble
+##! - cmdline [windows|unix]
+##!
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
 
 ##!+ i
 


### PR DESCRIPTION
The header comment in the regexp-assemble data files was no longer in
sync with the implementation after the merge of the improvements to the
preprocessing engine of regexp-assemble.

Replaces https://github.com/coreruleset/coreruleset/pull/2545#issuecomment-1126973298 for v4.1/dev