### PR TITLE
feat(list): update php errors list

### DIFF
--- a/rules/php-errors.data
+++ b/rules/php-errors.data
@@ -35,9 +35,18 @@ API is restricted by "
 can't be temporary enabled (it may be only disabled till the end of request)
 has not been properly started, can't compile file
 is not a valid backing value for enum "
+# is too long
+# &
+# *
+# **
+# +
+# -
+# /
 64-bit format codes are not available for 32-bit versions of PHP
+# :
 : module registration failed!
 : opcache.huge_code_pages has no affect as huge page is not supported
+# ???
 A 'day of year' can only come after a year has been found
 A PHP Object cannot be converted to a XPath-string
 A four digit ISO year could not be found
@@ -90,6 +99,7 @@ Attempt to read property "
 Attempt to write over data boundary
 Attempting to set reference to non referenceable value
 Attempting to use non-attribute class "
+# Attribute "
 Attribute class "
 Automatic conversion of false to array is deprecated
 Backup failed: source database is busy
@@ -106,11 +116,12 @@ CTRL events can only be received on the main thread
 CTRL events trapping is only supported on console
 Can only throw objects
 Can only use PDO::FETCH_FUNC in PDOStatement::fetchAll()
+# Can use "
 Can't bind a lob for output
 Can't cache files in chroot() directory with too big inode
-Can't create a temporary mailbox:
+# Can't create a temporary mailbox:
 Can't initialize heap
-Can't re-open '$new_mailbox' mailbox:
+# Can't re-open '$new_mailbox' mailbox:
 Cannot access "
 Cannot access node list without offset
 Cannot access parser properties before loading data
@@ -134,8 +145,8 @@ Cannot change opcache.jit setting at run-time (JIT is disabled)
 Cannot check dimension on a COM object
 Cannot compare DateInterval objects
 Cannot connect to HTTPS server through proxy
-Cannot connect to IMAP server
-Cannot connect to IMAP server $server:
+# Cannot connect to IMAP server
+# Cannot connect to IMAP server $server:
 Cannot convert to resource type
 Cannot copy hash
 Cannot create duplicate attribute
@@ -206,6 +217,7 @@ Cannot unset PDORow offset
 Cannot unset PDORow property
 Cannot unset offset in a non-array variable
 Cannot unset string offsets
+# Cannot use "
 Cannot use 'readonly' as method modifier
 Cannot use [] for reading
 Cannot use [] on objects in constant expression
@@ -219,12 +231,13 @@ Cannot write to PDORow property
 Cannot write to read-only property
 Cannot yield from finally in a force-closed generator
 Case folding mode must be one of the PDO::CASE_* constants
+# Class "
 Class name must be a valid object or a string
 Collator class not defined
 Column index must be greater than or equal to 0
 Comparison of incompatible C types
 Corrupt member variable name
-Could not allocate parser
+# Could not allocate parser
 Could not copy from temporary stream - ini file truncated
 Could not create WBMP
 Could not create gdImage
@@ -250,9 +263,12 @@ Direct instantiation of WeakReference is not allowed, use WeakReference::create 
 Directive oci8.old_oci_close_semantics is deprecated
 Directory object is already initialized
 Division by zero
+# Done
+# Done.
 Double date specification
 Double time specification
 Double timezone specification
+# Dummy
 Duplicate field name "
 During class fetch
 EOF before image was complete
@@ -344,6 +360,7 @@ HY000
 HY093
 HY105
 Handler name must be a string
+Header "
 Header may not contain
 Header may not contain NUL bytes
 Header name "
@@ -358,6 +375,7 @@ Illegal offset type
 Illegal offset type in isset or empty
 Illegal offset type in unset
 Illegal string offset
+# Illegal string offset "
 Implicit conversion from float-string "
 Impossible to not specify a stdin delimiter without -rr
 Impossible to yield from the Generator being currently run
@@ -365,9 +383,11 @@ Incompatible types when assigning
 Incomplete enum "
 Incomplete struct "
 Incomplete union "
+# Incorrect "
 Input string is too long
 Instantiation of class Closure is not allowed
 Insufficient data for unserializing -
+# Interface "
 Internal error: Failed to retrieve the argument's reflection object
 Internal error: Failed to retrieve the reflection object
 Internal help error, non-unique alias "
@@ -375,6 +395,7 @@ Interned string buffer overflow
 IntlCalendar::set() has no variant with exactly 4 parameters
 IntlGregorianCalendar object is already constructed
 IntlRuleBasedBreakIterator object is already constructed
+# Invalid "
 Invalid OID value passed
 Invalid RelaxNG Validation Context
 Invalid Schema Validation Context
@@ -433,6 +454,7 @@ Missing redirection target
 Mixing of ISO dates with natural dates is not allowed
 Mode must be one of 'r', 'r+', 'w', or 'w+'
 Modification of ArrayObject during sorting is prohibited
+# Module "
 Multi OID walks are not supported!
 NULL pointer dereference
 Nanoseconds was not in the range 0 to 999 999 999 or seconds was negative
@@ -446,6 +468,7 @@ No execution context
 No execution context set
 No file uploaded
 No function table loaded
+# No key "
 No more entries in hash table!
 No pattern was provided
 No resource supplied
@@ -463,8 +486,12 @@ Not a full path given or extension_dir ini setting is not set
 Not a valid gd2 file
 Not enough data available to satisfy format
 Not enough free shared space to allocate
+# Not executing
+# Not executing!
 Not executing, and execution context not set
+# Not running
 Not supported in multithreaded Web servers
+# Not yet implemented
 Nothing to execute!
 Nothing was deleted, no corresponding watchpoint found
 Number is not an integer string
@@ -507,7 +534,8 @@ Only variable references should be returned by reference
 Only variable references should be yielded by reference
 Only variables should be assigned by reference
 Only variables should be passed by reference
