### PR TITLE
Negative lookarounds for rule 941310 to stop matching Japanese word Company.

### DIFF
--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -557,7 +557,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # US-ASCII on Wikipedia: https://en.wikipedia.org/wiki/ASCII
 # ISO 8859-1 on Wikipedia: https://en.wikipedia.org/wiki/ISO/IEC_8859-1
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@rx \xbc[^\xbe>]*[\xbe>]|<[^\xbe]*\xbe" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@rx [^\xe4]\xbc[^\x9a][^\xbe>]*[^\xe7\xa4][\xbe>]|<[^\xbe]*[^\xe7\xa4]\xbe" \
     "id:941310,\
     phase:2,\
     block,\


### PR DESCRIPTION
Hi guys,

we received (Redhat) a bug about rule 941310 which is triggered by Japanese word 'Company' (会社).

echo -e '\xe4\xbc\x9a\xe7\xa4\xbe'
会社

I used lookarounds to get rid of this false positive. 
Could you please take a look if is this change acceptable? Thanks.