### PR TITLE
Removing usage of TX:sql_error_match

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -255,7 +255,6 @@ SecRule &TX:enforce_bodyproc_urlencoded "@eq 0" \
 # Initialize anomaly scoring variables.
 # All _score variables start at 0, and are incremented by the various rules
 # upon detection of a possible attack.
-# sql_error_match is used for shortcutting rules for performance reasons.
 
 SecAction \
     "id:901200,\
@@ -283,8 +282,7 @@ SecAction \
     setvar:'tx.outbound_anomaly_score_pl1=0',\
     setvar:'tx.outbound_anomaly_score_pl2=0',\
     setvar:'tx.outbound_anomaly_score_pl3=0',\
-    setvar:'tx.outbound_anomaly_score_pl4=0',\
-    setvar:'tx.sql_error_match=0'"
+    setvar:'tx.outbound_anomaly_score_pl4=0'"
 
 
 #

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -57,9 +57,9 @@ SecRule RESPONSE_BODY "@rx (?i:JET Database Engine|Access Database Engine|\[Micr
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
+    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    ctl:auditLogParts=+E,\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -78,9 +78,9 @@ SecRule RESPONSE_BODY "@rx (?i:ORA-[0-9][0-9][0-9][0-9]|java\.sql\.SQLException|
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
+    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    ctl:auditLogParts=+E,\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -99,9 +99,9 @@ SecRule RESPONSE_BODY "@rx (?i:DB2 SQL error:|\[IBM\]\[CLI Driver\]\[DB2/6000\]|
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
+    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    ctl:auditLogParts=+E,\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -120,9 +120,9 @@ SecRule RESPONSE_BODY "@rx (?i:\[DM_QUERY_E_SYNTAX\]|has occurred in the vicinit
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
+    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    ctl:auditLogParts=+E,\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -141,9 +141,9 @@ SecRule RESPONSE_BODY "@rx (?i)Dynamic SQL Error" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
+    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    ctl:auditLogParts=+E,\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -162,9 +162,9 @@ SecRule RESPONSE_BODY "@rx (?i)Exception (?:condition )?\d+\. Transaction rollba
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
+    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    ctl:auditLogParts=+E,\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -183,9 +183,9 @@ SecRule RESPONSE_BODY "@rx (?i)org\.hsqldb\.jdbc" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
+    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    ctl:auditLogParts=+E,\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -204,9 +204,9 @@ SecRule RESPONSE_BODY "@rx (?i:An illegal character has been found in the statem
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
+    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    ctl:auditLogParts=+E,\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -225,9 +225,9 @@ SecRule RESPONSE_BODY "@rx (?i:Warning.*ingres_|Ingres SQLSTATE|Ingres\W.*Driver
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
+    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    ctl:auditLogParts=+E,\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -246,9 +246,9 @@ SecRule RESPONSE_BODY "@rx (?i:<b>Warning</b>: ibase_|Unexpected end of command 
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
+    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    ctl:auditLogParts=+E,\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -267,9 +267,9 @@ SecRule RESPONSE_BODY "@rx (?i:SQL error.*POS[0-9]+.*|Warning.*maxdb.*)" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
+    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    ctl:auditLogParts=+E,\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -288,9 +288,9 @@ SecRule RESPONSE_BODY "@rx (?i)(?:System\.Data\.OleDb\.OleDbException|\[Microsof
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
+    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    ctl:auditLogParts=+E,\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -314,9 +314,9 @@ SecRule RESPONSE_BODY "@rx (?i)(?:MyS(?:QL server version for the right syntax t
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
+    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    ctl:auditLogParts=+E,\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -335,9 +335,9 @@ SecRule RESPONSE_BODY "@rx (?i:PostgreSQL query failed:|pg_query\(\) \[:|pg_exec
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
+    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    ctl:auditLogParts=+E,\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -356,9 +356,9 @@ SecRule RESPONSE_BODY "@rx (?i)(?:Warning.*sqlite_.*|Warning.*SQLite3::|SQLite/J
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
+    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    ctl:auditLogParts=+E,\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
@@ -377,9 +377,9 @@ SecRule RESPONSE_BODY "@rx (?i)(?:Sybase message:|Warning.{2,20}sybase|Sybase.*S
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
+    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    ctl:auditLogParts=+E,\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -26,7 +26,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:951012,phase:4,pass,nolog,skipAf
 # Ref: https://raw.github.com/sqlmapproject/sqlmap/master/xml/errors.xml
 # Ref: https://github.com/Arachni/arachni/tree/master/components/checks/active/sql_injection/regexps
 #
