### PR TITLE
Forbid range header at PL3

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -321,7 +321,7 @@ SecRule &REQUEST_HEADERS:Range "@gt 0" \
     tag:'capec/1000/210/272/220',\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
 # -=[ HTTP Parameter Pollution ]=-

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -295,6 +295,35 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:921016,phase:2,pass,nolog,skipAf
 #
 #
 
+# Forbid Request Range Header
+#
+# It is possible abuse the HTTP Request Range Header to leak error pages
+# and other information in very small snippets.
+# The easiest way to fight this is to deny the use of this header.
+# This is a viable option since the header is only used in rare circumstances
+# anymore.
+# If it is necessary to use it in a certain setup, then it is best to
+# create a rule exclusion for a given URI and this rule ID as a workaround.
+#
+SecRule &REQUEST_HEADERS:Range "@gt 0" \
+    "id:921230,\
+    phase:1,\
+    block,\
+    t:none,\
+    msg:'HTTP Range Header detected',\
+    logdata:'Matched Data: Header %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    tag:'paranoia-level/3',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/210/272/220',\
+    ver:'OWASP_CRS/4.0.0-rc1',\
+    severity:'CRITICAL',\
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+
+
 # -=[ HTTP Parameter Pollution ]=-
 #
 # [ Rule Logic ]

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921230.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921230.yaml
@@ -1,0 +1,22 @@
+---
+meta:
+  author: "Christian Folini (dune73)"
+  description: "HTTP Range Header"
+  enabled: true
+  name: 921230.yaml
+tests:
+  - test_title: 921230-1
+    desc: "Submit HTTP Range Header, forbidden at PL3 by default"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Range: 1-2
+            port: 80
+            uri: "/"
+          output:
+            log_contains: id "921230"


### PR DESCRIPTION
This fixes bug bounty finding M4IXRHRZ, an exploit that abuses the HTTP request Range header.

Range header seems to have fallen out of fashion. Chrome and Firefox no longer use it on PDFs it seems
and youtube does not use it either anymore. By denying it for PL3, we deny it for high security setups
and if they need it, they can write a rule exclusion for a a specific URI.

We could play around with minimal ranges etc. at PL2 to mitigate this, but this would be very complicated and it is not sure if not a hacker would still find a way around it. 

Also: This is only an exploit that allows you to extract a response that would otherwise be blocked. For it to
work, there has to be a weakness on the backend. So it's a combination of multiple weaknesses and we do not necessarily need to address that below PL3.