### PR TITLE
fix(942130): add glob to sql tautologies

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -612,7 +612,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:\b(?:collate(?:\W+(?:(?:binary|nocase
 # (consult util/regexp-assemble/README.md for details):
 #   util/regexp-assemble/regexp-assemble.py update 942130
 #
-SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s'\"`()]*?\b([\d\w]+)\b[\s'\"`()]*?(?:(?:sounds\s+)?like|r(?:egexp|like)|<=>|=)[\s'\"`()]*?\b([\d\w]+)\b" \
+SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s'\"`()]*?\b([\d\w]+)\b[\s'\"`()]*?(?:(?:sounds\s+)?like|r(?:egexp|like)|glob|<=>|=)[\s'\"`()]*?\b([\d\w]+)\b" \
     "id:942130,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942130.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942130.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "Christian S.J. Peron and Allan Boll"
+  author: "Christian S.J. Peron and Allan Boll, Franziska Bühler"
   description: None
   enabled: true
   name: 942130.yaml
@@ -140,6 +140,21 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             method: GET
             uri: "/get?a=42<=>42"
+            version: HTTP/1.1
+          output:
+            log_contains: id "942130"
+  - test_title: 942130-10
+    desc: "SQL Injection Attack: SQL Tautology using glob"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            uri: "/?user=admin%40juice-sh.op'%20and%20password%20glob%20password;"
             version: HTTP/1.1
           output:
             log_contains: id "942130"

--- a/util/regexp-assemble/data/942130.data
+++ b/util/regexp-assemble/data/942130.data
@@ -34,6 +34,9 @@
 like[\s'\"`()]*?\b([\d\w]+)\b
 sounds\s+like[\s'\"`()]*?\b([\d\w]+)\b
 
+##! GLOB operator is used to match text values against a pattern
+glob[\s'\"`()]*?\b([\d\w]+)\b
+
 ##! String based regexp. These don't use % as wildcard.
 rlike[\s'\"`()]*?\b([\d\w]+)\b
 regexp[\s'\"`()]*?\b([\d\w]+)\b


### PR DESCRIPTION
This PR resolves BB issue #2709 by adding `glob` to PL2 sql tautologies rule 942130.

See linked issue and https://www.tutorialspoint.com/sqlite/sqlite_glob_clause.htm.