-SecRule RESPONSE_BODY "@pmFromFile sql-errors.data" \
+SecRule RESPONSE_BODY "!@pmFromFile sql-errors.data" \
     "id:951100,\
     phase:4,\
     pass,\

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -40,9 +40,9 @@ SecRule RESPONSE_BODY "@pmFromFile sql-errors.data" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
     ver:'OWASP_CRS/4.0.0-rc1',\
-    setvar:'tx.sql_error_match=1'"
+    skipAfter:END-SQL-ERROR-MATCH-PL1"
 
-SecRule TX:sql_error_match "@eq 1" \
+SecRule RESPONSE_BODY "@rx (?i:JET Database Engine|Access Database Engine|\[Microsoft\]\[ODBC Microsoft Access Driver\])" \
     "id:951110,\
     phase:4,\
     block,\
@@ -59,14 +59,11 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'capec/1000/118/116/54',\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    chain"
-    SecRule RESPONSE_BODY "@rx (?i:JET Database Engine|Access Database Engine|\[Microsoft\]\[ODBC Microsoft Access Driver\])" \
-        "capture,\
-        ctl:auditLogParts=+E,\
-        setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
+    ctl:auditLogParts=+E,\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:sql_error_match "@eq 1" \
+SecRule RESPONSE_BODY "@rx (?i:ORA-[0-9][0-9][0-9][0-9]|java\.sql\.SQLException|Oracle error|Oracle.*Driver|Warning.*oci_.*|Warning.*ora_.*)" \
     "id:951120,\
     phase:4,\
     block,\
@@ -83,14 +80,11 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'capec/1000/118/116/54',\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    chain"
-    SecRule RESPONSE_BODY "@rx (?i:ORA-[0-9][0-9][0-9][0-9]|java\.sql\.SQLException|Oracle error|Oracle.*Driver|Warning.*oci_.*|Warning.*ora_.*)" \
-        "capture,\
-        ctl:auditLogParts=+E,\
-        setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
+    ctl:auditLogParts=+E,\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:sql_error_match "@eq 1" \
+SecRule RESPONSE_BODY "@rx (?i:DB2 SQL error:|\[IBM\]\[CLI Driver\]\[DB2/6000\]|CLI Driver.*DB2|DB2 SQL error|db2_\w+\()" \
     "id:951130,\
     phase:4,\
     block,\
@@ -107,14 +101,11 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'capec/1000/118/116/54',\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    chain"
-    SecRule RESPONSE_BODY "@rx (?i:DB2 SQL error:|\[IBM\]\[CLI Driver\]\[DB2/6000\]|CLI Driver.*DB2|DB2 SQL error|db2_\w+\()" \
-        "capture,\
-        ctl:auditLogParts=+E,\
-        setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
+    ctl:auditLogParts=+E,\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:sql_error_match "@eq 1" \
+SecRule RESPONSE_BODY "@rx (?i:\[DM_QUERY_E_SYNTAX\]|has occurred in the vicinity of:)" \
     "id:951140,\
     phase:4,\
     block,\
@@ -131,14 +122,11 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'capec/1000/118/116/54',\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    chain"
-    SecRule RESPONSE_BODY "@rx (?i:\[DM_QUERY_E_SYNTAX\]|has occurred in the vicinity of:)" \
-        "capture,\
-        ctl:auditLogParts=+E,\
-        setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
+    ctl:auditLogParts=+E,\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:sql_error_match "@eq 1" \
+SecRule RESPONSE_BODY "@rx (?i)Dynamic SQL Error" \
     "id:951150,\
     phase:4,\
     block,\
@@ -155,15 +143,11 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'capec/1000/118/116/54',\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    chain"
-    SecRule RESPONSE_BODY "@rx (?i)Dynamic SQL Error" \
-        "capture,\
-        ctl:auditLogParts=+E,\
-        setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
+    ctl:auditLogParts=+E,\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
-
-SecRule TX:sql_error_match "@eq 1" \
+SecRule RESPONSE_BODY "@rx (?i)Exception (?:condition )?\d+\. Transaction rollback\." \
     "id:951160,\
     phase:4,\
     block,\
@@ -180,14 +164,11 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'capec/1000/118/116/54',\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    chain"
-    SecRule RESPONSE_BODY "@rx (?i)Exception (?:condition )?\d+\. Transaction rollback\." \
-        "capture,\
-        ctl:auditLogParts=+E,\
-        setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
+    ctl:auditLogParts=+E,\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:sql_error_match "@eq 1" \
+SecRule RESPONSE_BODY "@rx (?i)org\.hsqldb\.jdbc" \
     "id:951170,\
     phase:4,\
     block,\
@@ -204,14 +185,11 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'capec/1000/118/116/54',\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    chain"
-    SecRule RESPONSE_BODY "@rx (?i)org\.hsqldb\.jdbc" \
-        "capture,\
-        ctl:auditLogParts=+E,\
-        setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
+    ctl:auditLogParts=+E,\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:sql_error_match "@eq 1" \
+SecRule RESPONSE_BODY "@rx (?i:An illegal character has been found in the statement|com\.informix\.jdbc|Exception.*Informix)" \
     "id:951180,\
     phase:4,\
     block,\
@@ -228,15 +206,11 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'capec/1000/118/116/54',\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    chain"
-    SecRule RESPONSE_BODY "@rx (?i:An illegal character has been found in the statement|com\.informix\.jdbc|Exception.*Informix)" \
-        "capture,\
-        ctl:auditLogParts=+E,\
-        setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
+    ctl:auditLogParts=+E,\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
-
-SecRule TX:sql_error_match "@eq 1" \
+SecRule RESPONSE_BODY "@rx (?i:Warning.*ingres_|Ingres SQLSTATE|Ingres\W.*Driver)" \
     "id:951190,\
     phase:4,\
     block,\
@@ -253,15 +227,11 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'capec/1000/118/116/54',\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    chain"
-    SecRule RESPONSE_BODY "@rx (?i:Warning.*ingres_|Ingres SQLSTATE|Ingres\W.*Driver)" \
-        "capture,\
-        ctl:auditLogParts=+E,\
-        setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
+    ctl:auditLogParts=+E,\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
-
-SecRule TX:sql_error_match "@eq 1" \
+SecRule RESPONSE_BODY "@rx (?i:<b>Warning</b>: ibase_|Unexpected end of command in statement)" \
     "id:951200,\
     phase:4,\
     block,\
@@ -278,14 +248,11 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'capec/1000/118/116/54',\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    chain"
-    SecRule RESPONSE_BODY "@rx (?i:<b>Warning</b>: ibase_|Unexpected end of command in statement)" \
-        "capture,\
-        ctl:auditLogParts=+E,\
-        setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
+    ctl:auditLogParts=+E,\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:sql_error_match "@eq 1" \
+SecRule RESPONSE_BODY "@rx (?i:SQL error.*POS[0-9]+.*|Warning.*maxdb.*)" \
     "id:951210,\
     phase:4,\
     block,\
@@ -302,14 +269,11 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'capec/1000/118/116/54',\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    chain"
-    SecRule RESPONSE_BODY "@rx (?i:SQL error.*POS[0-9]+.*|Warning.*maxdb.*)" \
-        "capture,\
-        ctl:auditLogParts=+E,\
-        setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
+    ctl:auditLogParts=+E,\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:sql_error_match "@eq 1" \
+SecRule RESPONSE_BODY "@rx (?i)(?:System\.Data\.OleDb\.OleDbException|\[Microsoft\]\[ODBC SQL Server Driver\]|\[Macromedia\]\[SQLServer JDBC Driver\]|\[SqlException|System\.Data\.SqlClient\.SqlException|Unclosed quotation mark after the character string|'80040e14'|mssql_query\(\)|Microsoft OLE DB Provider for ODBC Drivers|Microsoft OLE DB Provider for SQL Server|Incorrect syntax near|Sintaxis incorrecta cerca de|Syntax error in string in query expression|Procedure or function .* expects parameter|Unclosed quotation mark before the character string|Syntax error .* in query expression|Data type mismatch in criteria expression\.|ADODB\.Field \(0x800A0BCD\)|the used select statements have different number of columns|OLE DB.*SQL Server|Warning.*mssql_.*|Driver.*SQL[ _-]*Server|SQL Server.*Driver|SQL Server.*[0-9a-fA-F]{8}|Exception.*\WSystem\.Data\.SqlClient\.)" \
     "id:951220,\
     phase:4,\
     block,\
@@ -326,19 +290,16 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'capec/1000/118/116/54',\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    chain"
-    SecRule RESPONSE_BODY "@rx (?i)(?:System\.Data\.OleDb\.OleDbException|\[Microsoft\]\[ODBC SQL Server Driver\]|\[Macromedia\]\[SQLServer JDBC Driver\]|\[SqlException|System\.Data\.SqlClient\.SqlException|Unclosed quotation mark after the character string|'80040e14'|mssql_query\(\)|Microsoft OLE DB Provider for ODBC Drivers|Microsoft OLE DB Provider for SQL Server|Incorrect syntax near|Sintaxis incorrecta cerca de|Syntax error in string in query expression|Procedure or function .* expects parameter|Unclosed quotation mark before the character string|Syntax error .* in query expression|Data type mismatch in criteria expression\.|ADODB\.Field \(0x800A0BCD\)|the used select statements have different number of columns|OLE DB.*SQL Server|Warning.*mssql_.*|Driver.*SQL[ _-]*Server|SQL Server.*Driver|SQL Server.*[0-9a-fA-F]{8}|Exception.*\WSystem\.Data\.SqlClient\.)" \
-        "capture,\
-        ctl:auditLogParts=+E,\
-        setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
+    ctl:auditLogParts=+E,\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
 # Regular expression generated from util/regexp-assemble/data/952230.data.
 # To update the regular expression run the following shell script
 # (consult util/regexp-assemble/README.md for details):
 #   util/regexp-assemble/regexp-assemble.py generate 951230
 # Copy the output and replace the regular expression in the chain rule with it.
