### PR TITLE
fix(lint): remove long lines check for 942521

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -11,6 +11,7 @@ rules:
       tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920380.yaml
       tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920390.yaml
       tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941360.yaml
+      tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942521.yaml
 
   # don't bother me with this rule
   indentation: disable


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

After merging PRs from BB program, we have some long text for tests in 942521. We need to ignore them.