### PR TITLE
930120: Added ECDSA type SSH identity files

### DIFF
--- a/rules/lfi-os-files.data
+++ b/rules/lfi-os-files.data
@@ -59,6 +59,8 @@
 .ssh/id_rsa.pub
 .ssh/identity
 .ssh/identity.pub
+.ssh/id_ecdsa
+.ssh/id_ecdsa.pub
 .ssh/known_hosts
 .subversion/auth
 .subversion/config


### PR DESCRIPTION
This is a report from the BugBounty event.

Report id: `4863ZMLJ`

Payload:
```
POST / HTTP/1.1
Host: sandbox.coreruleset.org
User-Agent: curl/7.68.0
Accept: */*
x-crs-paranoia-level: 3
x-format-output: txt-matched-rules
x-backend: apache
x-crs-version: nightly
Content-Length: 23
Content-Type: application/x-www-form-urlencoded

cat /root/.ssh/id_ecdsa
```