### PR TITLE
fix (regexp-assemble): handle multiple templates on same line

### DIFF
--- a/util/regexp-assemble/lib/processors/template.py
+++ b/util/regexp-assemble/lib/processors/template.py
@@ -41,7 +41,12 @@ class Template(Processor):
             self.logger.debug('Found template %s in line %s', self.identifier, line)
             # need to use a function as the replacement to prevent Python from parsing
             # escape sequences
-            transformed_line = self.template_regex.sub(lambda _: self.replacement, line)
+            def replacer(matchobj):
+                if matchobj.group(1) == self.identifier:
+                    return self.replacement
+                else:
+                    return matchobj.group(0)
+            transformed_line = self.template_regex.sub(replacer, line)
             self.lines.append(transformed_line)
             self.logger.debug('Transformed line: %s', transformed_line)
         else:

--- a/util/regexp-assemble/tests/preprocessor_test.py
+++ b/util/regexp-assemble/tests/preprocessor_test.py
@@ -503,16 +503,53 @@ other
 
         assert output == r'\n\s\b\v\t'
 
-    
-    def test_template1(self, context):
+
+    def test_template_replaces_only_specified_template(self, context):
         contents = r'''##!> template slashes [/\]
-regex with {{slashes}}
+regex with {{slashes}} and {{dots}}
 '''
         assembler = Assembler(context)
 
         output = assembler._run(Peekerator(contents.splitlines()))
 
-        assert output == r'regex with [\/\]'
+        # TODO: Regexp::Assemble is inconsistent with escaping forward slashes in
+        # character classes. They should either be consistently escaped or not.
+        assert output == r'regex with [\/\] and {{dots}}'
+
+    def test_template_replaces_all(self, context):
+        contents = r'''##!> template slashes [/\]
+##!> template dots [.,;]
+regex with {{slashes}} and {{dots}}
+'''
+        assembler = Assembler(context)
+
+        output = assembler._run(Peekerator(contents.splitlines()))
+
+        # TODO: Regexp::Assemble is inconsistent with escaping forward slashes in
+        # character classes. They should either be consistently escaped or not.
+        assert output == r'regex with [/\] and [.,;]'
+
+    def test_template_replaces_on_all_lines(self, context):
+        contents = r'''##!> template slashes [/\]
+##!> template dots [.,;]
+##!> template other {{slashes}}+
+{{slashes}}
+##!=>
+{{dots}}
+##!=>
+regex with {{slashes}} and {{dots}}
+##!=>
+{{other}}
+##!=>
+'''
+        assembler = Assembler(context)
+
+        output = assembler._run(Peekerator(contents.splitlines()))
+
+        # TODO: Regexp::Assemble is inconsistent with escaping forward slashes in
+        # character classes. They should either be consistently escaped or not.
+        assert output == r'[\/\][.,;]regex with [/\] and [.,;][\/\]+'
+
 
 class TestIncludePreprocessor:
     def test_fails_for_missing_include_name(self, context):


### PR DESCRIPTION
When a line contains multiple template identifiers, regexp-assemble will
no longer replace all identifiers with the value of the first but only
the matching identifier.