### PR TITLE
fix(response): ignore case on php response text

### DIFF
--- a/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -74,9 +74,9 @@ SecRule RESPONSE_BODY "@rx (?:\b(?:f(?:tp_(?:nb_)?f?(?:ge|pu)t|get(?:s?s|c)|scan
 #
 # To prevent false positives (due to the short "<?" sequences), we also include,
 # the space after it in an attempt to stop alerts in binary output.
+# And we make it case insensitive.
 #
-#
-SecRule RESPONSE_BODY "@rx <\?(?:=|php)?\s+" \
+SecRule RESPONSE_BODY "@rx (?i)<\?(?:=|php)?\s+" \
     "id:953120,\
     phase:4,\
     block,\

--- a/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953120.yaml
+++ b/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953120.yaml
@@ -131,3 +131,24 @@ tests:
             data: <?=!@#$%^&
           output:
             no_log_contains: "id \"953120\""
+  - test_title: 953120-6
+    desc: "Case insensitive test <?PhP "
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Accept: "*/*"
+              Accept-Charset: "ISO-8859-1,utf-8;q=0.7,*;q=0.7"
+              Accept-Encoding: "gzip,deflate"
+              Accept-Language: "en-us,en;q=0.5"
+              Content-Type: "text/plain"
+            method: "GET"
+            version: "HTTP/1.0"
+            uri: "/anything"
+            data: <?PhP echo "Hello World!\n" ?>
+          output:
+            log_contains: "id \"953120\""


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Kudos to Shivam for reporting this.

We should catch `<?PHP` and/or `<?Php` strings. It is not uncommon.