### PR TITLE
feat(xss): add js methods to prevent xss

### DIFF
--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -658,10 +658,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS|XML:
 #
 # JavaScript methods which take code as a string types are considered unsafe.
 # Unsafe JS functions like eval(), setInterval(), setTimeout()
+# Unsafe JS constructor new Function()
 # https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#dangerous-contexts
+# https://snyk.io/blog/5-ways-to-prevent-code-injection-in-javascript-and-node-js/
 #
 
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \b(?i:eval|settimeout|setinterval)\s*\(" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \b(?i:eval|settimeout|setinterval|new\s+Function)\s*\(" \
     "id:941390,\
     phase:2,\
     block,\

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -655,6 +655,32 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS|XML:
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
+#
+# JavaScript methods which take code as a string types are considered unsafe.
+# Unsafe JS functions like eval(), setInterval(), setTimeout()
+# https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#dangerous-contexts
+#
+
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \b(?i:eval|settimeout|setinterval)\s*\(" \
+    "id:941390,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:urlDecode,t:htmlEntityDecode,t:jsDecode,\
+    msg:'Javascript method detected',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'attack-xss',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/242',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/4.0.0-rc1',\
+    severity:'CRITICAL',\
+    setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:941013,phase:1,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:941014,phase:2,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -668,7 +668,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     phase:2,\
     block,\
     capture,\
-    t:none,t:urlDecode,t:htmlEntityDecode,t:jsDecode,\
+    t:none,t:htmlEntityDecode,t:jsDecode,\
     msg:'Javascript method detected',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941390.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941390.yaml
@@ -1,0 +1,56 @@
+---
+meta:
+  author: "Franziska Buehler"
+  description: None
+  enabled: true
+  name: 941390.yaml
+tests:
+  - test_title: 941390-1
+    desc: "JavaScript method setInterval(code, 1)"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+            method: GET
+            port: 80
+            uri: '/?arg=setInterval%28code%2C%201%29'
+            version: HTTP/1.1
+          output:
+            log_contains: id "941390"
+  - test_title: 941390-2
+    desc: "JavaScript method: arg=x\";setTimeout(name, 1)//"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+            method: GET
+            port: 80
+            uri: '/?arg=x%22%3BsetTimeout%28name%2C%201%29%2F%2F'
+            version: HTTP/1.1
+          output:
+            log_contains: id "941390"
+  - test_title: 941390-3
+    desc: "JavaScript method eval('2 + 2')"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+            method: GET
+            port: 80
+            uri: '/?arg=eval%28%272%20%2B%202%27%29'
+            version: HTTP/1.1
+          output:
+            log_contains: id "941390"
+~                                      

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941390.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941390.yaml
@@ -53,4 +53,19 @@ tests:
             version: HTTP/1.1
           output:
             log_contains: id "941390"
-~                                      
+  - test_title: 941390-4
+    desc: "JavaScript constructor new Function()"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+            method: GET
+            port: 80
+            uri: '/?arg=new%20Function%28%29'
+            version: HTTP/1.1
+          output:
+            log_contains: id "941390"


### PR DESCRIPTION
This PR resolves BB finding 4A9UJH6G (issue #2661) by adding the missing js method `setTimeout()` by addind a new rule.
I also added the problematic methods `setInterval()` and `eval()` and the constructor `new Function()`, because I found them in the same context while researching the topic. 

2 open points to discuss:
* I'm not sure with `eval()` because it's already covered in 934100 and 933160. Do we need this in this new rule 941390?
* I added the new rule to PL1 which is maybe at too low PL. Maybe a higher PL would fit better?

And of course I added tests as well!