### PR TITLE
fix (regexp-assemble): process all lines for each template

### DIFF
--- a/util/regexp-assemble/lib/processors/assemble.py
+++ b/util/regexp-assemble/lib/processors/assemble.py
@@ -78,9 +78,11 @@ class Assemble(Processor):
         if not identifier:
             raise ValueError('missing identifier for input marker')
 
-        regex = self._run_assembler()
-        self.logger.debug('Storing expression at %s: %s', identifier, regex)
-        self.stash[identifier] = self.output + regex
+        self._append(None)
+        self.logger.debug('Storing expression at %s: %s', identifier, self.output)
+        self.stash[identifier] = self.output
+        # reset output, the next call to `complete` should not print
+        # the value we just stored
         self.output = ''
 
     def _append(self, identifier:str):


### PR DESCRIPTION
The template processor applies to every following line and can be used
in definitions of other processors. Contrary to the other processors,
the template processor must, therefore, run on all lines and has to run
before any other processor.

Originally, there used to be different types
of processors with file, block, and line scopes; the template processor
broke when this idea was removed in favor of always using block scope.