### PR TITLE
fix(rce): block PHP function calls without trailing semi-colon (stricter sibling)

### DIFF
--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -722,6 +722,37 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
+# [ PHP Functions: Variable Function Prevent Bypass ]
+#
+# This rule is a stricter sibling of 933210.
+# Unlike 933210, this rule will also match "this is a 'dog' (not a cat)", because the semi-colon at the end of the string is optional.
+# This is useful for PHP evals where the semi-colon is already hardcoded:
+# <?php eval("($input);") ?>
+#
+# Any potential function calls not at the end of a string will require a semi-colon to form valid PHP, which is automatically covered by 933210.
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@rx (\(.+\)\(.+\)|\(.+\)['\"][a-zA-Z-_0-9]+['\"]\(.+\)|\[\d+\]\(.+\)|\{\d+\}\(.+\)|\$[^(\),.;\x5c/]+\(.+\)|[\"'][a-zA-Z0-9-_\x5c]+[\"']\(.+\)|\([^\)]*string[^\)]*\)[a-zA-Z-_0-9\"'.{}\[\]\s]+\([^\)]*\))(?:;|$)" \
+    "id:933211,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:urlDecode,t:replaceComments,t:removeWhitespace,\
+    msg:'PHP Injection Attack: Variable Function Call Found',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-injection-php',\
+    tag:'paranoia-level/3',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/242',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/4.0.0-rc1',\
+    severity:'CRITICAL',\
+    setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:933017,phase:1,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:933018,phase:2,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
 #

--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933211.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933211.yaml
@@ -1,0 +1,317 @@
+---
+meta:
+  author: karelorigin
+  description: Test for "933211" PHP Variable Function bypass
+  enabled: true
+  name: 933211.yaml
+tests:
+  - test_title: 933211-1
+    desc: Check for false positive 1
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /?x=%5bACME%5d%3a+this+is%2c+%28another%29+test+%28foo%29bar+or+foo%28bar%29.
+          output:
+            no_log_contains: id "933211"
+  - test_title: 933211-2
+    desc: Check for false positive 2
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /?x=%28foo%29bar+or+foo%28bar%29+or+%5bfoo%5dbar+or+foo%5bbar%5d
+          output:
+            no_log_contains: id "933211"
+  - test_title: 933211-3
+    desc: PHP Variable Function bypass "(system)('uname')"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /?x=%28system%29%28%27uname%27%29%20%3B
+          output:
+            log_contains: id "933211"
+  - test_title: 933211-4
+    desc: PHP Variable Function bypass "(sy.(st).em)('uname')"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /?x=%28sy.%28st%29.em%29%28%27uname%27%29%3B
+          output:
+            log_contains: id "933211"
+  - test_title: 933211-5
+    desc: PHP Variable Function bypass "(string)'system'('uname')"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /?x=%28string%29%22system%22%28%27uname%27%29%3B
+          output:
+            log_contains: id "933211"
+  - test_title: 933211-6
+    desc: PHP Variable Function bypass "( string ) 'sys'.'t'.'em' ('uname')"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /?x=%28+string+%29+%22sys%22.%22t%22.%22em%22+%28%27uname%27%29%3B
+          output:
+            log_contains: id "933211"
+  - test_title: 933211-7
+    desc: PHP Variable Function bypass "(string) {[system][0]} ('uname')"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /?x=%28string%29+%7b%5bsystem%5d%5b0%5d%7d+%28%27uname%27%29%3B
+          output:
+            log_contains: id "933211"
+  - test_title: 933211-8
+    desc: PHP Variable Function bypass "define('x', 'sys' . 'tem');(x)/* comment */('uname')"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /?x=define%28%27x%27,+%27sys%27+.+%27tem%27%29%3b%28x%29%2f*+comment+*%2f%28%27uname%27%29%3B
+          output:
+            log_contains: id "933211"
+  - test_title: 933211-9
+    desc: PHP Variable Function bypass "$y = 'sys'.'tem';($y)('uname')"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /?x=$y+=+%27sys%27.%27tem%27%3b%28$y%29%28%27uname%27%29%3B
+          output:
+            log_contains: id "933211"
+  - test_title: 933211-10
+    desc: PHP Variable Function bypass "define('z', [['sys' .'tem']]);(z)[0][0]('uname')"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /?x=define%28%27z%27,+%5b%5b%27sys%27+.%27tem%27%5d%5d%29%3b%28z%29%5b0%5d%5b0%5d%28%27uname%27%29%3B
+          output:
+            log_contains: id "933211"
+  - test_title: 933211-11
+    desc: PHP Variable Function bypass "(system)(ls)"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /?x=%28system%29%28ls%29%3B
+          output:
+            log_contains: id "933211"
+  - test_title: 933211-12
+    desc: PHP Variable Function bypass "(/* comment */system)(ls/* comment */)"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /?x=%28%2f*+comment+*%2fsystem%29%28ls%2f*+comment+*%2f%29%3B
+          output:
+            log_contains: id "933211"
+  - test_title: 933211-13
+    desc: PHP Variable Function bypass "[system][0](ls)"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /?x=%5bsystem%5d%5b0%5d%28ls%29%3B
+          output:
+            log_contains: id "933211"
+  - test_title: 933211-14
+    desc: PHP Variable Function bypass "[ system ] [ 0 ] ( ls )"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /?x=%5b+system+%5d+%5b+0+%5d+%28+ls+%29%3B
+          output:
+            log_contains: id "933211"
+  - test_title: 933211-15
+    desc: PHP Variable Function bypass "(['system'])[0]('uname')"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /?x=%28%5b%27system%27%5d%29%5b0%5d%28%27uname%27%29%3B
+          output:
+            log_contains: id "933211"
+  - test_title: 933211-16
+    desc: PHP Variable Function bypass "(  [  system  ][  0  ])  {/* comment */0}  (  ls  )"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /?x=%28++%5b++system++%5d%5b++0++%5d%29++%7b%2f*+comment+*%2f0%7d++%28++ls++%29%3B
+          output:
+            log_contains: id "933211"
+  - test_title: 933211-17
+    desc: Check FP if Cookie contains '/' (slash)
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Cookie: "x=(foo)/(bar)"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /
+          output:
+            no_log_contains: id "933211"
+  - test_title: 933211-18
+    desc: Check FP if Cookie contains '/' (slash)
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Cookie: "x=(/foo)/(/bar)"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /
+          output:
+            no_log_contains: id "933211"
+  - test_title: 933211-19
+    desc: Block function call via string
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /?code=%22system%22%28ls%29%3B
+          output:
+            log_contains: id "933211"
+  - test_title: 933211-20
+    desc: Block function call via string using hex escape sequence
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /?code=%22%5Cx73y%5Cx73tem%22%28ls%29%3B
+          output:
+            log_contains: id "933211"
+  - test_title: 933211-21
+    desc: Check false-positive for "this is a 'dog' (not a cat)."
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /?code=this%20is%20a%20'dog'%20(not%20a%20cat).
+          output:
+            log_contains: id "933211"
+  - test_title: 933211-22
+    desc: Block function call bypass '(sy.(st).em)(@id)' (without trailing semi-colon)
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: /?code=(sy.(st).em)(%40id)
+          output:
+            log_contains: id "933211"

--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933211.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933211.yaml
@@ -300,7 +300,7 @@ tests:
             port: 80
             uri: /?code=this%20is%20a%20'dog'%20(not%20a%20cat).
           output:
-            log_contains: id "933211"
+            no_log_contains: id "933211"
   - test_title: 933211-22
     desc: Block function call bypass '(sy.(st).em)(@id)' (without trailing semi-colon)
     stages:


### PR DESCRIPTION
Rule 933210 is incapable of blocking `(sy.(st).em)(@id)` when it is passed to the following PHP snippet:

```php
<?php

eval("(".$_GET["rce"].");");

?>
```
This is because the trailing semi-colon is not injected by the attacker, but hardcoded by the receiving application. It's safe to assume that any application that knowingly passes user-input to `eval` does something like this. 

933210 probably does not block this due to the false positives that can come with it, which isn't allowed at PL1. That is why I created a stricter sibling (933211) that evaluates from PL3 and up to take this scenario into account. However, since the trailing semi-colon is now optional (only when at the end of the string), it also matches the following harmless sentence that 933210 avoids:

```
this is a 'dog' (not a cat)
```

but not

```
this is a 'dog' (not a cat).
```

That should provide a decent balance between false negatives and positives at PL3.

The bypass was originally found and reported by @hussein98d in `4HF1VE22`