### PR TITLE
fix(regexp-assemble): fix complex concatenation

### DIFF
--- a/util/regexp-assemble/lib/processors/assemble.py
+++ b/util/regexp-assemble/lib/processors/assemble.py
@@ -80,7 +80,8 @@ class Assemble(Processor):
 
         regex = self._run_assembler()
         self.logger.debug('Storing expression at %s: %s', identifier, regex)
-        self.stash[identifier] = regex
+        self.stash[identifier] = self.output + regex
+        self.output = ''
 
     def _append(self, identifier:str):
         if not identifier:

--- a/util/regexp-assemble/tests/preprocessor_test.py
+++ b/util/regexp-assemble/tests/preprocessor_test.py
@@ -312,6 +312,24 @@ cd
         with pytest.raises(KeyError):
             assembler.preprocess(Peekerator(contents.splitlines()))
 
+    def test_storing_alternation_and_concatenation(self, context):
+        contents = '''##!> assemble
+  ##!> assemble
+a
+b
+  ##!=>
+c
+d
+  ##!=< input
+  ##!<
+  ##!<
+##!=> input
+'''
+        assembler = Assembler(context)
+
+        output = assembler._run(Peekerator(contents.splitlines()))
+
+        assert output == '[ab][cd]'
 
 class TestCmdLinePreprocessor:
     def test_adds_unix_escapes(self, context):


### PR DESCRIPTION
Make it possible to mix concatenation and alternation to produce output
that can be stored for later use