### PR TITLE
feat: Split Node-Validator keywords functionally

### DIFF
--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -239,9 +239,9 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
 #
 # [Deny List Keywords from Node-Validator]
 # https://raw.github.com/chriso/node-validator/master/validator.js
-# This rule has a stricter sibling 941181 (PL2) that covers the additional payload "-->"
+# This rule has a stricter sibling 941181 (PL2) that covers the additional comment payloads
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@pm document.cookie document.domain document.write .parentnode .innerhtml window.location -moz-binding <!-- <![cdata[" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@pm document.cookie document.domain document.write .parentnode .innerhtml window.location -moz-binding" \
     "id:941180,\
     phase:2,\
     block,\
@@ -829,13 +829,13 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
 # https://raw.github.com/chriso/node-validator/master/validator.js
 # This rule is a stricter sibling of 941180 (PL1)
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@contains -->" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@pm --> <!-- <![cdata[" \
     "id:941181,\
     phase:2,\
     block,\
     capture,\
     t:none,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,t:lowercase,t:removeNulls,\
-    msg:'Node-Validator Deny List Keywords',\
+    msg:'Node-Validator Deny List Keywords (comments)',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941180.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941180.yaml
@@ -54,39 +54,6 @@ tests:
           output:
             log_contains: id "941180"
   - test_title: 941180-4
-    desc: Negative test for Node-validator deny list keyword -->, present in stricter sibling 941181, ARGS
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            method: POST
-            port: 80
-            uri: '/foo'
-            headers:
-              User-Agent: "OWASP CRS test agent"
-              Host: localhost
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            data: '941180-4=-->'
-          output:
-            no_log_contains: id "941180"
-  - test_title: 941180-5
-    desc: "XSS with embedded shell execution attempt (batch script)"
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: "OWASP CRS test agent"
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            method: POST
-            port: 80
-            uri: "/"
-            data: "var=\"-->'-->`--><!--#set var=\"qjr9\" value=\"kjkjg7sdk\"--><!--#set var=\"fqz7\" value=\"sql4xxaq\"--><!--#echo var=\"qjr9\"--><!--#echo var=\"fq4p\"-->"
-            version: HTTP/1.0
-          output:
-            log_contains: id "941180"
-  - test_title: 941180-6
     desc: "Node-validator deny list keywords, ARGS, issue #2512"
     stages:
       - stage:
@@ -102,7 +69,7 @@ tests:
             data: 'arg=...(document.domain)...'
           output:
             log_contains: id "941180"
-  - test_title: 941180-7
+  - test_title: 941180-5
     desc: "We should not trigger on REQUEST_FILENAME without special characters"
     stages:
       - stage:

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941181.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941181.yaml
@@ -3,7 +3,7 @@ meta:
   author: "Paul Beckett"
   enabled: true
   name: "941181.yaml"
-  description: "Tests to trigger, or not trigger 941180"
+  description: "Tests to trigger, or not trigger 941181"
 tests:
   - test_title: 941181-1
     desc: Node-validator deny list keywords, ARGS
@@ -38,6 +38,22 @@ tests:
           output:
             log_contains: id "941181"
   - test_title: 941181-3
+    desc: Node-validator deny list keywords, ARGS
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            method: POST
+            port: 80
+            uri: '/foo'
+            headers:
+              User-Agent: "OWASP CRS test agent"
+              Host: localhost
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            data: '941181-4=-->'
+          output:
+            log_contains: id "941181"
+  - test_title: 941181-4
     desc: Node-validator deny list keywords, ARGS_NAMES
     stages:
       - stage:
@@ -53,7 +69,7 @@ tests:
             data: '-->=941181-3'
           output:
             log_contains: id "941181"
-  - test_title: 941181-4
+  - test_title: 941181-5
     desc: Node-validator deny list keywords, ARGS_NAMES
     stages:
       - stage:
@@ -66,6 +82,39 @@ tests:
               User-Agent: "OWASP CRS test agent"
               Host: localhost
               Cookie: '-->=941181-4'
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          output:
+            log_contains: id "941181"
+  - test_title: 941181-6
+    desc: "XSS with embedded shell execution attempt (batch script)"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: "OWASP CRS test agent"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            data: "var=\"-->'-->`--><!--#set var=\"qjr9\" value=\"kjkjg7sdk\"--><!--#set var=\"fqz7\" value=\"sql4xxaq\"--><!--#echo var=\"qjr9\"--><!--#echo var=\"fq4p\"-->"
+            version: HTTP/1.0
+          output:
+            log_contains: id "941181"
+  - test_title: 941181-7
+    desc: Node-validator deny list keywords, ARGS_NAMES
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            method: GET
+            port: 80
+            uri: '/baz'
+            headers:
+              User-Agent: "OWASP CRS test agent"
+              Host: localhost
+              Cookie: '<![cdata[=941181-4'
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
           output:
             log_contains: id "941181"


### PR DESCRIPTION
This improvement adds further consistency to https://github.com/coreruleset/coreruleset/pull/2088

The PL1 rule (`941180`) of Node-Validator keywords contains both evident attack fragments, i.e. `document.cookie`, as well as comment payloads, i.e. `<!--`.

This change moves all comment payloads to the PL2 rule (`941181`) that already contains the comment closing tag `-->`. 

This makes the PL1 rule in line with the goal of PL1, and makes the already existing PL2 rule consistent with the goal of having `comment` payloads.