### PR TITLE
fix(921422) Added \b to groups to avoid unwanted FP's

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -335,7 +335,7 @@ SecRule ARGS_GET "@rx [\n\r]" \
 # (consult util/regexp-assemble/README.md for details):
 #   util/regexp-assemble/regexp-assemble.py update 921422
 #
-SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s,]+[;\s,].*?(?:(audio|image|video|csv|css|vnd|pdf|plain|json|soap|xml|x-www-form-urlencoded|form-data|related|x-amf|octet|stream|csp|report)|(text|multipart|application)|(\/|\+))" \
+SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s,]+[;\s,].*?\b(?:(audio|image|video|csv|css|vnd|pdf|plain|json|soap|xml|x-www-form-urlencoded|form-data|related|x-amf|octet|stream|csp|report)|(text|multipart|application)|(\/|\+))\b" \
     "id:921422,\
     phase:1,\
     block,\

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921422.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921422.yaml
@@ -261,3 +261,19 @@ tests:
             version: HTTP/1.1
           output:
             no_log_contains: id "921422"
+  - test_title: 921422-17
+    desc: Negative test for rule 921422-9
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Content-Type: multipart/form-data; boundary=----webkitformboundary12w4lszoxn26vnd
+            method: POST
+            port: 80
+            uri: /post
+            version: HTTP/1.1
+          output:
+            no_log_contains: id "921422"

--- a/util/regexp-assemble/data/921422.data
+++ b/util/regexp-assemble/data/921422.data
@@ -4,6 +4,6 @@
 ##! Attacks attempting to bypass content-type restrictions or behaviour
 ##! Find Content-Type: application/x-www-form-urlencoded;boundary="multipart/form-data"
 ##! Find Content-Type: application/soap-xml;boundary="multipart/form-data"
-^[^;\s,]+[;\s,].*?(text|multipart|application)
-^[^;\s,]+[;\s,].*?(audio|image|video|csv|css|vnd|pdf|plain|json|soap|xml|x-www-form-urlencoded|form-data|related|x-amf|octet|stream|csp|report)
-^[^;\s,]+[;\s,].*?(\/|\+)
+^[^;\s,]+[;\s,].*?\b(text|multipart|application)\b
+^[^;\s,]+[;\s,].*?\b(audio|image|video|csv|css|vnd|pdf|plain|json|soap|xml|x-www-form-urlencoded|form-data|related|x-amf|octet|stream|csp|report)\b
+^[^;\s,]+[;\s,].*?\b(\/|\+)\b


### PR DESCRIPTION
Added `\b` to groups of 921422's regex.

Also added a negative test based on reported issue.

This PR fixes #2783.