### PR TITLE
Perl and Ruby generic RCE signatures (934140 and 934150)

### DIFF
--- a/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
+++ b/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
@@ -225,6 +225,39 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
+# [ Perl generic RCE signatures ]
+#
+# Detects Perl-based injection attacks.
+# Example: @{[system whoami]}
+#
+# Regular expression generated from util/regexp-assemble/data/934140.data.
+# To update the regular expression run the following shell script
+# (consult util/regexp-assemble/README.md for details):
+#   util/regexp-assemble/regexp-assemble.py update 934140
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \@{.*}" \
+    "id:934140,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'Perl Injection Attack',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-perl',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
+    tag:'attack-injection-generic',\
+    tag:'paranoia-level/2',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/242',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/4.0.0-rc1',\
+    severity:'CRITICAL',\
+    setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:934015,phase:1,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:934016,phase:2,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
 #

--- a/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
+++ b/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
@@ -143,6 +143,39 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
+# [ Ruby generic RCE signatures ]
+#
+# Detects Ruby-based injection attacks.
+# Example: Process.spawn("id")
+#
+# Regular expression generated from util/regexp-assemble/data/934150.data.
+# To update the regular expression run the following shell script
+# (consult util/regexp-assemble/README.md for details):
+#   util/regexp-assemble/regexp-assemble.py update 934150
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx Process\s*\.\s*spawn\s*\(" \
+    "id:934150,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'Ruby Injection Attack',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-ruby',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
+    tag:'attack-injection-generic',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/242',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/4.0.0-rc1',\
+    severity:'CRITICAL',\
+    setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:934013,phase:1,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:934014,phase:2,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
 #

--- a/tests/regression/tests/REQUEST-934-APPLICATION-ATTACK-GENERIC/934140.yaml
+++ b/tests/regression/tests/REQUEST-934-APPLICATION-ATTACK-GENERIC/934140.yaml
@@ -1,0 +1,23 @@
+---
+meta:
+  author: karelorigin
+  enabled: true
+  name: "934140.yaml"
+  description: "Tests for rule 934140"
+tests:
+  - test_title: 934140-1
+    desc: Perl interpolation attack
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "*/*"
+              Host: localhost
+              User-Agent: ModSecurity CRS 3 Tests
+            method: GET
+            port: 80
+            uri: "/?x=@{[system+whoami]}"
+            version: HTTP/1.0
+          output:
+            log_contains: id "934140"

--- a/tests/regression/tests/REQUEST-934-APPLICATION-ATTACK-GENERIC/934150.yaml
+++ b/tests/regression/tests/REQUEST-934-APPLICATION-ATTACK-GENERIC/934150.yaml
@@ -1,0 +1,23 @@
+---
+meta:
+  author: karelorigin
+  enabled: true
+  name: "934150.yaml"
+  description: "Tests for rule 934150"
+tests:
+  - test_title: 934150-1
+    desc: Perl interpolation attack
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "*/*"
+              Host: localhost
+              User-Agent: ModSecurity CRS 3 Tests
+            method: GET
+            port: 80
+            uri: "/?x=Process.spawn(%22id%22)"
+            version: HTTP/1.0
+          output:
+            log_contains: id "934150"

--- a/util/regexp-assemble/data/934140.data
+++ b/util/regexp-assemble/data/934140.data
@@ -1,0 +1,26 @@
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
+##! util/regexp-assemble/regexp-assemble.py.
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
+##! script in util/regexp-assemble/README.md.
+##!
+##! Lines starting with `##!` are comments and will be skipped,
+##! empty lines will be ignored completely.
+##! In addition, the quote character `'` at the beginning of a line will
+##! cause the line to be interpreted as literal by the cmdline preprocessor only.
+##!
+##! Five special comments are at your disposal to influence the assembled expression:
+##! - `##!+`: the flag comment
+##! - `##!^`: the prefix comment
+##! - `##!$`: the suffix comment
+##! - `##!>`: the preprocessor comment
+##! - `##!<`: the block preprocessor end comment
+##!
+##! Currently supported preprocessors:
+##! - cmdline [windows|unix] (file scope)
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
+
+##! RegEx list for rule 934140
+
+\@{.*}

--- a/util/regexp-assemble/data/934150.data
+++ b/util/regexp-assemble/data/934150.data
@@ -1,0 +1,26 @@
+##! This is a data file used to generate a regular expression for a CRS rule.
+##! The generation of the regular expression happens with the help of
+##! util/regexp-assemble/regexp-assemble.py.
+##! The ID of the rule in question is part of the file name of this data file.
+##! Read more about the format of this data file and the use of the assembly
+##! script in util/regexp-assemble/README.md.
+##!
+##! Lines starting with `##!` are comments and will be skipped,
+##! empty lines will be ignored completely.
+##! In addition, the quote character `'` at the beginning of a line will
+##! cause the line to be interpreted as literal by the cmdline preprocessor only.
+##!
+##! Five special comments are at your disposal to influence the assembled expression:
+##! - `##!+`: the flag comment
+##! - `##!^`: the prefix comment
+##! - `##!$`: the suffix comment
+##! - `##!>`: the preprocessor comment
+##! - `##!<`: the block preprocessor end comment
+##!
+##! Currently supported preprocessors:
+##! - cmdline [windows|unix] (file scope)
+##! Please refer to util/regexp-assemble/README.md for a full explanation.
+
+##! RegEx list for rule 934150
+
+Process\s*\.\s*spawn\s*\(


### PR DESCRIPTION
This PR contains two new rules for detecting Ruby and Perl-based generic RCE attacks. The bypasses found in this PR were originally found and reported by @hussein98d in `UOOMX10R` and `BJKIDAAW`.