-Options should have the form ["
+# Option "
+Options should have the form [\
 Out of memory
 Overflow in enumeration values "
 PDO object is not initialized, constructor was not called
@@ -669,6 +697,8 @@ String offset cast occurred
 String size overflow
 TCP/IP option is not available for error logging
 Telling...
+# The
+# The "
 The (unset) cast is no longer supported
 The DateTime object has not been correctly initialized by its constructor
 The InternalIterator object has not been properly initialized
@@ -740,6 +770,7 @@ Unsupported attribute type
 Unsupported constant expression
 Unsupported operand types
 Use after free()
+# Use of "
 User-supplied function must be a valid callback
 User-supplied statement class cannot have a public constructor
 User-supplied statement does not accept constructor arguments
@@ -755,6 +786,7 @@ VirtualFree() failed
 WeakMap key must be an object
 WebP decode: realloc failed
 Width must be an integer
+# Width of "
 Writing index
 Wrong argument number
 Wrong field name
@@ -771,10 +803,13 @@ You should not create a tidyNode manually
 Zero width in bit-field "
 [] operator not supported for SplFixedArray
 [] operator not supported for strings
+# \
+# ^
 __clone method called on non-object
 and argument #2 ($string_2) must have the same length
 and argument #2 ($values) must have the same number of elements
 args element is not an array
+# array
 attempt to cast to larger type
 attempt to read over data boundary
 attempt to read over string boundary
@@ -790,8 +825,10 @@ avif error - image dimensions must not be zero
 bad type specifier while parsing parameters
 c-client imap_getacl failed
 call a method
+# calling
 can't allocate continuation
 can't re-open '$new_mailbox' mailbox:
+# cannot be "
 cannot be 0 for the POSIX_S_IFCHR and POSIX_S_IFBLK modes
 cannot be PDO::FETCH_LAZY in PDOStatement::fetchAll()
 cannot be a class constant
@@ -811,6 +848,8 @@ cannot be provided when argument #2 ($wrapper_or_options) is an array
 cannot be true when argument #2 ($width) is 0
 cannot change a protected metatable
 cannot combine mode "
+# cannot contain
+# cannot contain "
 cannot contain empty keys
 cannot create tempnam
 cannot have a fractional part
@@ -875,6 +914,7 @@ invalid pattern capture
 is an invalid DocumentType object
 is an invalid configuration option, "
 is an invalid offset
+# is invalid
 is not a supported source encoding
 is not a supported target encoding
 is not a valid cURL multi option
@@ -885,7 +925,11 @@ is not a valid encoding
 is not a valid fault code
 is not a valid node type
 is not an integer string
+# is not well-formed
+# is out of range
 is required when using this extract type
+# is too large
+# is too long
 is uninitialized
 iterable type is now a compile time alias for array|Traversable,
 jday must be between 2440588 and
@@ -894,6 +938,9 @@ malformed pattern (missing
 mb_chr() does not support the "
 mb_ord() does not support the "
 mb_strpos(): Unknown error
+# missing
+# modify a property
+# must be "
 must be 0 or 1 for attribute MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH
 must be 1 for SQLSetConnectOption(), or 2 for SQLSetStmtOption()
 must be CL_EXPUNGE or 0
@@ -1043,6 +1090,7 @@ must be between 2 and 36 (inclusive)
 must be contained in argument #1 ($haystack)
 must be contained in argument #1 ($main_str)
 must be contained in argument #2 ($data)
+# must be either "
 must be either COUNT_NORMAL or COUNT_RECURSIVE
 must be either FTP_ASCII or FTP_BINARY
 must be either IntlCalendar::WALLTIME_FIRST or
@@ -1053,13 +1101,12 @@ must be either PGSQL_STATUS_LONG or PGSQL_STATUS_STRING
 must be either SIG_DFL or SIG_IGN when an integer value is given
 must be either SQL_FETCH_FIRST or SQL_FETCH_NEXT
 must be either Transliterator::FORWARD or Transliterator::REVERSE
-must be either "
 must be empty or a single character
 must be greater or equal than 0
 must be greater than 0
 must be greater than 0 for attribute MYSQLI_STMT_ATTR_PREFETCH_ROWS
-must be greater than 0 for the FTP_TIMEOUT_SEC option
-must be greater than 0 for the "
+# must be greater than 0 for the "
+# must be greater than 0 for the FTP_TIMEOUT_SEC option
 must be greater than or equal to -1
 must be greater than or equal to 0
 must be greater than or equal to 0 when using the threshold mode
@@ -1092,6 +1139,9 @@ must be of type array, string given
 must be of type string when argument #1 ($ldap) is an LDAP instance
 must be of type string, array given
 must be of type string|int|float|bool|null
+# must be one character
+# must be one of
+# must be one of "
 must be one of AF_UNIX, AF_INET, or AF_INET6
 must be one of AF_UNIX, AF_INET6, or AF_INET
 must be one of E_USER_ERROR, E_USER_WARNING, E_USER_NOTICE,
@@ -1126,6 +1176,7 @@ must be provided for instance properties
 must be provided when argument #2 ($wrapper_or_options) is a string
 must be specified when enabling encryption
 must be the same size as argument #1 ($im1)
+# must contain a "
 must contain arrays only containing the "
 must contain arrays with consecutive integer indices starting from 0
 must contain at least 1 valid key
@@ -1137,16 +1188,20 @@ must contain only strings
 must contain only valid cURL options
 must contain only valid callbacks
 must have 6 elements
+# must have a "
 must have a correct length
 must have a multiple of 4 elements
 must have a valid syntax
+# must have an "
 must have an even number of elements
 must have at least one color
 must have at least one element
 must have consecutive integer indices starting from 0
 must have exactly two elements: "
+# must have key "
 must have the node attribute
 must have the same number of elements as the links array
+# must not be empty
 must not be the spl_autoload_call() function
 must not be zero
 must not combine 'H' and 'K' flags
@@ -1180,13 +1235,16 @@ mysqli_result::data_seek() cannot be used in MYSQLI_USE_RESULT mode
 name conflict for module
 negative array index
 no magic files loaded
+# not implemented
+# not passed
 only the leftmost array can be undimensioned
 opcache.file_cache must be a full path of accessible directory.\n
 opcache.max_wasted_percentage must be set between 1 and 50.\n
 opcache.memory_consumption is set below the required 8MB.\n
+# option "
 pdo_oci_handle_factory
+# phar error: "
 phar error: Directory not empty
-phar error: "
 phar error: cannot create directory "
 phar error: cannot remove directory "
 phar error: cannot rmdir directory "
@@ -1205,6 +1263,7 @@ pthread_mutex_init
 pthread_mutexattr_destroy
 pthread_mutexattr_init
 pthread_mutexattr_settype
+# put.
 remote cafile streams are disabled for security purposes
 rfc2397: illegal URL
 rfc2397: illegal media type
@@ -1241,9 +1300,13 @@ wrong number of arguments to
 wrong size for the hashed password
 zend.assertions may be completely enabled or disabled only in php.ini
 zlib window size (logarithm) (
+# |
 
 # Group with format strings
 
+#   into (
+# ($end)
+# (after
  (breaking at opline
  (inclusive)
  (path:
@@ -1251,23 +1314,44 @@ zlib window size (logarithm) (
  - dynamic modules are not supported
  Chunks Wide
  Chunks vertically
+# \n
+# already defined
+# and
+# and %%H
+# and property
+# argument
+# arguments are required,
  arguments for the fetch mode provided,
+# as array
  as execution context, not a valid file or symlink
+# as non static
+# at continuation
+# at line
+# bytes
  bytes (Current memory usage is
  bytes exhausted (tried to allocate
  bytes exhausted at
+# bytes passed
  bytes were written, expected to write
+# bytes)
  bytes) (tried to allocate
+# bytes) at
+# bytes,
  bytes. Uncompressing into buffer of
  cannot be instantiated
  cannot be of type array
  cannot be passed by reference
  cannot contain non abstract method
+# characters to "
  chunk index entries
+# colours
  command is disallowed during hard interrupt
+# constant
  contains a null byte
+# could not be converted to
  could not be converted to bool
  could not be converted to string
+# could not be found
  could not compile file
  did not create an Iterator
  died before SIGKILL was sent
@@ -1275,59 +1359,127 @@ zlib window size (logarithm) (
  does not match enum backing type
  does not support method calls
  doesn't exist in class
+# done.
+# elements
+# elements,
+# exists
+# expected
  file is closed
+# for cases
+# for initialization
+# for parameter
  for stream_metadata
+# from
+# from uncompress
+# given
+# given, called in
+# has no effect
  has no unserializer
+# held by property
  implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary)
+# in
+# in table for
  instance wasn't initialized properly
+# is deprecated
  is greater than \\377
  is inapplicable to this socket type
+# is installed
  is nor an array nor an object
+# is not a string
  is not a user defined function, no oplines exist
  is not a user defined method, no oplines exist
  is not a valid backing value for enum "
  is not a valid phar archive
+# is not allowed
+# is not callable
  is not compatible with property
+# is undefined
+# items,
+# magic
+# method
+# module failed
  must be a field name from this result set
  must be greater than or equal to 0
  must be less than the number of fields for this result set
  must be passed by reference, value given
+# must be public
  must not be accessed before initialization
+# not found
  object is already closed
  object is not fully initialized
  object_id:
  of C function '
+# of type
+# offset
+# on line
+# on string
  oplines in file
  oplines in function
  oplines in method
  option must have an array value
+# or null,
  overwrites previous argument
  packet. PID=
+# parameter
+# passed and
+# passed in
+# past its maximal value
+# past its minimal value
+# points
  points in array with only
+# present
+# property
+# provided
  readonly property
+# received
  requires PDO API version
  requires Zend Engine API version
+# resource
+# resource supplied
+# returned
+# size
+# supports only version
+# to
+# to property
  to reference held by property
+# to write index
  used as array
  was built with configuration
  when argument #1 ($search) is
+# when declared
  with an empty name
 ' (include_path='
 ' (info)\n
 ' (mem)\n
 ' (tried:
+#' (value '
+#' (wrong "
 ' (wrong header)\n
+#' already defined
 ' already defined in '
-' excepted checksum:
+# ' and '
+# ' at line
+# ' doesn't exist
+# ' excepted checksum: 0x%08x actual checksum: 0x%08x\n
+# ' flags
 ' for reading from stdin
 ' from PHP '
+# ' from type '
+# ' has fixed value '
 ' in <message>
 ' in s[np]printf call
 ' is not a valid mode for fopen
 ' is not a valid utf-8 string
+# ' is not allowed)
+# ' is too
 ' must have a single part
+# ' not present
 ' of C struct/union
 ' of non C struct/union
+# ' property
+# ' type='
+# ' value='
+# ') failed:
 ', FFI_LIB defined twice
 ', FFI_SCOPE defined twice
 ', bad FFI_LIB define
@@ -1336,11 +1488,18 @@ zlib window size (logarithm) (
 ', cannot resolve C function '
 ', cannot resolve C variable '
 ', different 'targetNamespace'
+# ', expecting '
+# ', expecting at least
 ', expecting exactly
 ', file doesn't exist
+# ', found '
+# ', found PHP '
 ', namespace must not match the enclosing schema 'targetNamespace'
 ', not a regular file
+# ', redefinition of '
 ', unexpected 'targetNamespace'='
+# ':  expected=0x%08x, found=0x%08x
+# '\n
 () (previously declared in
 () - access must be exactly one of public, protected or private
 () can only be called after a stylesheet has been imported
@@ -1350,6 +1509,8 @@ zlib window size (logarithm) (
 () cannot take arguments
 () cannot take arguments by reference
 () does not accept unknown named parameters
+# () dynamically
+# () expects
 () expects at least
 () expects at most
 () expects at most 2 argument for the fetch mode provided,
@@ -1357,6 +1518,7 @@ zlib window size (logarithm) (
 () expects exactly 0 arguments,
 () expects exactly 1 argument for the fetch mode provided,
 () expects exactly 2 argument for PDO::FETCH_FUNC,
+# () from
 () from global scope
 () from scope
 () has been disabled for security reasons
@@ -1366,6 +1528,7 @@ zlib window size (logarithm) (
 () must not return a value,
 () must take exactly %
 () must take exactly 1 argument
+# () on
 () to object of class
 (): Argument #
 (): Argument #1 ($callback) must be a valid callback,
@@ -1384,28 +1547,47 @@ zlib window size (logarithm) (
 (): Disabling safe uploads is no longer supported
 (): Expects exactly 3 arguments when argument #3
 (): If option "
+# (): Option "
 (): Option must be a valid callback
 (): Parameter #
 (): Return type must be
 (): Return value must be of type
 (): Sort key list must have an "
+# (): The
 (): The provided file handle must be writable
 (): cURL option must not contain any null bytes
 (): never-returning function must not implicitly return
+# (): no
+# (): option "
 (): option array cannot have numeric keys
 (): supplied argument is not a valid
 (): supplied resource is not a valid
+# ) after startup
 ) at index
+# ) cannot be found
+# ) could not be found
+# ) for command
 ) from chunk
+# ) from position
+# ) is already in use
 ) is not user defined
+# ) must be of type
 ) the file does not exist
+# ), from
 ), not a regular file or symlink
 ), please try to set opcache.use_cwd to 0 in ini file
+# ), y from
+# ).\n
+# , %%G, %
 , as this would result in an inconsistent type conversion
+# , because the name is already in use
+# , cannot run
 , check path and permissions
 , ensure the file exists
+# , err
 , file does not exist
 , invalid data source
+# , it does not exist
 , it is not a regular file
 , not found or invalid zend extension / module:
 , or -2 and -36
@@ -1467,6 +1649,7 @@ Attempt to read undefined field '
 Attempt to unset static property
 Attempting to kill locker
 Attempting to use non-attribute class "
+# Attribute class
 Attribute class "
 Attribute constructor of class
 Attribute value must be of type bool for selected attribute,
@@ -1480,25 +1663,34 @@ Bad version:
 Bit field "
 Blacklist JIT compilation failed,
 Breakpoint already exists for
+# Breakpoint at
 Breakpoint exists at
 Breakpoint exists for
 Cached script '
+# Call to
 Call to a member function
 Call to undefined function
 Call to undefined method
+# Cannot access
 Cannot access offset of type
 Cannot access property of object of type
 Cannot append properties to objects, use
+# Cannot assign
 Cannot bind closure to scope of internal class
 Cannot bind method
+# Cannot call
 Cannot call abstract method
 Cannot call private
+# Cannot create
 Cannot create dynamic property
 Cannot create mutex (error
+# Cannot declare
 Cannot declare self-referencing constant
+# Cannot decrement
 Cannot decrement property
 Cannot dynamically load
 Cannot get fiber return value:
+# Cannot increment
 Cannot increment property
 Cannot instantiate abstract class
 Cannot instantiate enum
@@ -1511,8 +1703,11 @@ Cannot modify readonly property
 Cannot modify readonly property DatePeriod::$
 Cannot open "
 Cannot perform bitwise not on
+# Cannot redeclare
 Cannot set breakpoint in
+# Cannot stat
 Cannot unset readonly property
+# Cannot use
 Cannot use "
 Cannot use object of type
 Cannot write read-only property
@@ -1523,15 +1718,19 @@ Command array element
 Conditional break
 Could not add variable: OID='
 Could not fetch class
+# Could not find
 Could not find the class
 Could not list function
+# Could not load
 Could not open '
 Could not open file
+# Couldn't fetch
 Couldn't fetch function
 Creation of dynamic property
 Data starts at
 Declaration does not declare anything at line
 Duplicate field name "
+# Duplicate tag
 Duplicate value in enum
 Encoding: Attribute '
 Encoding: Element '
@@ -1588,13 +1787,17 @@ File size is
 Flexible array member in union at line
 Flexible array member not at end of struct at line
 Forced restart at
+# Format:
 Function registration failed - duplicate name -
 Function returning array is not allowed at line
 Function returning function is not allowed at line
 GetAdaptersAddresses failed:
 Got file code:
+# HTTP request failed!
+# Header name "
 Illegal length modifier specified '
 Illegal string offset "
+# Image is
 Image palette completed:
 Implicit conversion from float-string "
 Incompatible types when assigning to type '
@@ -1612,6 +1815,7 @@ Indirect modification of overloaded property
 Instantiation of
 Internal help error, non-unique alias "
 Invalid access level for
+# Invalid action
 Invalid backtrace size
 Invalid callback
 Invalid file for conditional break
@@ -1635,6 +1839,8 @@ Negative width in bit-field "
 No blacklist file found matching:
 No frame #
 No help topic found for
+# No key "
+# No response from
 Not allowed to call handler '
 OID value must be of type string|int,
 Object of class
@@ -1704,6 +1910,8 @@ RestartC(+1):
 RestartC(-1):
 RestartC:
 Session callback must have a return value of type bool,
+# Size of `
+# Size:
 SoapHeader::__construct(): "
 SoapServer::addFunction(): Function "
 Static function
@@ -1711,18 +1919,24 @@ Struct/union can't contain an instance of itself at line
 Stuck count for pid
 Stuck count for thread id
 The arguments array must contain
+# The class
 The class requested (
+# The command "
 The expanded parameter requires SQLite3 >= 3.14 and
+The function
 The function requested (
 The magic method
+# The method
 The requested class (
 The requested function (
 The requested name (
 The source of the requested class (
 The use statement with non-compound name '
+# There are only
 Too few arguments to function
 Trying to access array offset on value of type
 Trying to clone an uncloneable object of class
+# Trying to use
 Type float/double is not allowed at position
 Type kind must be dispatchable, %08x given
 Typed property
@@ -1753,6 +1967,7 @@ Undefined variable $
 Unknown class '
 Unknown format specifier "
 Unknown named parameter $
+# Unknown option
 Unknown parameter type:
 UnlockAll:
 Unsupported array index type at line
@@ -1770,15 +1985,26 @@ UpdateC(+1):
 UpdateC(-1):
 UpdateC:
 Uploaded file size 0 - file [
+# Value for
 Value must be of type string|int|float|null,
+# Value of type
 Values must be of type string|int|float|bool|null,
+# Version:
 Width must be greater than zero and less than
+# Width of "
 Wrong COM_STMT_PREPARE response size. Received
 Wrong parameter count for
 Wrong type of bit field "
 Zero width in bit-field "
+# [%03d/
+# [%03d] Cannot remove records, [
+# [%03d] [
 [clean] Failed to drop old test table: [
+# \n
 ] cannot be found (missing integer key)
+# ] not saved
+# ] only has
+# array item
 array_key_exists(): Argument #2 ($array) must be of type array,
 avif error -
 bad argument #
@@ -1786,15 +2012,20 @@ bad magic in `
 call_user_func_array(): Argument #2 ($args) must be of type array,
 cannot allocate %
 cannot find entry `
+# cannot map `
 cannot mprotect `
+# cannot open `
 cannot open tmp file `
+# cannot read `
 cannot read fd
 cannot read magic file `
+# cannot stat `
 cannot write tmp file `
 contains invalid encoding "
 contains invalid flag: '
 contains invalid type for element
 corrupted file '
+# error writing `
 failed loading cafile stream: `
 failed pre-loading '
 foreach() argument must be of type array|object,
@@ -1806,8 +2037,10 @@ gd-png warning: image data references out-of-range color index (
 get_class(): Argument #1 ($object) must be of type object,
 getcwd() failed for '
 getifaddrs() failed
+# indirect count (
 individual body must be of type array,
 invalid mode 0
+# invalid option
 invalid replacement value (a
 invalid value (
 is an invalid configuration option, "
@@ -1817,6 +2050,7 @@ malformed pattern (ends with
 mb_chr() does not support the "
 mb_ord() does not support the "
 mm_malloc failed, avail
+# must be
 must be a 3x3 array, matrix[
 must be a class name compatible with
 must be a class name derived from
@@ -1831,6 +2065,7 @@ must be a valid encoding, "
 must be a valid function name, function "
 must be a valid language, "
 must be an instance of mysqli,
+# must be between
 must be between 0 and
 must be between 2 and
 must be greater than 0 and less than
@@ -1838,6 +2073,7 @@ must be greater than or equal to
 must be less than
 must be less than or equal to
 must be less than or equal to argument #
+# must be of type
 must be of type ?
 must be of type ?array,
 must be of type Countable|array,
@@ -1861,11 +2097,15 @@ must be of type string,
 must be of type string|int|array,
 must be of type string|int|float|bool,
 must be of type zero-terminated string or array,
+# must consist of exactly
+# must contain a "
+# must have key "
 must not combine '
 must only have elements of type Socket,
 must only have elements of type string|int,
 name conflict for module
 name use count (
+# negative offset
 no function environment for tail call at level
 no valid certs found cafile stream: `
 opcache cannot create directory for file '
@@ -1895,6 +2135,8 @@ skip Can't connect to MySQL Server - [
 stack overflow (
 string too long: `
 strlen(): Argument #1 ($str) must be of type string,
+# u) exceeded
+# unlink of "
 unreadable symlink `
 upload_max_filesize of
 void type is not allowed at line
@@ -1902,3 +2144,7 @@ write() failed -
 zend_signal: handler was replaced for signal (
 zend_signal: shutdown with non-zero blocking depth (
 zlib >= 1.2.4 required for BLOCK deflate; current version:
+# |int,
+# |int|null,
+# |string,
+# |string|null,

--- a/rules/php-errors.data
+++ b/rules/php-errors.data
@@ -1,30 +1,31 @@
 # The contents of this list come from the [PHP source code](https://github.com:php/php-src).
 #
-# There are different types of errors that might be thrown. An easy way to consolidate is to
+# There are different types of errors that might be thrown. An easy way to discover them is to
 # get any text that comes from the error handling functions: `zend_error`, `zend_throw_error`, `soap_error0`, etc.
 # Using the regexp `_error([0-9])?\(` will give you all. And you can see them using:
 # `ggrep -h -E -r -o --exclude="*.phpt" '\w+_error([0-9])?\(' * | sort | uniq`
 #
-# After getting the list, there are two different types of errors: those who are literal text, and those who include
+# After getting the list, there are two different types of errors: those with literal text, and those that include
 # print format args like `%s`, `%d`, `%zu`, etc. We sort them in two groups.
 #
 # The first group is just anything without formatting args. Only text, sorted ascending. Command used:
-#   - `ggrep -E -h -r --exclude="*.phpt" '_error([0-9])?\(' * | awk -F\" '{ print $2;} ' | sed -e 's/ \\$/ "/g' | sort | uniq | grep -v '%'`
-# Small post processing might be done to adjust strings that might cause false positives. Examples are lines too short,
-# or very common Enlgish sencentes (e.g. `Can use`, `Attribute`, etc.). There also text coming from php unit/regression
-# tests, like 'DROP TABLE IF EXISTS test_bug_71863` that we need to clean.
+#   - `grep -E -h -r --exclude="*.phpt" '_error([0-9])?\(' * | awk -F\" '{ print $2;} ' | sed -e 's/ \\$/ "/g' | sort | uniq | grep -v '%'`
+# Post processing might be necessary to adjust strings that can cause false positives, such as
+# - line is very short
+# - line is a (partial) common English sentence, like `Can use`, `Attribute`, etc.
+# - text coming from php unit/regression tests, like 'DROP TABLE IF EXISTS test_bug_71863`
 #
 # The second group will be the part with format strings. Only text, sorted ascending.
 # This will need a more careful processing. The format string will appear in the text result,
 # but it will (of course) be substituted by some variable value. So we need to clean more text here.
-# The easiest way is to split in lines when a format string is found. This will shorten the texts, but
-# then we can sort who are the ones more fit for being in this file.
+# The easiest way is to split a line whenever a format string is found. This will shorten the texts but,
+# then we can sort out the ones we don't want to include more easily.
 # We also remove:
-# - text with just one word (too easy for FP), or one word, one space (optional) and one non-word (optional).
-#   this will match things like `Collect "`, `Method` or `Class `.
+# - text with just one word (likely to be FP), or one word, one space (optional) and one non-word (optional),
+#   which will match things like `Collect "`, `Method` or `Class `.
 #
 # Command used:
-#   - `ggrep -E -h -r --exclude="*.phpt" '_error([0-9])?\(' * | awk -F\" '/%/ { print $2;} ' | sed -e 's/ \\$/ "/g' -e 's/%[zlp][ud]/\n/g' -e 's/%[a-z]/\n/g'  -e 's/%\.\*s/\n/g' | sort | uniq | ggrep -E -v '^\w+\s?\W?$' | ggrep -E -v '^\W+$'
+#   - `grep -E -h -r --exclude="*.phpt" '_error([0-9])?\(' * | awk -F\" '/%/ { print $2;} ' | sed -e 's/ \\$/ "/g' -e 's/%[zlp][ud]/\n/g' -e 's/%[a-z]/\n/g'  -e 's/%\.\*s/\n/g' | sort | uniq | grep -E -v '^\w+\s?\W?$' | grep -E -v '^\W+$'
 #
 # Anything that is too short, or nonsense, we remove.
 

--- a/rules/php-errors.data
+++ b/rules/php-errors.data
@@ -3,7 +3,7 @@
 # There are different types of errors that might be thrown. An easy way to discover them is to
 # get any text that comes from the error handling functions: `zend_error`, `zend_throw_error`, `soap_error0`, etc.
 # Using the regexp `_error([0-9])?\(` will give you all. And you can see them using:
-# `ggrep -h -E -r -o --exclude="*.phpt" '\w+_error([0-9])?\(' * | sort | uniq`
+# `grep -h -E -r -o --exclude="*.phpt" '\w+_error([0-9])?\(' * | sort | uniq`
 #
 # After getting the list, there are two different types of errors: those with literal text, and those that include
 # print format args like `%s`, `%d`, `%zu`, etc. We sort them in two groups.

--- a/rules/php-errors.data
+++ b/rules/php-errors.data
@@ -1328,8 +1328,6 @@ zlib window size (logarithm) (
 ' must have a single part
 ' of C struct/union
 ' of non C struct/union
-' type='
-' value='
 ', FFI_LIB defined twice
 ', FFI_SCOPE defined twice
 ', bad FFI_LIB define
@@ -1338,15 +1336,10 @@ zlib window size (logarithm) (
 ', cannot resolve C function '
 ', cannot resolve C variable '
 ', different 'targetNamespace'
-', expecting '
-', expecting at least
 ', expecting exactly
 ', file doesn't exist
-', found '
-', found PHP '
 ', namespace must not match the enclosing schema 'targetNamespace'
 ', not a regular file
-', redefinition of '
 ', unexpected 'targetNamespace'='
 () (previously declared in
 () - access must be exactly one of public, protected or private
@@ -1402,11 +1395,9 @@ zlib window size (logarithm) (
 (): option array cannot have numeric keys
 (): supplied argument is not a valid
 (): supplied resource is not a valid
-) after startup
 ) at index
 ) from chunk
 ) is not user defined
-) must be of type
 ) the file does not exist
 ), not a regular file or symlink
 ), please try to set opcache.use_cwd to 0 in ini file
@@ -1870,7 +1861,6 @@ must be of type string,
 must be of type string|int|array,
 must be of type string|int|float|bool,
 must be of type zero-terminated string or array,
-must consist of exactly
 must not combine '
 must only have elements of type Socket,
 must only have elements of type string|int,

--- a/rules/php-errors.data
+++ b/rules/php-errors.data
@@ -1,139 +1,533 @@
-No row with the given identifier
-open_basedir restriction in effect
-eval()'d code</b> on line <b>
-Cannot execute a blank command in
-Fatal error</b>:  preg_replace
-thrown in <b>
-#0 {main}
-Stack trace:
-</b> on line <b>
-() cannot be called statically
-- not a Class::Method
-::__toString() must not throw an exception
-Access to undeclared static property:
+# The contents of this list come from the [PHP source code](https://github.com:php/php-src).
+#
+# There are different types of errors that might be thrown. An easy way to consolidate is to
+# get any text that comes from the error handling functions: `zend_error`, `zend_throw_error`, `soap_error0`, etc.
+# Using the regexp `_error([0-9])?\(` will give you all. And you can see them using:
+# `ggrep -h -E -r -o --exclude="*.phpt" '\w+_error([0-9])?\(' * | sort | uniq`
+#
+# After getting the list, there are two different types of errors: those who are literal text, and those who include
+# print format args like `%s`, `%d`, `%zu`, etc. We sort them in two groups.
+#
+# The first group is just anything without formatting args. Only text, sorted ascending. Command used:
+#   - `ggrep -E -h -r --exclude="*.phpt" '_error([0-9])?\(' * | awk -F\" '{ print $2;} ' | sed -e 's/ \\$/ "/g' | sort | uniq | grep -v '%'`
+# Small post processing might be done to adjust strings that might cause false positives. Examples are lines too short,
+# or very common Enlgish sencentes (e.g. `Can use`, `Attribute`, etc.). There also text coming from php unit/regression
+# tests, like 'DROP TABLE IF EXISTS test_bug_71863` that we need to clean.
+#
+# The second group will be the part with format strings. Only text, sorted ascending.
+# This will need a more careful processing. The format string will appear in the text result,
+# but it will (of course) be substituted by some variable value. So we need to clean more text here.
+# The easiest way is to split in lines when a format string is found. This will shorten the texts, but
+# then we can sort who are the ones more fit for being in this file.
+# We also remove:
+# - text with just one word (too easy for FP), or one word, one space (optional) and one non-word (optional).
+#   this will match things like `Collect "`, `Method` or `Class `.
+#
+# Command used:
+#   - `ggrep -E -h -r --exclude="*.phpt" '_error([0-9])?\(' * | awk -F\" '/%/ { print $2;} ' | sed -e 's/ \\$/ "/g' -e 's/%[zlp][ud]/\n/g' -e 's/%[a-z]/\n/g'  -e 's/%\.\*s/\n/g' | sort | uniq | ggrep -E -v '^\w+\s?\W?$' | ggrep -E -v '^\W+$'
+#
+# Anything that is too short, or nonsense, we remove.
+
+# Group without format strings
+
+API is restricted by "
+can't be temporary enabled (it may be only disabled till the end of request)
+has not been properly started, can't compile file
+is not a valid backing value for enum "
+64-bit format codes are not available for 32-bit versions of PHP
+: module registration failed!
+: opcache.huge_code_pages has no affect as huge page is not supported
+A 'day of year' can only come after a year has been found
+A PHP Object cannot be converted to a XPath-string
+A four digit ISO year could not be found
+A four digit year could not be found
+A meridian could not be found
+A non-numeric value encountered
+A single digit day of week could not be found
+A six digit microsecond could not be found
+A textual day could not be found
+A textual month could not be found
+A thread value other than 1 is not supported by this implementation
+A three digit day-of-year could not be found
+A three digit millisecond could not be found
+A two digit ISO week could not be found
+A two digit day could not be found
+A two digit hour could not be found
+A two digit minute could not be found
+A two digit month could not be found
+A two digit second could not be found
+A two digit year could not be found
+Access violation (Segmentation fault) encountered\ntrying to abort cleanly...
+Address buffer overflow
+An error occurred while invoking the authorizer callback
 An iterator cannot be used with foreach by reference
+Apache is running a threaded MPM, but your PHP Module is not compiled to be threadsafe.  You need to recompile PHP.
+Array and string offset access syntax with curly braces is no longer supported
 Array callback has to contain indices 0 and 1
-Arrived at end of main loop which shouldn't happen
-Attempt to destruct pending exception
-Attempt to unset static property
-Balloc() allocation exceeds list boundary
-Balloc() failed to allocate memory
-Base lambda function for closure not found
-Call to a member function
-Call to private
-Call to protected
-Call to undefined function
-Call to undefined method
+Array callback must have exactly two elements
+Array of functions is not allowed
+Array of incomplete type is not allowed
+Array of object IDs cannot be empty
+Array of values must be an associative array with string keys
+Array of void type is not allowed
+Array sizes are inconsistent
+Array to string conversion
+Attempt to assign an invalid callback, insufficient number of arguments
+Attempt to assign element of non C array
+Attempt to assign property of non-object
+Attempt to assign read-only location
+Attempt to call non C function pointer
+Attempt to cast owned C pointer
+Attempt to count() on non C array
+Attempt to iterate on non C array
+Attempt to perform assign of owned C pointer
+Attempt to perform assign pointer to owned C data
+Attempt to read element of non C array
+Attempt to read over data boundary
+Attempt to read over string boundary
+Attempt to read property "
+Attempt to write over data boundary
+Attempting to set reference to non referenceable value
+Attempting to use non-attribute class "
+Attribute class "
+Automatic conversion of false to array is deprecated
+Backup failed: source database is busy
+Backup failed: source database is locked
+Bad GD2 header
+Bad scan conversion character "
+Bad unserialize data
+Bit field "
+Breakpoint exists at #
+Breakpoint exists for opline #
+C array index out of bounds
+CPU doesn't support SSE2
+CTRL events can only be received on the main thread
+CTRL events trapping is only supported on console
 Can only throw objects
-Cannot access empty property
-Cannot access parent:: when current class scope has no parent
-Cannot access parent:: when no class scope is active
-Cannot access property started with '\\0'
-Cannot access self:: when no class scope is active
-Cannot access static:: when no class scope is active
-Cannot access undefined property for object with overloaded property access
+Can only use PDO::FETCH_FUNC in PDOStatement::fetchAll()
+Can't bind a lob for output
+Can't cache files in chroot() directory with too big inode
+Can't create a temporary mailbox:
+Can't initialize heap
+Can't re-open '$new_mailbox' mailbox:
+Cannot access "
+Cannot access node list without offset
+Cannot access parser properties before loading data
+Cannot access property starting with "
+Cannot add element to the array as the next element is already occupied
+Cannot add newnode as the previous sibling of refnode
+Cannot add next element to object of type FFI\\CData
+Cannot allocate callback
+Cannot append to WeakMap
+Cannot append to an attribute list
+Cannot apply [] to ResourceBundle object
+Cannot assign an empty string to a string offset
+Cannot assign by reference to an array dimension of an object
 Cannot assign by reference to overloaded object
-Cannot break/continue %d level%s
-Cannot call abstract method
+Cannot bind an instance to a static closure
+Cannot call callback
 Cannot call constructor
+Cannot call default session handler
 Cannot call forward_static_call() when no class scope is active
-Cannot call non static method
-Cannot call overloaded function for non-object
-Cannot call private
-Cannot create references to/from string offsets
-Cannot create references to/from string offsets nor overloaded objects
-Cannot declare self-referencing constant
-Cannot destroy active lambda function
-Cannot get arguments for
-Cannot increment/decrement overloaded objects nor string offsets
-Cannot instantiate abstract class
-Cannot instantiate interface
-Cannot instantiate trait
-Cannot override final
-Cannot pass parameter
-Cannot redeclare
-Cannot redeclare class
+Cannot change opcache.jit setting at run-time (JIT is disabled)
+Cannot check dimension on a COM object
+Cannot compare DateInterval objects
+Cannot connect to HTTPS server through proxy
+Cannot connect to IMAP server
+Cannot connect to IMAP server $server:
+Cannot convert to resource type
+Cannot copy hash
+Cannot create duplicate attribute
+Cannot create unnamed attribute
+Cannot delete dimension from a COM object
+Cannot delete properties from a COM object
+Cannot directly construct AddressInfo, use socket_addrinfo_lookup() instead
+Cannot directly construct CurlHandle, use curl_init() instead
+Cannot directly construct CurlMultiHandle, use curl_multi_init() instead
+Cannot directly construct CurlShareHandle, use curl_share_init() instead
+Cannot directly construct DeflateContext, use deflate_init() instead
+Cannot directly construct FTP\\Connection, use ftp_connect() or ftp_ssl_connect() instead
+Cannot directly construct IMAP\\Connection, use imap_open() instead
+Cannot directly construct InflateContext, use inflate_init() instead
+Cannot directly construct LDAP\\Connection, use ldap_create() instead
+Cannot directly construct LDAP\\Result, use the dedicated functions instead
+Cannot directly construct LDAP\\ResultEntry, use the dedicated functions instead
+Cannot directly construct OpenSSLAsymmetricKey, use openssl_pkey_new() instead
+Cannot directly construct OpenSSLCertificate, use openssl_x509_read() instead
+Cannot directly construct OpenSSLCertificateSigningRequest, use openssl_csr_new() instead
+Cannot directly construct PgSql\\Connection, use pg_connect() or pg_pconnect() instead
+Cannot directly construct PgSql\\Lob, use pg_lo_open() instead
+Cannot directly construct PgSql\\Result, use a dedicated function instead
+Cannot directly construct Shmop, use shmop_open() instead
+Cannot directly construct Socket, use socket_create() instead
+Cannot directly construct SysvMessageQueue, use msg_get_queue() instead
+Cannot directly construct SysvSemaphore, use sem_get() instead
+Cannot directly construct SysvSharedMemory, use shm_attach() instead
+Cannot directly construct XMLParser, use xml_parser_create() or xml_parser_create_ns() instead
+Cannot directly construct mysqli_warning
+Cannot end an oplog without starting it
+Cannot fetch SoapServer object
+Cannot fetch all data from the symbol table, invalid data source
+Cannot fetch all the constants, invalid data source
+Cannot fetch information from a fiber that has not been started or is terminated
+Cannot fetch the callable from a fiber that has terminated
+Cannot fit all OIDs for SET query into one packet, using multiple queries
+Cannot free EnchantBroker object with open EnchantDictionary objects
+Cannot instantiate FFI\\CData of zero size
+Cannot instantiate user-supplied statement class
+Cannot leak variable that is not refcounted
+Cannot load module "
+Cannot lock mutex
+Cannot manually construct InternalIterator
+Cannot modify header information - headers already sent
+Cannot open "
+Cannot prepare callback
+Cannot prepare callback CIF
+Cannot re-assign $this
+Cannot read property
+Cannot rebind scope of closure created from function
+Cannot rebind scope of closure created from method
 Cannot register a reverse output handler conflict outside of MINIT
 Cannot register an output handler alias outside of MINIT
 Cannot register an output handler conflict outside of MINIT
+Cannot resume a fiber that is not suspended
 Cannot resume an already running generator
-Cannot return string offsets by reference
-Cannot set non exception as previous exception
+Cannot start a fiber that has already been started
+Cannot start a fiber that is the target of another fiber
+Cannot suspend in a force-closed fiber
+Cannot suspend outside of a fiber
+Cannot switch fibers in current execution context
+Cannot throw objects that do not implement Throwable
+Cannot unbind $this of closure using $this
+Cannot unbind $this of method
+Cannot unset $this
+Cannot unset PDORow offset
+Cannot unset PDORow property
+Cannot unset offset in a non-array variable
 Cannot unset string offsets
+Cannot use 'readonly' as method modifier
 Cannot use [] for reading
-Cannot use assign-op operators with overloaded objects nor string offsets
+Cannot use [] on objects in constant expression
+Cannot use a scalar value as an array
+Cannot use empty array elements in arrays
+Cannot use list() as standalone expression
 Cannot use object as array
-Cannot use object of type
-Cannot use string offset as an array
-Cannot use string offset as an object
+Cannot use temporary expression in write context
+Cannot write to PDORow offset
+Cannot write to PDORow property
+Cannot write to read-only property
 Cannot yield from finally in a force-closed generator
-Cannot yield string offsets by reference
-Class entry requested for an object without PHP class
+Case folding mode must be one of the PDO::CASE_* constants
 Class name must be a valid object or a string
-Corrupted fcall_info provided to zend_call_function()
-DCOM has been disabled by your administrator [com.allow_dcom=0]
+Collator class not defined
+Column index must be greater than or equal to 0
+Comparison of incompatible C types
+Corrupt member variable name
+Could not allocate parser
+Could not copy from temporary stream - ini file truncated
+Could not create WBMP
+Could not create gdImage
+Could not fetch data, invalid data source
+Could not fetch file name, invalid data source, aborting included file listing
+Could not fetch included file count, invalid data source
+Could not find information about included file...
+Could not get x-size
+Could not get y-size
+Could not read color palette
+Could not save WBMP
+Couldn't fetch backtrace, invalid data source
+Couldn't switch frames, invalid data source
+Data must be loaded before expanding
+Data must be loaded before reading
 DateFormat class not defined
+DatePeriod has not been initialized correctly
+DatePeriod::__construct() accepts (DateTimeInterface, DateInterval, int [, int]), or (DateTimeInterface, DateInterval, DateTime [, int]), or (string [, int]) as arguments
 DateTimeInterface can't be implemented by user classes
-EXTREMELY fatal error: jmpbuf unrecoverable; terminating
-EXTREMELY fatal error: jmpbuf unrecoverable; terminating.
-EXTREMELY fatal error: longjmp returned control; terminating
+Day of week must be between 1 and 7
+Different numbers of variable names and field specifiers
+Direct instantiation of WeakReference is not allowed, use WeakReference::create instead
+Directive oci8.old_oci_close_semantics is deprecated
+Directory object is already initialized
+Division by zero
+Double date specification
+Double time specification
+Double timezone specification
+Duplicate field name "
+During class fetch
+EOF before image was complete
+Empty string
+Empty string as an extension
+Encoding mode must be ZLIB_ENCODING_RAW, ZLIB_ENCODING_GZIP or ZLIB_ENCODING_DEFLATE
 Encoding: '*' may only be first arraySize value in list
-Encoding: Attribute
 Encoding: Can't decode apache map, missing key
 Encoding: Can't decode apache map, missing value
-Encoding: Can't decode apache map, only Strings or Longs are allowd as keys
+Encoding: Can't decode apache map, only Strings or Longs are allowed as keys
 Encoding: Cannot find encoding
-Encoding: Element
 Encoding: Error calling from_xml callback
 Encoding: Error calling to_xml callback
-Encoding: External reference
 Encoding: Internal Error
 Encoding: Invalid timestamp
+Encoding: Restriction: invalid enumeration value "
+Encoding: Restriction: length greater than 'maxLength'
+Encoding: Restriction: length is not equal to 'length'
+Encoding: Restriction: length less than 'minLength'
 Encoding: SoapVar has no 'enc_type' property
-Encoding: Unresolved reference
 Encoding: Violation of encoding rules
-Encoding: Violation of id and ref information items
-Encoding: object has no '
 Encoding: object has no 'any' property
-Encoding: string '
-Error installing signal handler for
-Exception thrown without a stack frame
-Exceptions must be valid objects derived from the Exception base class
+Enumerator value "
+Epoch doesn't fit in a PHP integer
+Error casting object to string in collator_convert_object_to_string()
+Error converting utf16 to utf8 in collator_convert_zval_utf16_to_utf8()
+Error from compressing
+Error mode must be one of the PDO::ERRMODE_* constants
+Error reading comproessed chunk
+Escaped character expected
+Execution context not set!
+Expected array for frame
+FFI API is restricted by "
+FFI internal error. Unsupported parameter type
+FFI internal error. Unsupported return type
+FFI passing array is not implemented
+FFI passing struct/union is not implemented
+FFI return array is not implemented
+FFI return struct/union is not implemented
+FFI::load() doesn't work in conjunction with "
+FFI\\CData
+FFI\\CData or FFI\\CType
+FFI\\CData or string
+FFI\\CType is not a function
+FFI\\CType is not a pointer
+FFI\\CType is not a structure
+FFI\\CType is not an array
+FFI\\CType is not an enumeration
+FFI\\Cdata is not a C string
+FFI\\Cdata is not a pointer
+FTP does not support simultaneous read/write connections
+FTP proxy may only be used in read mode
+Fail to read header
 Failed to clone SpoofChecker object
-Failed to register IntlDateFormatter class
-Failed to register MessageFormatter class
-Failed to register NumberFormatter class
-Failed to register ResourceBundle class
-Field width %d is too long
+Failed to create closure from callable
+Failed to find breakpoint #
+Failed to read property due to libxml error
+Fetch mode must be a bitmask of PDO::FETCH_* constants
+File Upload Mime headers garbled
+File name is not a string
+File upload error - unable to create a temporary file
+Filename cannot be empty
 First array member is not a valid class name or object
-Function name must be a string
-Illegal length modifier specified
+Format literal not found
+Found unconstructed BreakIterator
+Found unconstructed IntlCalendar
+Found unconstructed IntlDateFormatter
+Found unconstructed IntlDatePatternGenerator
+Found unconstructed IntlIterator
+Found unconstructed IntlTimeZone
+Found unconstructed MessageFormatter
+Found unconstructed NumberFormatter
+Found unconstructed ResourceBundle
+Found unconstructed Spoofchecker
+Found unconstructed transliterator
+Found unexpected data
+Freeing memory
+GC buffer overflow (GC disabled)\n
+Generated salt too short
+Generator already closed
+Generator currently running
+Generator passed to yield from was aborted without proper return and is unable to continue
+Get commit status
+Glob support is not available
+Got chunk
+HTTP request failed!
+HTTP wrapper does not support writeable connections
+HY000
+HY093
+HY105
+Handler name must be a string
+Header may not contain
+Header may not contain NUL bytes
+Header name "
+Header name cannot be numeric,
+Header to delete may not contain colon.
+Hour cannot be higher than 12
+IM001
+ISO Week must be between 1 and 53
+Ignoring session_start() because a session has already been started
+Illegal member variable name
 Illegal offset type
+Illegal offset type in isset or empty
+Illegal offset type in unset
+Illegal string offset
+Implicit conversion from float-string "
+Impossible to not specify a stdin delimiter without -rr
+Impossible to yield from the Generator being currently run
+Incompatible types when assigning
+Incomplete enum "
+Incomplete struct "
+Incomplete union "
 Input string is too long
+Instantiation of class Closure is not allowed
+Insufficient data for unserializing -
+Internal error: Failed to retrieve the argument's reflection object
+Internal error: Failed to retrieve the reflection object
+Internal help error, non-unique alias "
+Interned string buffer overflow
+IntlCalendar::set() has no variant with exactly 4 parameters
+IntlGregorianCalendar object is already constructed
+IntlRuleBasedBreakIterator object is already constructed
+Invalid OID value passed
 Invalid RelaxNG Validation Context
 Invalid Schema Validation Context
-Invalid opcode
+Invalid XBM
+Invalid XPath Context
+Invalid arguments to print, expected nothing, function name or method name
+Invalid bcrypt cost parameter specified:
+Invalid boundary in multipart/form-data POST data
+Invalid browscap ini file:
+Invalid characters passed for attempted conversion, these have been ignored
+Invalid column index
+Invalid date
+Invalid document encoding
+Invalid finfo object
+Invalid number of threads
+Invalid object handle
+Invalid or uninitialized EnchantBroker object
+Invalid or uninitialized EnchantDictionary object
+Invalid or uninitialized SNMP object
+Invalid or uninitialized XMLWriter object
+Invalid or uninitialized Zip object
+Invalid parameter type for conditional breakpoint
+Invalid run command, cannot put further arguments after stdin
+Invalid run command, unterminated escape sequence
+Invalid scanner mode
 Invalid serialization data for DatePeriod object
 Invalid serialization data for DateTime object
 Invalid serialization data for DateTimeImmutable object
-Maximum execution time of
+Invalid serialization data for DateTimeZone object
+Invalid stream/context parameter
+Invalid timezone offset in minutes
+Iterated value is no longer an array or object
+Iterator does not support rewinding
+Iterator not initialized or already consumed
+JIT is compatible only with CALL and HYBRID VM. JIT disabled.
+JIT is incompatible with third party extensions that override zend_execute_ex(). JIT disabled.
+JIT is incompatible with third party extensions that setup user opcode handlers. JIT disabled.
+Key array must be of the form array(0 => key, 1 => phrase)
+LDAP connection has already been closed
+LDAP result has already been closed
+Length is too large to safely generate
+Line is not an int
+Locale class not defined
+Malformed input
+Maximum number of allowable file uploads has been exceeded
+Memory Manager Disabled!
+Memory allocation failed for IP_ADAPTER_ADDRESSES struct
+Memory cost is outside of allowed memory range
+Meridian can only come after an hour has been found
 Method name must be a string
-Need to supply an object when throwing an exception
-Nesting level too deep - recursive dependency?
+Missing boundary in multipart/form-data POST data
+Missing expected time part
+Missing format specifier at end of string
+Missing padding character
+Missing redirection target
+Mixing of ISO dates with natural dates is not allowed
+Mode must be one of 'r', 'r+', 'w', or 'w+'
+Modification of ArrayObject during sorting is prohibited
+Multi OID walks are not supported!
+NULL pointer dereference
+Nanoseconds was not in the range 0 to 999 999 999 or seconds was negative
+Negative width in bit-field "
+No PostgreSQL connection opened yet
+No URL resource specified
+No active class
+No active op array!
+No active symbol table!
+No execution context
+No execution context set
+No file uploaded
+No function table loaded
+No more entries in hash table!
+No pattern was provided
+No resource supplied
+No security protocol supported
+No session id returned by function
+No set command selected!
+No stream arrays were passed
+No string was provided
+No variant with 4 arguments (excluding trailing NULLs)
+Node from wrong document
+Node must be associated with a document
+Normalizer class not defined
+Not Executing!
+Not a full path given or extension_dir ini setting is not set
+Not a valid gd2 file
+Not enough data available to satisfy format
+Not enough free shared space to allocate
+Not executing, and execution context not set
+Not supported in multithreaded Web servers
+Nothing to execute!
+Nothing was deleted, no corresponding watchpoint found
+Number is not an integer string
+Number of bind variables doesn't match number of fields in prepared statement
 NumberFormatter class not defined
-Object does not support method calls
-Only variables can be passed by reference
-PDO: driver
+NumberFormatter object is already constructed
+OCIAttrGet: OCI_ATTR_CALL_TIMEOUT
+OCIAttrSet: OCI_ATTR_ACTION
+OCIAttrSet: OCI_ATTR_CALL_TIMEOUT
+OCIAttrSet: OCI_ATTR_CLIENT_IDENTIFIER
+OCIAttrSet: OCI_ATTR_CLIENT_INFO
+OCIAttrSet: OCI_ATTR_MODULE
+OCIAttrSet: OCI_ATTR_PASSWORD
+OCIAttrSet: OCI_ATTR_SERVER
+OCIAttrSet: OCI_ATTR_SESSION
+OCIAttrSet: OCI_ATTR_USERNAME
+OCIEnvNlsCreate: Check the character set is valid and that PHP has access to Oracle libraries and NLS data
+OCIHandleAlloc: OCI_HTYPE_SESSION
+OCIHandleAlloc: OCI_HTYPE_SVCCTX
+OCINlsCharSetNameToId: unknown character set name
+OCINlsNumericInfoGet: OCI_NLS_CHARSET_MAXBYTESZ
+OCIServerDetach
+OCISessionBegin
+OCIStmtExecute
+OCIStmtFetch
+OCIStmtPrepare
+OCITransCommit
+OCITransRollback
+OCI_NEED_DATA
+Object is not initialized
+Object not initialized
+One parameter to a memory allocation multiplication is negative or zero, failing operation gracefully\n
+Only 'cdata' property may be read
+Only 'cdata' property may be set
+Only arrays and Traversables can be unpacked
+Only classes can be marked with #[ZendTestAttribute]
+Only the first byte will be assigned to the string offset
+Only the leftmost array can be undimensioned
+Only variable references should be returned by reference
+Only variable references should be yielded by reference
+Only variables should be assigned by reference
+Only variables should be passed by reference
+Options should have the form ["
+Out of memory
+Overflow in enumeration values "
+PDO object is not initialized, constructor was not called
+PDO object is uninitialized
+PDO::ATTR_STATEMENT_CLASS class must be a valid class
+PDO::ATTR_STATEMENT_CLASS class must be derived from PDOStatement
+PDO::ATTR_STATEMENT_CLASS value must be an array with the format
+PDO::FETCH_INTO and PDO::FETCH_CLASS cannot be set as the default fetch mode
+PNG support is not available
+POST Content-Length of
+Pair level
+Paletter image not supported by webp
+Parser must not be called recursively
 Parsing Schema: <restriction> or <extension> expected in complexContent
-Parsing Schema: attribute
 Parsing Schema: attribute has both 'ref' and 'type' attributes
 Parsing Schema: attribute has both 'ref' attribute and subtype
 Parsing Schema: attribute has both 'type' attribute and subtype
 Parsing Schema: attribute has no 'name' nor 'ref' attributes
-Parsing Schema: attributeGroup
 Parsing Schema: attributeGroup has both 'ref' attribute and subattribute
 Parsing Schema: attributeGroup has no 'name' nor 'ref' attributes
-Parsing Schema: can't import schema from
+Parsing Schema: can't import schema. Namespace must not match the enclosing schema 'targetNamespace'
 Parsing Schema: complexType has no 'name' attribute
 Parsing Schema: element has both 'default' and 'fixed' attributes
 Parsing Schema: element has both 'itemType' attribute and subtype
@@ -153,67 +547,1367 @@ Parsing Schema: missing restriction value
 Parsing Schema: redefine has no 'schemaLocation' attribute
 Parsing Schema: restriction has no 'base' attribute
 Parsing Schema: simpleType has no 'name' attribute
-Parsing Schema: unexpected
-Parsing Schema: unresolved element 'ref' attribute
-Parsing Schema: unresolved group 'ref' attribute
-Parsing WSDL: <binding>
 Parsing WSDL: <binding> has no name attribute
-Parsing WSDL: <fault> with name
 Parsing WSDL: <message> has no name attribute
-Parsing WSDL: <portType>
 Parsing WSDL: <portType> has no name attribute
-Parsing WSDL: <service>
 Parsing WSDL: <service> has no name attribute
 Parsing WSDL: Could not find any usable binding services in WSDL.
 Parsing WSDL: Couldn't bind to service
-Parsing WSDL: Couldn't find <definitions> in
-Parsing WSDL: Couldn't load from
 Parsing WSDL: Missing 'name' attribute for <binding>
 Parsing WSDL: Missing 'name' attribute for <operation>
 Parsing WSDL: Missing 'type' attribute for <binding>
-Parsing WSDL: Missing <message> with name
-Parsing WSDL: Missing <portType> with name
-Parsing WSDL: Missing <portType>/<operation> with name
 Parsing WSDL: Missing message attribute for <header>
-Parsing WSDL: Missing name for <fault> of
-Parsing WSDL: Missing name for <input> of
-Parsing WSDL: Missing name for <output> of
-Parsing WSDL: Missing part '%s' in <message>
 Parsing WSDL: Missing part attribute for <header>
-Parsing WSDL: No <binding> element with name
 Parsing WSDL: No address associated with <port>
 Parsing WSDL: No binding associated with <port>
 Parsing WSDL: No location associated with <port>
-Parsing WSDL: No name associated with <part>
-Parsing WSDL: The fault message
+Parsing WSDL: Unspecified encodingStyle
+Password hashing failed for unknown reason
+Password is too long
+Path cannot be empty
+Path to document must not contain any null bytes
+PostgreSQL connection has already been closed
+PostgreSQL large object has already been closed
+PostgreSQL result has already been closed
+Precision must be an integer
+Preloading doesn't work in "
+Preloading failed to initgroups(\
+Preloading is incompatible with first-exec and profile triggered JIT
+Private methods cannot be final as they are never overridden by other classes
+Product of memory allocation multiplication would exceed INT_MAX, failing operation gracefully\n
+Property access is not allowed yet
+Property queryString is read only
+Putting buf...
+Putting int...
+Putting word...
+Read Error: truncated data
+Read-only segment cannot be written
+Reading file
+Reading gd2 header info
+Recursion detected
+Redeclaration of "
+Redefinition of "
+Redirection limit reached, aborting
+Registered tick function cannot be unregistered while it is being executed
+Remote file already exists and overwrite context option not specified
+ResourceBundle does not support writable iterators
+ResourceBundle object is already constructed
+Restarting!
+Returning by reference from a void function is deprecated
+SNMP output print format must be an SNMP_OID_OUTPUT_* constant
+SNMP retrieval method must be a bitmask of SNMP_VALUE_LIBRARY, SNMP_VALUE_PLAIN, and SNMP_VALUE_OBJECT
+SNMP::$max_oids must be greater than 0 or null
+SOAP-ERROR:
+SQLAllocHandle (DBC)
+SQLAllocHandle: STMT
+SQLAllocStmt
+SQLBindCol
+SQLBindParameter
+SQLColAttribute
+SQLColumnPrivileges
+SQLColumns
+SQLConnect
+SQLDataSources
+SQLDescribeCol
+SQLDescribeParameter
+SQLDriverConnect
+SQLEndTran: Commit
+SQLEndTran: Rollback
+SQLExecDirect
+SQLExecute
+SQLFetchScroll
+SQLForeignKeys
+SQLFreeStmt
+SQLGetCursorName
+SQLGetData
+SQLGetTypeInfo
+SQLMoreResults
+SQLPrepare
+SQLPrimaryKeys
+SQLProcedureColumns
+SQLProcedures
+SQLRowCount
+SQLSetConnectAttr AUTOCOMMIT
+SQLSetConnectAttr AUTOCOMMIT = OFF
+SQLSetConnectAttr AUTOCOMMIT = ON
+SQLSetConnectAttr SQL_ODBC_CURSORS
+SQLSetConnectOption
+SQLSetCursorName
+SQLSetEnvAttr: ODBC3
+SQLSetEnvAttr: SQL_ATTR_CP_MATCH
+SQLSetStmtAttr: SQL_ATTR_CURSOR_SCROLLABLE
+SQLSpecialColumns
+SQLStatistics
+SQLTablePrivileges
+SQLTables
+SQLTransact
+SQLite Extension are disabled
+SSL: failed invoking reneg limit notification callback
+SSL: failed loading CA names from cafile
+Schema must be set prior to reading
+Second array member is not a valid method
+Security level must be one of "
+Security protocol must be "
+Security protocol must be one of "
+Seeking...
+Server doesn't support FTPS.
+Session id must be a string
+Session is not active
+Set autocommit
+SetConnectOption
+SetStmtOption
+Shared memory block has already been destroyed
+SimpleXMLElement is not properly initialized
+SoapHeader::__construct(): "
+SoapServer::addFunction(): Function "
+SoapServer::addSoapHeader() may be called only during SOAP request processing
+SoapServer::setPersistence(): Persistence cannot be set when the SOAP server is used in function mode
+Some opcache.jit_debug bits cannot be changed after startup
+Spoofchecker class not defined
+String offset cast occurred
+String size overflow
+TCP/IP option is not available for error logging
+Telling...
+The (unset) cast is no longer supported
+The DateTime object has not been correctly initialized by its constructor
+The InternalIterator object has not been properly initialized
+The additional headers cannot contain the "
+The authorizer callback returned an invalid type: expected int
+The authorizer callback returned an invalid value
+The command "
+The driver_version property is deprecated
+The escaped character could not be found
+The filter.default ini setting is deprecated
+The first parameter in session.save_path is invalid
+The first parameter makes no sense !
+The format separator does not match
+The inner constructor wasn't initialized with an iterator instance
+The number of elements in the type definition string must match the number of bind variables
+The number of variables must match the number of parameters in the prepared statement
+The object is in an invalid state as the parent constructor was not called
+The parent constructor was not called: the object is in an invalid state
+The passed argument was not a stack !
+The second parameter in session.save_path is invalid
+The separation symbol ([;:/.,-]) could not be found
+The separation symbol could not be found
+The stack contains nothing !
+The timezone could not be found in the database
+This shared object is nor a Zend extension nor a module
+Throwing from FFI callbacks is not allowed
+Time cost is outside of allowed time range
+Timezone database is corrupt. Please file a bug report as this should never happen
+Timezone initialization failed
+Too many arguments
+Trailing data
+Trait "
+Transliterator class not defined
+Transliterator::$id is read-only
+Trying to compare uninitialized DateTimeZone objects
+Type float/double is not allowed at position
+Type must be a single character
+Type must be of type string when object ID is a string
+Unable to activate SSL mode
+Unable to bind parameter number
+Unable to call custom replacement function
+Unable to cast node to string
+Unable to find my handle property
+Unable to generate salt
+Unable to initialize the input buffer
+Unable to open extensions outside the defined directory
+Unable to resume from offset
+Unconstructed Transliterator object cannot be cloned
+Undefined C type "
+Undefined array key
+Undefined array key "
+Undefined constant "
+Undefined period specifier
+Undefined variable $this
+Unexpected character
+Unexpected data found.
+Unexpected failure hashing password
+Uninitialized string offset
+Unknown SOAP version
+Unknown and uncaught modification type.
+Unknown file open mode
+Unknown format specifier "
+Unknown reason
+Unmatched [ in format string
+Unsupported "
+Unsupported argument type
+Unsupported attribute "
+Unsupported attribute type
+Unsupported constant expression
+Unsupported operand types
+Use after free()
+User-supplied function must be a valid callback
+User-supplied statement class cannot have a public constructor
+User-supplied statement does not accept constructor arguments
+Using $this when not in object context
+Using ${expr} (variable variables) in strings is deprecated, use {${expr}} instead
+Using ${var} in strings is deprecated, use {$var} instead
+Using raw format data
+Value must be of type string when object ID is a string
+Variable is not assigned by any conversion specifiers
+Variadic function closures are not supported
+VirtualAlloc() failed
+VirtualFree() failed
+WeakMap key must be an object
+WebP decode: realloc failed
+Width must be an integer
+Writing index
+Wrong argument number
+Wrong field name
+Wrong type of bit field "
+XMLReader::expand() requires the DOM extension to be enabled
+XPath query did not return a nodeset
+Year out of range (0-9999)
+You MUST load PDO before loading any PDO drivers
+You cannot initialize a GdFont object except through helper functions
+You cannot initialize a GdImage object except through helper functions
+You cannot initialize a PSpell\\Config object except through helper functions
+You cannot initialize a PSpell\\Dictionary object except through helper functions
+You should not create a tidyNode manually
+Zero width in bit-field "
+[] operator not supported for SplFixedArray
+[] operator not supported for strings
+__clone method called on non-object
+and argument #2 ($string_2) must have the same length
+and argument #2 ($values) must have the same number of elements
+args element is not an array
+attempt to cast to larger type
+attempt to read over data boundary
+attempt to read over string boundary
+attempt to use a closed file
+attempt to write over data boundary
+auto_detect_line_endings is deprecated
+avif error - Could not allocate memory
+avif error - Could not create GD truecolor image
+avif error - avif doesn't support palette images
+avif error - couldn't allocate memory
+avif error - image dimensions are too large
+avif error - image dimensions must not be zero
+bad type specifier while parsing parameters
+c-client imap_getacl failed
+call a method
+can't allocate continuation
+can't re-open '$new_mailbox' mailbox:
+cannot be 0 for the POSIX_S_IFCHR and POSIX_S_IFBLK modes
+cannot be PDO::FETCH_LAZY in PDOStatement::fetchAll()
+cannot be a class constant
+cannot be a recursive array
+cannot be an array when working on a single string
+cannot be empty
+cannot be empty when HMAC is requested
+cannot be null for non-static methods
+cannot be null for the chosen cipher algorithm
+cannot be null when argument #1 ($objectOrMethod) is an object
+cannot be null when argument #2 ($name) is a string
+cannot be null when argument #2 ($wrapper_or_options) is a string
+cannot be null when argument #3 ($atime) is an integer
+cannot be null when the socket type is AF_INET
+cannot be null when the socket type is AF_INET6
+cannot be provided when argument #2 ($wrapper_or_options) is an array
+cannot be true when argument #2 ($width) is 0
+cannot change a protected metatable
+cannot combine mode "
+cannot contain empty keys
+cannot create tempnam
+cannot have a fractional part
+cannot use multiple endian options
+cannot use multiple word order options
+connect.inc: Failed to connect as '$user' to '$dbase':
+contains a closed socket
+contains an invalid cURL option
+contains invalid encoding "
+corrupt magic file
+could not dup descriptor for temp file
+could not find any valid magic files!
+could not obtain parameters for parsing
+declare(encoding=...) ignored because
+define(): Argument #3 ($case_insensitive) is ignored since declaration of case-insensitive constants is no longer supported
+deflate_init(): "
+empty password
+error converting input string
+error copying from pipe to temp file
+error reading
+error seeking
+error while writing to temp file
+failed setting compression level
+failed to invoke callback
+file is already closed
+file_override_enabled has no effect when file_cache_only is set
+first character must be one of "
+free() non a C pointer
+func_get_arg() cannot be called from the global scope
+func_get_args() cannot be called from the global scope
+func_num_args() must be called from a function context
+gd-jpeg error: cannot allocate gdImage struct
+gd-jpeg: error: jpeg library was compiled for 12-bit precision. This is mostly useless, because JPEGs on the web are 8-bit and such versions of the jpeg library won't read or write them. GD doesn't support these unusual images. Edit your jmorecfg.h file to specify the correct precision and completely 'make clean' and 'make install' libjpeg again. Sorry
+gd-jpeg: error: jpeg library was compiled for 12-bit precision. This is mostly useless, because JPEGs on the web are 8-bit and such versions of the jpeg library won't read or write them. GD doesn't support these unusual images. Edit your jmorecfg.h file to specify the correct precision and completely 'make clean' and 'make install' libjpeg again. Sorry.
+gd-jpeg: warning: jpeg_finish_decompress reports suspended data source
+gd-jpeg: warning: jpeg_start_decompress reports suspended data source
+gd-png error: cannot allocate gdImage struct
+gd-png error: cannot allocate gray palette
+gd-png error: cannot allocate libpng info struct
+gd-png error: cannot allocate libpng main struct
+gd-png error: compression level must be 0 through 9
+gd-png error: no colors in palette
+gd-png error: setjmp returns error condition
+gd-tga: premature end of image data\n
+gd-webp cannot allocate temporary buffer
+gd-webp cannot get webp info
+gd-webp encoding failed
+gd2 header complete
+gd2: EOF while reading\n
+get_called_class() must be called from within a class
+get_class() without arguments must be called from within a class
+has already been closed
+individual body cannot be empty
+infinite recursion prevented
+input LOB is no longer a stream
+invalid capture index
+invalid format (repeated flags)
+invalid format (width or precision too long)
+invalid option
+invalid order function for sorting
+invalid pattern capture
+is an invalid DocumentType object
+is an invalid configuration option, "
+is an invalid offset
+is not a supported source encoding
+is not a supported target encoding
+is not a valid cURL multi option
+is not a valid cURL option
+is not a valid cURL share option
+is not a valid codepoint
+is not a valid encoding
+is not a valid fault code
+is not a valid node type
+is not an integer string
+is required when using this extract type
+is uninitialized
+iterable type is now a compile time alias for array|Traversable,
+jday must be between 2440588 and
+malformed pattern (ends with
+malformed pattern (missing
+mb_chr() does not support the "
+mb_ord() does not support the "
+mb_strpos(): Unknown error
+must be 0 or 1 for attribute MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH
+must be 1 for SQLSetConnectOption(), or 2 for SQLSetStmtOption()
+must be CL_EXPUNGE or 0
+must be CP_UID or 0
+must be FORK_NOSIGCHLD or FORK_WAITPID
+must be FT_UID or 0
+must be Palette
+must be RegexIterator::MATCH, RegexIterator::GET_MATCH,
+must be SOAP_FUNCTIONS_ALL when an integer is passed
+must be SODIUM_CRYPTO_AEAD_AES256GCM_KEYBYTES bytes long
+must be SODIUM_CRYPTO_AEAD_AES256GCM_NPUBBYTES bytes long
+must be SODIUM_CRYPTO_AEAD_CHACHA20POLY1305_IETF_KEYBYTES bytes long
+must be SODIUM_CRYPTO_AEAD_CHACHA20POLY1305_IETF_NPUBBYTES bytes long
+must be SODIUM_CRYPTO_AEAD_CHACHA20POLY1305_KEYBYTES bytes long
+must be SODIUM_CRYPTO_AEAD_CHACHA20POLY1305_NPUBBYTES bytes long
+must be SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES bytes long
+must be SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES bytes long
+must be SODIUM_CRYPTO_AUTH_BYTES bytes long
+must be SODIUM_CRYPTO_AUTH_KEYBYTES bytes long
+must be SODIUM_CRYPTO_BOX_KEYPAIRBYTES bytes long
+must be SODIUM_CRYPTO_BOX_NONCEBYTES bytes long
+must be SODIUM_CRYPTO_BOX_PUBLICKEYBYTES bytes long
+must be SODIUM_CRYPTO_BOX_SECRETKEYBYTES bytes long
+must be SODIUM_CRYPTO_BOX_SEEDBYTES bytes long
+must be SODIUM_CRYPTO_KDF_BYTES_MIN bytes long
+must be SODIUM_CRYPTO_KDF_CONTEXTBYTES bytes long
+must be SODIUM_CRYPTO_KX_KEYPAIRBYTES bytes long
+must be SODIUM_CRYPTO_KX_PUBLICKEYBYTES bytes long
+must be SODIUM_CRYPTO_KX_SEEDBYTES bytes long
+must be SODIUM_CRYPTO_PWHASH_SALTBYTES bytes long
+must be SODIUM_CRYPTO_PWHASH_SCRYPTSALSA208SHA256_SALTBYTES bytes long
+must be SODIUM_CRYPTO_SCALARMULT_SCALARBYTES bytes long
+must be SODIUM_CRYPTO_SECRETBOX_KEYBYTES bytes long
+must be SODIUM_CRYPTO_SECRETBOX_NONCEBYTES bytes long
+must be SODIUM_CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_HEADERBYTES bytes long
+must be SODIUM_CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_KEYBYTES bytes long
+must be SODIUM_CRYPTO_SHORTHASH_KEYBYTES bytes long
+must be SODIUM_CRYPTO_SIGN_BYTES bytes long
+must be SODIUM_CRYPTO_SIGN_KEYPAIRBYTES bytes long
+must be SODIUM_CRYPTO_SIGN_PUBLICKEYBYTES bytes long
+must be SODIUM_CRYPTO_SIGN_SECRETKEYBYTES bytes long
+must be SODIUM_CRYPTO_SIGN_SEEDBYTES bytes long
+must be SODIUM_CRYPTO_STREAM_KEYBYTES bytes long
+must be SODIUM_CRYPTO_STREAM_NONCEBYTES bytes long
+must be SODIUM_CRYPTO_STREAM_XCHACHA20_KEYBYTES bytes long
+must be SODIUM_CRYPTO_STREAM_XCHACHA20_NONCEBYTES bytes long
+must be STR_PAD_LEFT, STR_PAD_RIGHT, or STR_PAD_BOTH
+must be ST_UID or 0
+must be TrueColor
+must be a 3x3 array
+must be a DNS_* constant
+must be a NumberFormatter::TYPE_* constant
+must be a PHP_XML_OPTION_* constant
+must be a PREG_* constant
+must be a RecursiveTreeIterator::PREFIX_* constant
+must be a UConverter::REASON_* constant
+must be a a valid normalization form
+must be a bitmask of CP_UID, and CP_MOVE
+must be a bitmask of FT_UID, FT_PEEK, and FT_INTERNAL
+must be a bitmask of FT_UID, FT_PREFETCHTEXT, and FT_INTERNAL
+must be a bitmask of IMAP_GC_TEXTS, IMAP_GC_ELT, and IMAP_GC_ENV
+must be a bitmask of OP_READONLY, OP_ANONYMOUS, OP_HALFOPEN,
+must be a bitmask of PDO::FETCH_* constants
+must be a bitmask of SA_* constants
+must be a bitmask of SE_FREE, and SE_UID
+must be a bitmask of SE_UID, and SE_NOPREFETCH
+must be a bitmask of SNMP_VALUE_LIBRARY, SNMP_VALUE_PLAIN, and SNMP_VALUE_OBJECT
+must be a bitmask of the OP_* constants, and CL_EXPUNGE
+must be a bz2 stream
+must be a callable, null given
+must be a combination of CLONE_* flags
+must be a cryptographic hashing algorithm if HMAC is requested
+must be a greater than 0
+must be a greater than or equal to 0
+must be a list array
+must be a multiple of argument #2 ($word_size)
+must be a non-empty string
+must be a reference to a state
+must be a single character
+must be a two-letter ISO 3166-1 compatible country code
+must be a user-defined class name, internal class name given
+must be a valid DNS record type
+must be a valid Directory resource
+must be a valid Hash Context resource
+must be a valid SNMP protocol version
+must be a valid URL component identifier,
+must be a valid XML attribute
+must be a valid XML node
+must be a valid access mode
+must be a valid array offset type
+must be a valid attribute filter flag
+must be a valid base64 string
+must be a valid base64 variant identifier
+must be a valid bit mask of PGSQL_CONV_FORCE_NULL, PGSQL_DML_NO_CONV,
+must be a valid bit mask of PGSQL_CONV_IGNORE_DEFAULT,
+must be a valid calendar ID
+must be a valid callback, function "
+must be a valid charset
+must be a valid class
+must be a valid codepage
+must be a valid comparison operator
+must be a valid cryptographic hashing algorithm
+must be a valid data source URI
+must be a valid data source name
+must be a valid data source name (via URI)
+must be a valid element type
+must be a valid encoding, "
+must be a valid extract type
+must be a valid flag value
+must be a valid format value
+must be a valid function name, function "
+must be a valid hashing algorithm
+must be a valid hexadecimal string
+must be a valid identifier
+must be a valid language, "
+must be a valid method name
+must be a valid mode
+must be a valid parser property
+must be a valid password hashing algorithm
+must be a valid resource type
+must be a valid sort flag
+must be a valid stream/context
+must be a valid type
+must be an ASSERT_* constant
+must be an INPUT_* constant
+must be an OPENSSL_ENCODING_* constant
+must be an SNMP_OID_OUTPUT_* constant
+must be an array or a sort flag
+must be an array or a sort flag that has not already been specified
+must be an integer indexed array
+must be an object that has a "
+must be at least as long as the block size
+must be at most 3 characters
+must be at most SODIUM_CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_MESSAGEBYTES_MAX bytes long
+must be between -1 and 255
+must be between -1 and 9
+must be between 0 and 255
+must be between 0 and the segment size
+must be between 1 and 32
+must be between 1 and 4 (inclusive)
+must be between 1 and 65535
+must be between 1 and 65535 when argument #5 ($raw) is true
+must be between 1 and 7
+must be between 1 and the number of elements in argument #1 ($array)
+must be between 1970 and 2037 (inclusive)
+must be between 2 and 36 (inclusive)
+must be contained in argument #1 ($haystack)
+must be contained in argument #1 ($main_str)
+must be contained in argument #2 ($data)
+must be either COUNT_NORMAL or COUNT_RECURSIVE
+must be either FTP_ASCII or FTP_BINARY
+must be either IntlCalendar::WALLTIME_FIRST or
+must be either Locale::ACTUAL_LOCALE or Locale::VALID_LOCALE
+must be either MYSQLI_STORE_RESULT or MYSQLI_USE_RESULT
+must be either MYSQLI_USE_RESULT or MYSQLI_STORE_RESULT with MYSQLI_ASYNC as an optional bitmask flag
+must be either PGSQL_STATUS_LONG or PGSQL_STATUS_STRING
+must be either SIG_DFL or SIG_IGN when an integer value is given
+must be either SQL_FETCH_FIRST or SQL_FETCH_NEXT
+must be either Transliterator::FORWARD or Transliterator::REVERSE
+must be either "
+must be empty or a single character
+must be greater or equal than 0
+must be greater than 0
+must be greater than 0 for attribute MYSQLI_STMT_ATTR_PREFETCH_ROWS
+must be greater than 0 for the FTP_TIMEOUT_SEC option
+must be greater than 0 for the "
+must be greater than or equal to -1
+must be greater than or equal to 0
+must be greater than or equal to 0 when using the threshold mode
+must be greater than or equal to 1
+must be greater than or equal to 3
+must be greater than or equal to SODIUM_CRYPTO_KDF_BYTES_MIN
+must be greater than or equal to argument #1 ($min)
+must be in the range of 0-255
+must be integer-indexed
+must be less than 65535 bytes
+must be less than argument #2 ($maximum)
+must be less than or equal to 1048576
+must be less than or equal to INT_MAX - 4 bytes
+must be less than or equal to SODIUM_CRYPTO_KDF_BYTES_MAX
+must be less than or equal to argument #2 ($max)
+must be less than or equal to the length of argument #2 ($buf)
+must be less than the number of fields for this result set
+must be less than the number of the arguments passed to the currently executed function
+must be longer than 2 characters
+must be null for a tar- or zip-based phar stub, string given
+must be null when argument #1 ($lifetime_or_options) is an array
+must be null when argument #2 ($name) is an array
+must be null when argument #2 ($wrapper_or_options) is an array
+must be null when argument #4 ($seconds) is null
+must be odd if argument #1 ($a) is negative
+must be of type PgSql\\Connection when the connection is provided
+must be of type array when argument #2 ($replacement) is an array, string given
+must be of type array when using translate or scale
+must be of type array, string given
+must be of type string when argument #1 ($ldap) is an LDAP instance
+must be of type string, array given
+must be of type string|int|float|bool|null
+must be one of AF_UNIX, AF_INET, or AF_INET6
+must be one of AF_UNIX, AF_INET6, or AF_INET
+must be one of E_USER_ERROR, E_USER_WARNING, E_USER_NOTICE,
+must be one of FTP_TIMEOUT_SEC, FTP_AUTOSEEK, or FTP_USEPASVADDRESS
+must be one of GMP_ROUND_ZERO, GMP_ROUND_PLUSINF, or GMP_ROUND_MINUSINF
+must be one of GRAPHEME_EXTR_COUNT, GRAPHEME_EXTR_MAXBYTES, or GRAPHEME_EXTR_MAXCHARS
+must be one of IMG_FLIP_VERTICAL, IMG_FLIP_HORIZONTAL, or IMG_FLIP_BOTH
+must be one of IntlCalendar::WALLTIME_FIRST,
+must be one of IntlPartsIterator::KEY_SEQUENTIAL,
+must be one of LOCK_SH, LOCK_EX, or LOCK_UN
+must be one of MYSQLI_NUM, MYSQLI_ASSOC, or MYSQLI_BOTH
+must be one of PDO::FETCH_BOTH, PDO::FETCH_ASSOC, or PDO::FETCH_NUM
+must be one of PGSQL_ASSOC, PGSQL_NUM, or PGSQL_BOTH
+must be one of PGSQL_NOTICE_LAST, PGSQL_NOTICE_ALL, or PGSQL_NOTICE_CLEAR
+must be one of PGSQL_SEEK_SET, PGSQL_SEEK_CUR, or PGSQL_SEEK_END
+must be one of PHPDBG_COLOR_PROMPT, PHPDBG_COLOR_NOTICE, or PHPDBG_COLOR_ERROR
+must be one of PRIO_PGRP, PRIO_USER, or PRIO_PROCESS
+must be one of SOAP_ACTOR_NEXT, SOAP_ACTOR_NONE, or SOAP_ACTOR_UNLIMATERECEIVER
+must be one of SOCK_STREAM, SOCK_DGRAM, SOCK_SEQPACKET,
+must be one of SQL_CUR_USE_IF_NEEDED,
+must be one of STREAM_SHUT_RD, STREAM_SHUT_WR, or STREAM_SHUT_RDWR
+must be one of SUNFUNCS_RET_TIMESTAMP, SUNFUNCS_RET_STRING, or SUNFUNCS_RET_DOUBLE
+must be one of Spoofchecker::ASCII, Spoofchecker::SINGLE_SCRIPT_RESTRICTIVE,
+must be one of ZLIB_ENCODING_RAW, ZLIB_ENCODING_GZIP, or ZLIB_ENCODING_DEFLATE
+must be one of ZLIB_NO_FLUSH, ZLIB_PARTIAL_FLUSH, ZLIB_SYNC_FLUSH, ZLIB_FULL_FLUSH, ZLIB_BLOCK, or ZLIB_FINISH
+must be one of the MB_CASE_* constants
+must be one of the MYSQLI_CURSOR_TYPE_* constants
+must be one of the MYSQLI_TRANS_* constants
+must be one of the PDO::FETCH_* constants
+must be one of the SORT* constants
+must be provided for instance properties
+must be provided when argument #2 ($wrapper_or_options) is a string
+must be specified when enabling encryption
+must be the same size as argument #1 ($im1)
+must contain arrays only containing the "
+must contain arrays with consecutive integer indices starting from 0
+must contain at least 1 valid key
+must contain at least one element
+must contain only arrays, where each array is a control
+must contain only one of CachingIterator::CALL_TOSTRING,
+must contain only string keys
+must contain only strings
+must contain only valid cURL options
+must contain only valid callbacks
+must have 6 elements
+must have a correct length
+must have a multiple of 4 elements
+must have a valid syntax
+must have an even number of elements
+must have at least one color
+must have at least one element
+must have consecutive integer indices starting from 0
+must have exactly two elements: "
+must have the node attribute
+must have the same number of elements as the links array
+must not be the spl_autoload_call() function
+must not be zero
+must not combine 'H' and 'K' flags
+must not combine 'h' and 'C' flags
+must not combine 'h' and 'c' flags
+must not combine 'h' and 'k' flags
+must not combine 'k' and 'C' flags
+must not combine 'k' and 'c' flags
+must not contain any null bytes
+must not contain empty strings
+must not contain null bytes
+must not contain strings with null bytes
+must not exceed the specified range
+must not go past 23:59:59, December 31, 3000, UTC
+must not include RFMEM value, not allowed within this context
+must not include RFSIGSHARE value, not allowed within this context
+must not include both RFFDG and RFCFDG, because these flags are mutually exclusive
+must only contain array keys "
+must only contain arrays
+must only contain arrays and streams
+must only contain objects of type LDAP
+must only contain string values
+must only contain string-indexed arrays
+must only contain the "
+must specify at least one encoding
+must use PDO::FETCH_CLASSTYPE with PDO::FETCH_CLASS
+must use PDO::FETCH_SERIALIZE with PDO::FETCH_CLASS
+mysqli_data_seek() cannot be used in MYSQLI_USE_RESULT mode
+mysqli_num_rows() cannot be used in MYSQLI_USE_RESULT mode
+mysqli_result::data_seek() cannot be used in MYSQLI_USE_RESULT mode
+name conflict for module
+negative array index
+no magic files loaded
+only the leftmost array can be undimensioned
+opcache.file_cache must be a full path of accessible directory.\n
+opcache.max_wasted_percentage must be set between 1 and 50.\n
+opcache.memory_consumption is set below the required 8MB.\n
+pdo_oci_handle_factory
+phar error: Directory not empty
+phar error: "
+phar error: cannot create directory "
+phar error: cannot remove directory "
+phar error: cannot rmdir directory "
+phar error: file "
+phar error: invalid url "
+phar error: invalid url or non-existent phar "
+phar error: no directory in "
+phar error: not a phar stream url "
+phar error: not a phar url "
+phar error: open mode append not supported
+phar error: unlink failed
+phar error: write operations disabled by the php.ini setting phar.readonly
+phar file "
+phar url "
+pthread_mutex_init
+pthread_mutexattr_destroy
+pthread_mutexattr_init
+pthread_mutexattr_settype
+remote cafile streams are disabled for security purposes
+rfc2397: illegal URL
+rfc2397: illegal media type
+rfc2397: illegal parameter
+rfc2397: no comma in URL
+rfc2397: unable to decode
+run command is disallowed during hard interrupt
+second character must be one of "
+set break used incorrectly: set break [id] <on|off>
+set breaks used incorrectly: set breaks <on|off>
+set colors used incorrectly: set colors <on|off>
+set lines used incorrectly: set lines <number>
+set pagination used incorrectly: set pagination <on|off>
+sh command is disallowed during hard interrupt
+socket type must be one of AF_UNIX, AF_INET, or AF_INET6
+socket_select(): At least one array argument must be passed
+sodium_init()
+string slice too long
+third character must be "
+tidy object is not initialized
+too many captures
+too many results to unpack
+unbalanced pattern
+unexpected <EOF>
+unexpected character 'escape_char(ch)'
+unexpected sequence 'escape_string(yy_text, 1 + YYPOS - yy_text))'
+unfinished capture
+unlink of "
+upload_max_filesize of
+usage set stepping [<opcode|line>]
+var_export does not handle circular references
+vasprintf failed
+wrong number of arguments to
+wrong size for the hashed password
+zend.assertions may be completely enabled or disabled only in php.ini
+zlib window size (logarithm) (
+
+# Group with format strings
+
+ (breaking at opline
+ (inclusive)
+ (path:
+ (tried to allocate
+ - dynamic modules are not supported
+ Chunks Wide
+ Chunks vertically
+ arguments for the fetch mode provided,
+ as execution context, not a valid file or symlink
+ bytes (Current memory usage is
+ bytes exhausted (tried to allocate
+ bytes exhausted at
+ bytes were written, expected to write
+ bytes) (tried to allocate
+ bytes. Uncompressing into buffer of
+ cannot be instantiated
+ cannot be of type array
+ cannot be passed by reference
+ cannot contain non abstract method
+ chunk index entries
+ command is disallowed during hard interrupt
+ contains a null byte
+ could not be converted to bool
+ could not be converted to string
+ could not compile file
+ did not create an Iterator
+ died before SIGKILL was sent
+ does not have a constructor, cannot pass arguments
+ does not match enum backing type
+ does not support method calls
+ doesn't exist in class
+ file is closed
+ for stream_metadata
+ has no unserializer
+ implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary)
+ instance wasn't initialized properly
+ is greater than \\377
+ is inapplicable to this socket type
+ is nor an array nor an object
+ is not a user defined function, no oplines exist
+ is not a user defined method, no oplines exist
+ is not a valid backing value for enum "
+ is not a valid phar archive
+ is not compatible with property
+ must be a field name from this result set
+ must be greater than or equal to 0
+ must be less than the number of fields for this result set
+ must be passed by reference, value given
+ must not be accessed before initialization
+ object is already closed
+ object is not fully initialized
+ object_id:
+ of C function '
+ oplines in file
+ oplines in function
+ oplines in method
+ option must have an array value
+ overwrites previous argument
+ packet. PID=
+ points in array with only
+ readonly property
+ requires PDO API version
+ requires Zend Engine API version
+ to reference held by property
+ used as array
+ was built with configuration
+ when argument #1 ($search) is
+ with an empty name
+' (include_path='
+' (info)\n
+' (mem)\n
+' (tried:
+' (wrong header)\n
+' already defined in '
+' excepted checksum:
+' for reading from stdin
+' from PHP '
+' in <message>
+' in s[np]printf call
+' is not a valid mode for fopen
+' is not a valid utf-8 string
+' must have a single part
+' of C struct/union
+' of non C struct/union
+' type='
+' value='
+', FFI_LIB defined twice
+', FFI_SCOPE defined twice
+', bad FFI_LIB define
+', bad FFI_SCOPE define
+', cannot read_file
+', cannot resolve C function '
+', cannot resolve C variable '
+', different 'targetNamespace'
+', expecting '
+', expecting at least
+', expecting exactly
+', file doesn't exist
+', found '
+', found PHP '
+', namespace must not match the enclosing schema 'targetNamespace'
+', not a regular file
+', redefinition of '
+', unexpected 'targetNamespace'='
+() (previously declared in
+() - access must be exactly one of public, protected or private
+() can only be called after a stylesheet has been imported
+() cannot be a NULL function
+() cannot be abstract
+() cannot be static
+() cannot take arguments
+() cannot take arguments by reference
+() does not accept unknown named parameters
+() expects at least
+() expects at most
+() expects at most 2 argument for the fetch mode provided,
+() expects exactly
+() expects exactly 0 arguments,
+() expects exactly 1 argument for the fetch mode provided,
+() expects exactly 2 argument for PDO::FETCH_FUNC,
+() from global scope
+() from scope
+() has been disabled for security reasons
+() is deprecated
+() must be static
+() must have public visibility
+() must not return a value,
+() must take exactly %
+() must take exactly 1 argument
+() to object of class
+(): Argument #
+(): Argument #1 ($callback) must be a valid callback,
+(): Argument #1 ($pieces) must be of type array, string given
+(): Argument #1 ($value) must be of type Countable|array,
+(): Array value for VLV control must have a "
+(): Array value for VLV control must have an "
+(): Array value for VLV control must have either an "
+(): Attempt to close cURL handle from a callback
+(): Attempt to reset cURL handle from a callback
+(): Class of end date must be exactly DateTime or DateTimeImmutable, object of class
+(): Class of start date must be exactly DateTime or DateTimeImmutable, object of class
+(): Control OID
+(): Control must have a "
+(): Control must have an "
+(): Disabling safe uploads is no longer supported
+(): Expects exactly 3 arguments when argument #3
+(): If option "
+(): Option must be a valid callback
+(): Parameter #
+(): Return type must be
+(): Return value must be of type
+(): Sort key list must have an "
+(): The provided file handle must be writable
+(): cURL option must not contain any null bytes
+(): never-returning function must not implicitly return
+(): option array cannot have numeric keys
+(): supplied argument is not a valid
+(): supplied resource is not a valid
+) after startup
+) at index
+) from chunk
+) is not user defined
+) must be of type
+) the file does not exist
+), not a regular file or symlink
+), please try to set opcache.use_cwd to 0 in ini file
+, as this would result in an inconsistent type conversion
+, check path and permissions
+, ensure the file exists
+, file does not exist
+, invalid data source
+, it is not a regular file
+, not found or invalid zend extension / module:
+, or -2 and -36
+, whereas running engine is
+, which does not match the installed Zend Engine API version
+. Node no longer exists
+. Packet size=
+: Only one of seed or secret is to be passed for initialization
+: Secret length must be >=
+: Unable to register functions, unable to load
+: integer overflow in format string
+: not enough arguments
+: too few arguments
+: unknown format code
+::__clone() from
+::__construct()
+::__serialize() must return an array
+::__toString() implemented without string return type
+::__toString() must return a string
+::__toString() must return a string value
+::getCurrentLine(): Return value must be of type string,
+::offsetSet() instead
+> in all
+> in attribute
+> in attributeGroup
+> in choice
+> in complexContent
+> in complexType
+> in element
+> in extension
+> in group
+> in list
+> in restriction
+> in schema
+> in sequence
+> in simpleContent
+> in simpleType
+> in union
+Access to undeclared static property
+Accessing static property
+Added key '
+Allowed memory size of
+Already Positioned in file to
+An infinite value cannot be converted to base
+Arginfo / zpp mismatch during call of
+Argument number specifier must be greater than zero and less than
+Array of functions is not allowed at line
+Attempt to assign an invalid callback,
+Attempt to assign field '
+Attempt to assign read-only C variable '
+Attempt to assign read-only field '
+Attempt to assign undefined C variable '
+Attempt to assign undefined field '
+Attempt to call undefined C function '
+Attempt to read field '
+Attempt to read property "
+Attempt to read undefined C variable '
+Attempt to read undefined field '
+Attempt to unset static property
+Attempting to kill locker
+Attempting to use non-attribute class "
+Attribute class "
+Attribute constructor of class
+Attribute value must be of type bool for selected attribute,
+Attribute value must be of type int for selected attribute,
+Backup failed:
+Bad chunk size:
+Bad data format:
+Bad magic format `
+Bad scan conversion character "
+Bad version:
+Bit field "
+Blacklist JIT compilation failed,
+Breakpoint already exists for
+Breakpoint exists at
+Breakpoint exists for
+Cached script '
+Call to a member function
+Call to undefined function
+Call to undefined method
+Cannot access offset of type
+Cannot access property of object of type
+Cannot append properties to objects, use
+Cannot bind closure to scope of internal class
+Cannot bind method
+Cannot call abstract method
+Cannot call private
+Cannot create dynamic property
+Cannot create mutex (error
+Cannot declare self-referencing constant
+Cannot decrement property
+Cannot dynamically load
+Cannot get fiber return value:
+Cannot increment property
+Cannot instantiate abstract class
+Cannot instantiate enum
+Cannot instantiate interface
+Cannot instantiate trait
+Cannot load blacklist file:
+Cannot load module "
+Cannot modify header information - headers already sent by (output started at
+Cannot modify readonly property
+Cannot modify readonly property DatePeriod::$
+Cannot open "
+Cannot perform bitwise not on
+Cannot set breakpoint in
+Cannot unset readonly property
+Cannot use "
+Cannot use object of type
+Cannot write read-only property
+Checksum failed for '
+ChunkSize:
+Chunks:
+Command array element
+Conditional break
+Could not add variable: OID='
+Could not fetch class
+Could not find the class
+Could not list function
+Could not open '
+Could not open file
+Couldn't fetch function
+Creation of dynamic property
+Data starts at
+Declaration does not declare anything at line
+Duplicate field name "
+Duplicate value in enum
+Encoding: Attribute '
+Encoding: Element '
+Encoding: External reference '
+Encoding: Restriction: invalid enumeration value "
+Encoding: Unresolved reference '
+Encoding: Violation of id and ref information items '
+Encoding: object has no '
+Encoding: string '
+Enum case type
+Enumerator value "
+Erroneous data format for unserializing '
+Error in packet at
+Error in packet at '
+Error while receiving public key. PID=
+Error while sending
+Error while sending public key request packet. PID=
+Error: OID not increasing:
+FFI Parser:
+FFI: Failed pre-loading '
+FFI: failed pre-loading '
+FTP server reports
+Failed identify data
+Failed loading '
+Failed loading Zend extension '
+Failed loading scope '
+Failed opening required '
+Failed resolving C function '
+Failed resolving C variable '
+Failed to check locker
+Failed to compile
+Failed to compile code for expression
+Failed to create closure from callable:
+Failed to create new session ID:
+Failed to create session ID by collision:
+Failed to create session ID:
+Failed to create test table: [
+Failed to create(read) session ID:
+Failed to drop old test table: [
+Failed to execute
+Failed to find the requested color (
+Failed to find the requested element (
+Failed to open
+Failed to open or create
+Failed to open session:
+Failed to send SIGKILL to locker
+Failed to set execution context (
+Failed to set memory limit to
+Failed to set up data channel:
+Failed to stat
+Fatal error:
+File cached script loaded into memory '
+File size is
+Flexible array member in union at line
+Flexible array member not at end of struct at line
+Forced restart at
+Function registration failed - duplicate name -
+Function returning array is not allowed at line
+Function returning function is not allowed at line
+GetAdaptersAddresses failed:
+Got file code:
+Illegal length modifier specified '
+Illegal string offset "
+Image palette completed:
+Implicit conversion from float-string "
+Incompatible types when assigning to type '
+Incomplete C type
+Incomplete enum "
+Incomplete struct "
+Incomplete type at line
+Incomplete union "
+Inconsistent entries in `
+Incorrect number of arguments for C function '
+Index must be between 0 and
+Index size is
+Indirect modification of overloaded element of
+Indirect modification of overloaded property
+Instantiation of
+Internal help error, non-unique alias "
+Invalid access level for
+Invalid backtrace size
+Invalid callback
+Invalid file for conditional break
+Invalid format type
+Invalid object identifier:
+Invalid opcode name
+Invalid range supplied: start=%0.0f end=%0.0f
+Invalid redirect URL!
+It's not possible to assign a complex type to
+KLockers:
+Killed locker
+Largest compressed chunk is
+Loading blacklist file:  '
+MAX_FILE_SIZE of %
+Missing arginfo for
+Missing mime boundary at the end of the data for file
+Multiple calling convention specifiers at line
+Named parameter $
+Negative array index at line
+Negative width in bit-field "
+No blacklist file found matching:
+No frame #
+No help topic found for
+Not allowed to call handler '
+OID value must be of type string|int,
+Object of class
+Object of type
+Octal escape sequence overflow \\
+Offset out of range %
+Only the leftmost array can be undimensioned at line
+Out of memory (allocated
+Output buffer space exceeded
+Output overrun of %
+Overflow in enumeration values "
+PDO: driver
+PDO::ATTR_STATEMENT_CLASS constructor_args must be of type ?array,
+PDO::ATTR_STATEMENT_CLASS value must be of type array,
+Packets out of order. Expected
+Parse Error:
+Parsing Schema: attribute '
+Parsing Schema: attributeGroup '
+Parsing Schema: can't import schema from '
+Parsing Schema: can't include schema from '
+Parsing Schema: element '
+Parsing Schema: group '
+Parsing Schema: unexpected <
+Parsing Schema: unresolved element 'ref' attribute '
+Parsing Schema: unresolved group 'ref' attribute '
+Parsing WSDL: <binding> '
+Parsing WSDL: <fault> with name '
+Parsing WSDL: <message> '
+Parsing WSDL: <portType> '
+Parsing WSDL: <service> '
+Parsing WSDL: Couldn't find <definitions> in '
+Parsing WSDL: Couldn't load from '
+Parsing WSDL: Missing <message> with name '
+Parsing WSDL: Missing <portType> with name '
+Parsing WSDL: Missing <portType>/<operation> with name '
+Parsing WSDL: Missing name for <fault> of '
+Parsing WSDL: Missing name for <input> of '
+Parsing WSDL: Missing name for <output> of '
+Parsing WSDL: Missing part '
+Parsing WSDL: No <binding> element with name '
+Parsing WSDL: No name associated with <part> '
+Parsing WSDL: The fault message '
 Parsing WSDL: Unexpected WSDL element <
 Parsing WSDL: Unexpected extensibility element <
 Parsing WSDL: Unknown encodingStyle '
 Parsing WSDL: Unknown required WSDL extension '
-Parsing WSDL: Unspecified encodingStyle
-Possible integer overflow in memory allocation (
-Second array member is not a valid method
-Spoofchecker class not defined
-String size overflow
-The object to be iterated is in an invalid state: "
-Trying to clone an uncloneable object
+Passing incompatible argument
+Positioning in file to
+Possible integer overflow in zend_arena_calloc() (
+Precision -1 is only supported for %
+Precision must be between -1 and
+Precision must be greater than zero and less than
+Preloading failed to initgroups(\
+Preloading failed to setgid(
+Preloading failed to setuid(
+Processing Chunk
+Processing Chunk (
+REQUEST_BODY_FILE: open('
+Redeclaration of "
+Redefinition of "
+Redirection target must be of type int,
+Reference with value of type
+Requires 1 or 2 arguments,
+Requires 2 or 3 arguments,
+Restart Scheduled! Reason:
+RestartC(+1):
+RestartC(-1):
+RestartC:
+Session callback must have a return value of type bool,
+SoapHeader::__construct(): "
+SoapServer::addFunction(): Function "
+Static function
+Struct/union can't contain an instance of itself at line
+Stuck count for pid
+Stuck count for thread id
+The arguments array must contain
+The class requested (
+The expanded parameter requires SQLite3 >= 3.14 and
+The function requested (
+The magic method
+The requested class (
+The requested function (
+The requested name (
+The source of the requested class (
+The use statement with non-compound name '
+Too few arguments to function
+Trying to access array offset on value of type
 Trying to clone an uncloneable object of class
-Unable to call
-Unable to cast node to string
-Undefined class constant '
-Undefined constant '
+Type float/double is not allowed at position
+Type kind must be dispatchable, %08x given
+Typed property
+Typed static property
+Unable to bind parameter number
+Unable to call handler
+Unable to clear statement:
+Unable to close database:
+Unable to execute statement:
+Unable to initialize module
+Unable to load extension at '
+Unable to open blob:
+Unable to prepare statement:
+Unable to read stream for parameter
+Unable to register module
+Unable to reset statement:
+Unable to set busy timeout:
+Unable to startup Zend extension
+Unable to startup module
+Uncaught exception
+Undefined C type "
+Undefined array key "
+Undefined constant
+Undefined constant "
 Undefined offset for object of type
-Unexpected inconsistency in create_function()
-Unknown SOAP version
-Unknown typehint
-Unsupported operand types
-Using $this when not in object context
-Wrong parameters for ErrorException(
-Wrong parameters for Exception(
-You MUST load PDO before loading any PDO drivers
-[] operator not supported for strings
-and must therefore be declared abstract or implement the remaining methods
-namespace must not match the enclosing schema 'targetNamespace'
-requires PDO API version
-PDO Connection Error: SQLSTATE[HY000]
-(HY000/2002): Connection refused
+Undefined property:
+Undefined variable $
+Unknown class '
+Unknown format specifier "
+Unknown named parameter $
+Unknown parameter type:
+UnlockAll:
+Unsupported array index type at line
+Unsupported attribute "
+Unsupported calling convention line
+Unsupported content type:  '
+Unsupported declare '
+Unsupported encoding [
+Unsupported node type:
+Unsupported operand types:
+Unsupported parameter type (
+Unsupported type _Complex at line
+Unsupported type specifier combination at line
+UpdateC(+1):
+UpdateC(-1):
+UpdateC:
+Uploaded file size 0 - file [
+Value must be of type string|int|float|null,
+Values must be of type string|int|float|bool|null,
+Width must be greater than zero and less than
+Wrong COM_STMT_PREPARE response size. Received
+Wrong parameter count for
+Wrong type of bit field "
+Zero width in bit-field "
+[clean] Failed to drop old test table: [
+] cannot be found (missing integer key)
+array_key_exists(): Argument #2 ($array) must be of type array,
+avif error -
+bad argument #
+bad magic in `
+call_user_func_array(): Argument #2 ($args) must be of type array,
+cannot allocate %
+cannot find entry `
+cannot mprotect `
+cannot open tmp file `
+cannot read fd
+cannot read magic file `
+cannot write tmp file `
+contains invalid encoding "
+contains invalid flag: '
+contains invalid type for element
+corrupted file '
+failed loading cafile stream: `
+failed pre-loading '
+foreach() argument must be of type array|object,
+function type is not allowed at line
+gd-jpeg, libjpeg: recoverable error:
+gd-jpeg, libjpeg: strace message:
+gd-png color_type is palette, colors:
+gd-png warning: image data references out-of-range color index (
+get_class(): Argument #1 ($object) must be of type object,
+getcwd() failed for '
+getifaddrs() failed
+individual body must be of type array,
+invalid mode 0
+invalid replacement value (a
+invalid value (
+is an invalid configuration option, "
+lu is not a multiple of
+magic element size
+malformed pattern (ends with
+mb_chr() does not support the "
+mb_ord() does not support the "
+mm_malloc failed, avail
+must be a 3x3 array, matrix[
+must be a class name compatible with
+must be a class name derived from
+must be a file name or a stream resource,
+must be a string, an array(class, method), or a callable object,
+must be a valid
+must be a valid callback or null,
+must be a valid callback,
+must be a valid callback, function "
+must be a valid class name,
+must be a valid encoding, "
+must be a valid function name, function "
+must be a valid language, "
+must be an instance of mysqli,
+must be between 0 and
+must be between 2 and
+must be greater than 0 and less than
+must be greater than or equal to
+must be less than
+must be less than or equal to
+must be less than or equal to argument #
+must be of type ?
+must be of type ?array,
+must be of type Countable|array,
+must be of type DOMNode|string,
+must be of type LDAP|array,
+must be of type SimpleXMLElement|DOMNode,
+must be of type SoapHeader|array|null,
+must be of type array for the LDAP_OPT_CLIENT_CONTROLS option,
+must be of type array,
+must be of type array|string|int,
+must be of type bool for the FTP_AUTOSEEK option,
+must be of type bool for the FTP_USEPASVADDRESS option,
+must be of type callable|int,
+must be of type int for the FTP_TIMEOUT_SEC option,
+must be of type int,
+must be of type object,
+must be of type object|string,
+must be of type resource|string,
+must be of type string or file-resource,
+must be of type string,
+must be of type string|int|array,
+must be of type string|int|float|bool,
+must be of type zero-terminated string or array,
+must consist of exactly
+must not combine '
+must only have elements of type Socket,
+must only have elements of type string|int,
+name conflict for module
+name use count (
+no function environment for tail call at level
+no valid certs found cafile stream: `
+opcache cannot create directory for file '
+opcache cannot create file '
+opcache cannot read from file '
+opcache cannot unlock file '
+opcache cannot write to file '
+opcache.max_accelerated_files is set above the limit (
+opcache.max_accelerated_files is set below the required minimum (
+phar error: "
+phar error: Could not write
+phar error: cannot create directory "
+phar error: cannot remove directory "
+phar error: cannot rmdir directory "
+phar error: file "
+phar error: invalid url "
+phar error: invalid url or non-existent phar "
+phar error: no directory in "
+phar error: not a phar stream url "
+phar error: not a phar url "
+phar file "
+phar url "
+remap to huge page
+request_startup() for
+skip Can't bind to LDAP Server - [
+skip Can't connect to MySQL Server - [
+stack overflow (
+string too long: `
+strlen(): Argument #1 ($str) must be of type string,
+unreadable symlink `
+upload_max_filesize of
+void type is not allowed at line
+write() failed -
+zend_signal: handler was replaced for signal (
+zend_signal: shutdown with non-zero blocking depth (
+zlib >= 1.2.4 required for BLOCK deflate; current version:


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

This PR will update the PHP errors list. I've added the description to the procedure I'm following to get, with some caveats, all the errors that might be disclosing information.

After doing a pass and documenting the procedure, there is still a manual job based on the experience of the person looking at the lines and removing the nonsense. We might come up with something better, automated, somehow.

Please take a look at the initial comment and let's iterate over the text we can use as errors.

Fixes #2652 