### PR TITLE
Add more php wrappers

### DIFF
--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -215,7 +215,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # (consult util/regexp-assemble/README.md for details):
 #   util/regexp-assemble/regexp-assemble.py update 933200
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:(?:bzip|ssh)2|z(?:lib|ip)|(?:ph|r)ar|expect|glob|ogg)://" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:ssh2(?:.(?:s(?:(?:ft|c)p|hell)|tunnel|exec))?|z(?:lib|ip)|(?:ph|r)ar|expect|bzip2|glob|ogg)://" \
     "id:933200,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933200.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933200.yaml
@@ -85,3 +85,83 @@ tests:
             version: HTTP/1.1
           output:
             no_log_contains: id "933200"
+  - test_title: 933200-6
+    desc: "Positive test: PHP Injection Attack - Wrapper scheme detected (ssh2.shell://)"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: "localhost"
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: /test.php?file=ssh2.shell://user:password@example.com:22/xterm
+            version: HTTP/1.1
+          output:
+            log_contains: id "933200"
+  - test_title: 933200-7
+    desc: "Positive test: PHP Injection Attack - Wrapper scheme detected (ssh2.exec://)"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: "localhost"
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: /test.php?file=ssh2.exec://user:password@example.com:22/usr/local/bin/kubectl
+            version: HTTP/1.1
+          output:
+            log_contains: id "933200"
+  - test_title: 933200-8
+    desc: "Positive test: PHP Injection Attack - Wrapper scheme detected (ssh2.tunnel://)"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: "localhost"
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: /test.php?file=ssh2.tunnel://user:password@example.com:22/10.0.0.1:25
+            version: HTTP/1.1
+          output:
+            log_contains: id "933200"
+  - test_title: 933200-9
+    desc: "Positive test: PHP Injection Attack - Wrapper scheme detected (ssh2.sftp://)"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: "localhost"
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: /test.php?file=ssh2.sftp://user:password@example.com:22/path/to/filename
+            version: HTTP/1.1
+          output:
+            log_contains: id "933200"
+  - test_title: 933200-10
+    desc: "Positive test: PHP Injection Attack - Wrapper scheme detected (ssh2.scp://)"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: "localhost"
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: /test.php?file=ssh2.scp://user:password@example.com:22/path/to/filename
+            version: HTTP/1.1
+          output:
+            log_contains: id "933200"

--- a/util/regexp-assemble/data/933200.data
+++ b/util/regexp-assemble/data/933200.data
@@ -23,5 +23,10 @@ ogg
 phar
 rar
 ssh2
+ssh2.shell
+ssh2.exec
+ssh2.tunnel
+ssh2.sftp
+ssh2.scp
 zip
 zlib


### PR DESCRIPTION
Associated issue: #2724

This PR adds the additional PHP wrappers documented at https://www.php.net/manual/en/wrappers.ssh2.php and a new test for each new wrapper:

- `ssh2.shell://`
- `ssh2.exec://`
- `ssh2.tunnel://`
- `ssh2.sftp://`
- `ssh2.scp://`

