### PR TITLE
chore: remove user-agentt from restricted headers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,7 +48,6 @@ New functionality and detections:
  * Detect CensysInspect and seoscanners.net crawlers (Andrew Howe) [#2155]
  * Detect burpcollaborator scanner (Amir Hosein Aliakbarian) [#2152]
  * Detect QQGameHall malware (Walter Hop) [#2144]
- * Detect zerodium PHP backdoor: 'User-Agentt' (Andrea Menin) [#2048]
  * Detect 'httpx' scanner (Will Woodson) [#2045]
  * Detect 'ecairn' crawler (Jozef Sudolský) [#2024]
  * Detect LeakIX scanner (Jozef Sudolský) [#1961]

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -509,7 +509,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 
 # Forbidden request headers.
 # Header names should be lowercase, enclosed by /slashes/ as delimiters.
-# Default: /accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /user-agentt/
+# Default: /accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/
 #
 # Note: Accept-Charset is a deprecated header that should not be used by clients and
 # ignored by servers. It can be used for a response WAF bypass, by asking for a charset
@@ -532,7 +532,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  nolog,\
 #  pass,\
 #  t:none,\
-#  setvar:'tx.restricted_headers=/accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /user-agentt/'"
+#  setvar:'tx.restricted_headers=/accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/'"
 
 # Content-Types charsets that a client is allowed to send in a request.
 # The content-types are enclosed by |pipes| as delimiters to guarantee exact matches.

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -237,7 +237,7 @@ SecRule &TX:restricted_headers "@eq 0" \
     pass,\
     nolog,\
     ver:'OWASP_CRS/4.0.0-rc1',\
-    setvar:'tx.restricted_headers=/accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /user-agentt/'"
+    setvar:'tx.restricted_headers=/accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/'"
 
 # Default enforcing of body processor URLENCODED
 SecRule &TX:enforce_bodyproc_urlencoded "@eq 0" \


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Fixes #2695.