-SecRule TX:sql_error_match "@eq 1" \
+SecRule RESPONSE_BODY "@rx (?i)(?:MyS(?:QL server version for the right syntax to use|qlClient\.)|(?:supplied argument is not a valid |SQL syntax.*)MySQL|Column count doesn't match(?: value count at row)?|(?:Table '[^']+' doesn't exis|valid MySQL resul)t|You have an error in your SQL syntax(?: near|;)|Warning.{1,10}mysql_(?:[a-z_()]{1,26})?|ERROR [0-9]{4} \([a-z0-9]{5}\):|mysql_fetch_array\(\)|on MySQL result index|\[MySQL\]\[ODBC)" \
     "id:951230,\
     phase:4,\
     block,\
@@ -355,14 +316,11 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'capec/1000/118/116/54',\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    chain"
-    SecRule RESPONSE_BODY "@rx (?i)(?:MyS(?:QL server version for the right syntax to use|qlClient\.)|(?:supplied argument is not a valid |SQL syntax.*)MySQL|Column count doesn't match(?: value count at row)?|(?:Table '[^']+' doesn't exis|valid MySQL resul)t|You have an error in your SQL syntax(?: near|;)|Warning.{1,10}mysql_(?:[a-z_()]{1,26})?|ERROR [0-9]{4} \([a-z0-9]{5}\):|mysql_fetch_array\(\)|on MySQL result index|\[MySQL\]\[ODBC)" \
-        "capture,\
-        ctl:auditLogParts=+E,\
-        setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
+    ctl:auditLogParts=+E,\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:sql_error_match "@eq 1" \
+SecRule RESPONSE_BODY "@rx (?i:PostgreSQL query failed:|pg_query\(\) \[:|pg_exec\(\) \[:|PostgreSQL.{1,20}ERROR|Warning.*\bpg_.*|valid PostgreSQL result|Npgsql\.|PG::[a-zA-Z]*Error|Supplied argument is not a valid PostgreSQL .*? resource|Unable to connect to PostgreSQL server)" \
     "id:951240,\
     phase:4,\
     block,\
@@ -379,14 +337,11 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'capec/1000/118/116/54',\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    chain"
-    SecRule RESPONSE_BODY "@rx (?i:PostgreSQL query failed:|pg_query\(\) \[:|pg_exec\(\) \[:|PostgreSQL.{1,20}ERROR|Warning.*\bpg_.*|valid PostgreSQL result|Npgsql\.|PG::[a-zA-Z]*Error|Supplied argument is not a valid PostgreSQL .*? resource|Unable to connect to PostgreSQL server)" \
-        "capture,\
-        ctl:auditLogParts=+E,\
-        setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
+    ctl:auditLogParts=+E,\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:sql_error_match "@eq 1" \
+SecRule RESPONSE_BODY "@rx (?i)(?:Warning.*sqlite_.*|Warning.*SQLite3::|SQLite/JDBCDriver|SQLite\.Exception|System\.Data\.SQLite\.SQLiteException)" \
     "id:951250,\
     phase:4,\
     block,\
@@ -403,14 +358,11 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'capec/1000/118/116/54',\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    chain"
-    SecRule RESPONSE_BODY "@rx (?i)(?:Warning.*sqlite_.*|Warning.*SQLite3::|SQLite/JDBCDriver|SQLite\.Exception|System\.Data\.SQLite\.SQLiteException)" \
-        "capture,\
-        ctl:auditLogParts=+E,\
-        setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
+    ctl:auditLogParts=+E,\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:sql_error_match "@eq 1" \
+SecRule RESPONSE_BODY "@rx (?i)(?:Sybase message:|Warning.{2,20}sybase|Sybase.*Server message.*)" \
     "id:951260,\
     phase:4,\
     block,\
@@ -427,13 +379,11 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'capec/1000/118/116/54',\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    chain"
-    SecRule RESPONSE_BODY "@rx (?i)(?:Sybase message:|Warning.{2,20}sybase|Sybase.*Server message.*)" \
-        "capture,\
-        ctl:auditLogParts=+E,\
-        setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
+    ctl:auditLogParts=+E,\
+    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
+SecMarker "END-SQL-ERROR-MATCH-PL1"
 
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:951013,phase:3,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"


### PR DESCRIPTION
Variable `TX:sql_error_match` is used to skip rules in file `RESPONSE-951-DATA-LEAKAGES-SQL.conf`. The proper solution for skipping rules should be to use `skipAfter` action, as this PR propose.

Advantages:
 - simplifying rules
 - make rules compatible with `SecRuleUpdateTargetById` (it doesn't support chained rules)
 - more readable exclusion rules as they will exclude `RESPONSE_BODY` directly instead of `TX:sql_error_match`

Disadvantages:
 - exclusion rules are not backward compatible (but can be made compatible with both versions at the same time)
