### PR TITLE
Add npm-shrinkwrap.json to restricted-files

### DIFF
--- a/rules/restricted-files.data
+++ b/rules/restricted-files.data
@@ -113,6 +113,7 @@ wp-config.txt
 # Node
 /package.json
 /package-lock.json
+/npm-shrinkwrap.json
 /gruntfile.js
 /npm-debug.log
 /ormconfig.json


### PR DESCRIPTION
Just like the `package.json` & `package-lock.json` already on the restricted files list, the [`npm-shrinkwrap.json`](https://docs.npmjs.com/cli/v8/configuring-npm/npm-shrinkwrap-json) (publishable version of `package-lock.json`) also reveals the dependencies as well as the locked versions that are installed. It is _publishable_ in the scope of a web application package, but should not be published with an installed web application.