### PR TITLE
feat (regexp-assemble): Add alternate suffix evasion pattern

### DIFF
--- a/util/regexp-assemble/lib/processors/cmdline.py
+++ b/util/regexp-assemble/lib/processors/cmdline.py
@@ -28,11 +28,12 @@ T = TypeVar('T', bound='CmdLine')
 
 
 class CmdLine(Processor):
-    def __init__(self, context: Context, evasion_pattern: str, suffix_evasion_pattern: str):
+    def __init__(self, context: Context, evasion_pattern: str, suffix_evasion_pattern: str, suffix_evasion_pattern_no_space: str):
         super().__init__(context)
 
         self.evasion_pattern = evasion_pattern
         self.suffix_evasion_pattern = suffix_evasion_pattern
+        self.suffix_evasion_pattern_no_space = suffix_evasion_pattern_no_space
 
     # override
     @classmethod
@@ -90,6 +91,8 @@ class CmdLine(Processor):
         char = str.replace(char, '-', '\-')
         if char == '@':
             char = str.replace(char, '@', self.suffix_evasion_pattern)
+        elif char == '~':
+            char = str.replace(char, '~', self.suffix_evasion_pattern_no_space)
 
         # Ensure multiple spaces are matched
         return str.replace(char, ' ', '\s+')
@@ -104,6 +107,10 @@ class CmdLineUnix(CmdLine):
             r'''[\x5c'\"]*''',
             # Unix: "cat foo", "cat<foo", "cat>foo"
             r'''(?:\s|<|>).*''',
+            # Same as above but does not allow any white space as the next token.
+            # This is useful for thing like `python3`, where `python@` would
+            # create too many false positives because it would match `python `.
+            r'''(?:<|>).*''',
         )
 
 
@@ -117,4 +124,8 @@ class CmdLineWindows(CmdLine):
             # Windows: "more foo", "more,foo", "more;foo", "more.com", "more/e",
             # "more<foo", "more>foo"
             r'''(?:[\s,;]|\.|/|<|>).*''',
+            # Same as above but does not allow any white space as the next token.
+            # This is useful for thing like `python3`, where `python@` would
+            # create too many false positives because it would match `python `.
+            r'''(?:[,;]|\.|/|<|>).*''',
         )

--- a/util/regexp-assemble/tests/preprocessor_test.py
+++ b/util/regexp-assemble/tests/preprocessor_test.py
@@ -371,6 +371,16 @@ class TestCmdLinePreprocessor:
 
         assert len(output) == 1
         assert output[0] == r'''f[\"\^]*o[\"\^]*o[\"\^]*(?:[\s,;]|\.|/|<|>).*'''
+
+    def test_tilde_adds_windows_suffix_evasion_no_space(self, context):
+        contents = 'foo~'
+        assemble = CmdLine.create(context, ['windows'])
+
+        assemble.process_line(contents)
+        output = assemble.complete()
+
+        assert len(output) == 1
+        assert output[0] == r'''f[\"\^]*o[\"\^]*o[\"\^]*(?:[,;]|\.|/|<|>).*'''
     
     def test_at_adds_unix_anti_evasion_suffix(self, context):
         contents = 'foo@'
@@ -381,6 +391,17 @@ class TestCmdLinePreprocessor:
 
         assert len(output) == 1
         assert output[0] == r'''f[\x5c'\"]*o[\x5c'\"]*o[\x5c'\"]*(?:\s|<|>).*'''
+
+    def test_tilde_adds_no_space_suffix_evasion(self, context):
+        contents = 'foo~'
+        assemble = CmdLine.create(context, ['unix'])
+
+        assemble.process_line(contents)
+        output = assemble.complete()
+
+        assert len(output) == 1
+        assert output[0] == r'''f[\x5c'\"]*o[\x5c'\"]*o[\x5c'\"]*(?:<|>).*'''
+
 
     def test_literal_has_precendence_over_other_operations(self, context):
         contents = r''''foo@.-    '''


### PR DESCRIPTION
The tilde (`~`) symbol can now be used instead of the at (`@`) symbol in
the commandline processor to specify that a word must be followed by the
same tokens as with `@`, except for white space. This makes it possible
to put common english words into word lists, like `python~`. `python@`
would create too many false positives, as `python ` would match.

See discussion in #2677.