### PR TITLE
Remove some default content-type

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -434,14 +434,34 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 
 # Content-Types that a client is allowed to send in a request.
 # Default: |application/x-www-form-urlencoded| |multipart/form-data| |multipart/related|
-# |text/xml| |application/xml| |application/soap+xml| |application/x-amf| |application/json|
-# |application/cloudevents+json| |application/cloudevents-batch+json| |application/octet-stream|
-# |application/csp-report| |application/xss-auditor-report| |text/plain|
-# Uncomment this rule to change the default.
+# |text/xml| |application/xml| |application/soap+xml| |application/json|
+# |application/cloudevents+json| |application/cloudevents-batch+json|
 #
 # Please note, that the rule where CRS uses this variable (920420) evaluates it with operator
 # `@within`, which is case sensitive, but uses t:lowercase. You must add your whole custom
 # Content-Type with lowercase.
+#
+# Bypass Warning: some applications may not rely on the content-type request header in order
+# to parse the request body. This could make an attacker able to send malicious URLENCODED/JSON/XML
+# payloads without being detected by the WAF. Allowing request content-type that doesn't activate any
+# body processor (for example: "text/plain", "application/x-amf", "application/octet-stream", etc..)
+# could lead to a WAF bypass. For example, a malicious JSON payload submitted with a "text/plain"
+# content type may still be interpreted as JSON by a backend application but would not trigger the
+# JSON body parser at the WAF, leading to a bypass.
+#
+# To prevent blocking request with not allowed content-type by default, you can create an exclusion
+# rule that removes rule 920420. For example:
+# SecRule REQUEST_HEADERS:Content-Type "@rx ^text/plain" \
+#  "id:1234,\
+#  phase:1,\
+#  nolog,\
+#  pass,\
+#  t:none,\
+#  ctl:ruleRemoveById=920420,\
+#  chain"
+#  SecRule REQUEST_URI "@rx ^/foo/bar" "t:none"
+#
+# Uncomment this rule to change the default.
 #
 #SecAction \
 # "id:900220,\
@@ -449,7 +469,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  nolog,\
 #  pass,\
 #  t:none,\
-#  setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |multipart/related| |text/xml| |application/xml| |application/soap+xml| |application/x-amf| |application/json| |application/cloudevents+json| |application/cloudevents-batch+json| |application/octet-stream| |application/csp-report| |application/xss-auditor-report| |text/plain|'"
+#  setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |multipart/related| |text/xml| |application/xml| |application/soap+xml| |application/json| |application/cloudevents+json| |application/cloudevents-batch+json|'"
 
 # Allowed HTTP versions.
 # Default: HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -201,7 +201,7 @@ SecRule &TX:allowed_request_content_type "@eq 0" \
     pass,\
     nolog,\
     ver:'OWASP_CRS/4.0.0-rc1',\
-    setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |multipart/related| |text/xml| |application/xml| |application/soap+xml| |application/x-amf| |application/json| |application/cloudevents+json| |application/cloudevents-batch+json| |application/octet-stream| |application/csp-report| |application/xss-auditor-report| |text/plain|'"
+    setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |multipart/related| |text/xml| |application/xml| |application/soap+xml| |application/json| |application/cloudevents+json| |application/cloudevents-batch+json|'"
 
 # Default HTTP policy: allowed_request_content_type_charset (rule 900270)
 SecRule &TX:allowed_request_content_type_charset "@eq 0" \

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920420.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920420.yaml
@@ -266,3 +266,73 @@ tests:
             data: "test"
           output:
             no_log_contains: "id \"920420\""
+  - test_title: 920420-14
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "POST"
+            port: 80
+            headers:
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: text/plain
+            data: 'cmd=/bin/unxz -c /var/log/something_sensitive.xz'
+            protocol: "http"
+          output:
+            log_contains: "id \"920420\""
+  - test_title: 920420-15
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Host: localhost
+              Proxy-Connection: keep-alive
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Content-Type: text/plain
+            method: GET
+            port: 80
+            uri: /
+            version: HTTP/1.0
+            data: "{\"foo\" : \";+cat+/e\\\\t\\\\*/pa\\\\?s\\\\wd\"}"
+          output:
+            log_contains: "id \"920420\""
+  - test_title: 920420-16
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Host: localhost
+              Proxy-Connection: keep-alive
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Content-Type: application/x-amf
+            method: GET
+            port: 80
+            uri: /
+            version: HTTP/1.0
+            data: "{\"foo\" : \";+cat+/e\\\\t\\\\*/pa\\\\?s\\\\wd\"}"
+          output:
+            log_contains: "id \"920420\""
+  - test_title: 920420-17
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Host: localhost
+              Proxy-Connection: keep-alive
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Content-Type: application/octet-stream
+            method: GET
+            port: 80
+            uri: /
+            version: HTTP/1.0
+            data: "{\"foo\" : \";+cat+/e\\\\t\\\\*/pa\\\\?s\\\\wd\"}"
+          output:
+            log_contains: "id \"920420\""


### PR DESCRIPTION
As we decided during the last meeting, this PR removes all previous allowed-by-default content-types that can't be parsed by any body-processor. The idea here is to warn the user about allowing content-type like "text/plain" and give a bit of advice on how to allow it on specific paths using a SecRule.

Any review is welcome, also for the comment wording.