### PR TITLE
New HTTP Parameter Rules

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -350,12 +350,94 @@ SecRule TX:/paramcounter_.*/ "@gt 1" \
         setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
+# -=[ HTTP Parameter Pollution ]=-
+#
+# [ Rule Logic ]
+# Parameter pollution rule 921180 PL3 can by bypassed when a weak backend parameter
+# parser is ignoring additional characters in a parameter array name after the
+# closing of the array.
+# Rule 921210 PL3 prevents this by disallowing arbitrary strings after an array has
+# been closed or inbetween the square brackets in multidimensional arrays.
+# Please note that rule 921120 allows for 2-dimensional, but not for higher dimensional
+# arrays. If these are flagged as attacks, a rule exclusion will have to be
+# deployed; ideally for the parameter(s) in question.
+#
+# [ References ]
+# Private bug bounty in Spring 2022, findings Z05OZUCH.
+#
+# [ Payloads ]
+# * foo[1]a=bar&foo[1]b=<evil> - parameter parsers often cut after the closing of
+#   the array. 921180 PL3 takes the full name, though.
+#   This impediance mismatch allows for bypasses.
+# * foo[1]x[1]=bar&foo[1]x[2]=<evil> - extension of 1; this has the advantage that
+#   the parameter name does end with "]" just like a valid array notation.
+#
+SecRule ARGS_NAMES "@rx (][^\]]+$|][^\]]+\[)" \
+    "id:921210,\
+    phase:2,\
+    pass,\
+    log,\
+    msg:'HTTP Parameter Pollution after detecting bogus char after parameter array',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/137/15/460',\
+    tag:'paranoia-level/3',\
+    ver:'OWASP_CRS/4.0.0-rc1',\
+    severity:'CRITICAL',\
+    setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+
+
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:921017,phase:1,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:921018,phase:2,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
+
+# -=[ HTTP Parameter Pollution ]=-
+#
+# [ Rule Logic ]
+# Parameter pollution rule 921180 PL3 and 921210 PL3 can by bypassed if a
+# weak backend parameter parser ignores parameter array alltogether at
+# cuts parameter names at the first occurrence of the "[" character.
+# The rule 921220 PL4 prevents this by disallowing parameter array names.
+#
+# If an application needs parameter array names, then this rule should be
+# disabled, ideally by issueing a rule exclusion for the parameter names
+# that need it.
+#
+# [ References ]
+# Private bug bounty in Spring 2022, finding 5UXE4RK0.
+#
+# [ Payloads ]
+# * foo[1]=bar&foo[2]=<evil>
+# * foo=bar&foo[1]=<evil>
+# * foo[1]=bar&foo[1]acb]=<evil> - this is an edge case that 921210 PL3 is not
+#   able to catch since the parameter name ends with "]".
+#
+SecRule ARGS_NAMES "@rx \[" \
+    "id:921220,\
+    phase:2,\
+    pass,\
+    log,\
+    msg:'HTTP Parameter Pollution possible via array notation',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/137/15/460',\
+    tag:'paranoia-level/4',\
+    ver:'OWASP_CRS/4.0.0-rc1',\
+    severity:'CRITICAL',\
+    setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
 

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921210.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921210.yaml
@@ -1,0 +1,49 @@
+---
+meta:
+  author: "Christian Folini (dune73)"
+  description: "HTTP Parameter Polution"
+  enabled: true
+  name: 921210.yaml
+tests:
+  - test_title: 921210-1
+    desc: "HTTP Parameter Pollution via bogus chars after parameter array name"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: "/?foo[1]a=bar&foo[1]b=<evil>"
+          output:
+            log_contains: id "921210"
+  - test_title: 921210-2
+    desc: "HTTP Parameter Pollution via bogus chars between square brackets of multi-dimensional array name"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: "/?foo[1]a[2]=bar"
+          output:
+            log_contains: id "921210"
+  - test_title: 921210-3
+    desc: "HTTP Parameter Pollution false positive test"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: "/?foo[1][2]=bar"
+          output:
+            no_log_contains: id "921210"

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921210.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921210.yaml
@@ -1,7 +1,7 @@
 ---
 meta:
   author: "Christian Folini (dune73)"
-  description: "HTTP Parameter Polution"
+  description: "HTTP Parameter Pollution"
   enabled: true
   name: 921210.yaml
 tests:

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921220.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921220.yaml
@@ -1,0 +1,21 @@
+---
+meta:
+  author: "Christian Folini (dune73)"
+  description: "HTTP Parameter Pollution"
+  enabled: true
+  name: 921220.yaml
+tests:
+  - test_title: 921220-1
+    desc: "Potential HTTP Parameter Pollution via parameter array"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: "/?foo[1]=bar"
+          output:
+            log_contains: id "921220"


### PR DESCRIPTION
This is a little set new pair of rules that prevents parameter pollution bypasses in bug bounty findings `Z05OZUCH` and `5UXE4RK0`.

The issues reported bypass existing parameter pollution rule 921180 via the following constructs:

1 - `foo[1]a=bar&foo[1]b=<evil>` - parameter parsers often cut after the closing of the array. 921180 PL3 takes the full name, though.
2 - `foo[1]x[1]=bar&foo[1]x[2]=<evil>` - extension of 1, came up with this myself, this has the advantage that the parameter name does end with `]` just like a valid array notation.
3 - `foo[1]=bar&foo[2]=<evil>` - simple parameter parsers don't do arrays
4 - `foo=bar&foo[1]=<evil>` - simple parameter parsers don't do arrays
5 - `foo[1]=bar&foo[1]acb]=<evil>` - simple parameter parsers don't do arrays

New rule 921210 PL3 prevents case 1 and case 2, while still allowing `foo[1]` and `foo[1][2]` (= array notation). They will not allow 3-dimensional arrays though (`foo[1][2][3]`).

New rule 921220 PL4 disallows the `[` character in parameter names. This effectively disallows array parameter (names). This prevents case 3, 4 and 5. Applications that make use of array parameters will have to disable this rule. Ideally via a rule exclusion for each array parameter name.

I would prefer to detect case 4 at PL3 while still allowing array parameter (names), however, this is seriously difficult and I can not see how this could be done without a construct over several helper rules. On top, case 4 only works against a stupid parameter parser, something that should not run behind a PL3 WAF.

I would also like to detect case 5 at PL3, but I could not get a regex that detects this while still allowing 2-dimensional arrays. The only way I could think of would make use of a look-around.
