### PR TITLE
fix (regexp-assemble): filter and sort files properly

### DIFF
--- a/util/regexp-assemble/lib/context.py
+++ b/util/regexp-assemble/lib/context.py
@@ -1,5 +1,7 @@
 import argparse
 from pathlib import Path
+import logging
+
 
 
 class Context(object):
@@ -23,3 +25,14 @@ class Context(object):
             and self.data_files_directory.exists()
             and self.include_files_directory.exists()
         )
+
+        self._dump_to_debug_log()
+
+    def _dump_to_debug_log(self):
+        logger = logging.getLogger()
+        logger.debug("Root directory: %s", self.root_directory)
+        logger.debug("Rules directory: %s", self.rules_directory)
+        logger.debug("Data files directory: %s", self.data_files_directory)
+        logger.debug("Include files directory: %s", self.include_files_directory)
+        logger.debug("Parsed rule ID: %s", self.single_rule_id)
+        logger.debug("Parsed chain offset: %s", self.single_chain_offset)

--- a/util/regexp-assemble/lib/context.py
+++ b/util/regexp-assemble/lib/context.py
@@ -18,6 +18,8 @@ class Context(object):
         if namespace and "chain_offset" in namespace:
             self.single_chain_offset = namespace.chain_offset
 
+        self._dump_to_debug_log()
+
         assert (
             self.rules_directory.exists()
             and self.util_directory.exists()
@@ -26,7 +28,6 @@ class Context(object):
             and self.include_files_directory.exists()
         )
 
-        self._dump_to_debug_log()
 
     def _dump_to_debug_log(self):
         logger = logging.getLogger()

--- a/util/regexp-assemble/lib/operators/parser.py
+++ b/util/regexp-assemble/lib/operators/parser.py
@@ -42,6 +42,7 @@ class Parser(object):
 
     def process_regex(self, rule_id: str, chain_offset: int, file_path: Path, assembler: Assembler, func):
         self.logger.info("Processing %s, chain offset %s", rule_id, chain_offset)
+        self.logger.debug("Processing data file %s", file_path)
 
         with file_path.open("rt") as file:
             regex = assembler.run(file)
@@ -52,6 +53,7 @@ class Parser(object):
         else:
             for rule_file in self.context.rules_directory.iterdir():
                 if rule_prefix in rule_file.name:
+                    self.logger.debug("Updating rule file %s", rule_file.name)
                     self.prefix_to_file_map[rule_prefix] = rule_file
                     with rule_file.open("rt") as handle:
                         parser = MSCParser()

--- a/util/regexp-assemble/lib/operators/parser.py
+++ b/util/regexp-assemble/lib/operators/parser.py
@@ -19,6 +19,7 @@ class Parser(object):
 
     def perform_compare_or_update(self, process_all: bool, func=None):
         files = [file for file in self.context.data_files_directory.iterdir()]
+        files = [file for file in files if file.match('*.data')]
         files.sort()
         for file in files:
             if process_all:
@@ -51,7 +52,10 @@ class Parser(object):
         if rule_prefix in self.parsers:
             parser = self.parsers[rule_prefix]
         else:
-            for rule_file in self.context.rules_directory.iterdir():
+            files = [file for file in self.context.rules_directory.iterdir()]
+            files = [file for file in files if file.match('*.conf')]
+            files.sort()
+            for rule_file in files:
                 if rule_prefix in rule_file.name:
                     self.logger.debug("Updating rule file %s", rule_file.name)
                     self.prefix_to_file_map[rule_prefix] = rule_file


### PR DESCRIPTION
Fixes bad selection of files on case-sensitive filesystems.

Thanks for pointing this out @RedXanadu, @airween.