### PR TITLE
fix(regexp-assemble): tilde flag also matches extended commands

### DIFF
--- a/util/regexp-assemble/tests/preprocessor_test.py
+++ b/util/regexp-assemble/tests/preprocessor_test.py
@@ -1,3 +1,4 @@
+import re
 import pytest
 from pathlib import Path
 
@@ -372,15 +373,34 @@ class TestCmdLinePreprocessor:
         assert len(output) == 1
         assert output[0] == r'''f[\"\^]*o[\"\^]*o[\"\^]*(?:[\s,;]|\.|/|<|>).*'''
 
-    def test_tilde_adds_windows_suffix_evasion_no_space(self, context):
-        contents = 'foo~'
+        regex = re.compile(output[0])
+        match = regex.match('foo10<<<foo')
+        assert match is None
+        match = regex.match('foo<<<foo')
+        assert match is not None
+        assert match.group(0) == 'foo<<<foo'
+
+    def test_tilde_adds_windows_expanded_command_suffix_evasion(self, context):
+        contents = 'gcc~'
         assemble = CmdLine.create(context, ['windows'])
 
         assemble.process_line(contents)
         output = assemble.complete()
 
         assert len(output) == 1
-        assert output[0] == r'''f[\"\^]*o[\"\^]*o[\"\^]*(?:[,;]|\.|/|<|>).*'''
+        assert output[0] == r'''g[\"\^]*c[\"\^]*c[\"\^]*(?:(?:[,;]|\.|/|<|>)|(?:[\w\d._-][\"\^]*)+(?:[\s,;]|\.|/|<|>)).*'''
+
+        regex = re.compile(output[0])
+        match = regex.match('gcc foo')
+        assert match is None
+
+        match = regex.match('gcc10.1 foo')
+        assert match is not None
+        assert match.group(0) == 'gcc10.1 foo'
+
+        match = regex.match('gcc10.1<<<foo')
+        assert match is not None
+        assert match.group(0) == 'gcc10.1<<<foo'
     
     def test_at_adds_unix_anti_evasion_suffix(self, context):
         contents = 'foo@'
@@ -392,16 +412,34 @@ class TestCmdLinePreprocessor:
         assert len(output) == 1
         assert output[0] == r'''f[\x5c'\"]*o[\x5c'\"]*o[\x5c'\"]*(?:\s|<|>).*'''
 
-    def test_tilde_adds_no_space_suffix_evasion(self, context):
-        contents = 'foo~'
+        regex = re.compile(output[0])
+        match = regex.match('foo10<<<foo')
+        assert match is None
+        match = regex.match('foo<<<foo')
+        assert match is not None
+        assert match.group(0) == 'foo<<<foo'
+
+    def test_tilde_adds_unix_expanded_command_suffix_evasion(self, context):
+        contents = 'gcc~'
         assemble = CmdLine.create(context, ['unix'])
 
         assemble.process_line(contents)
         output = assemble.complete()
 
         assert len(output) == 1
-        assert output[0] == r'''f[\x5c'\"]*o[\x5c'\"]*o[\x5c'\"]*(?:<|>).*'''
+        assert output[0] == r'''g[\x5c'\"]*c[\x5c'\"]*c[\x5c'\"]*(?:(?:<|>)|(?:[\w\d._-][\x5c'\"]*)+(?:\s|<|>)).*'''
 
+        regex = re.compile(output[0])
+        match = regex.match('gcc foo')
+        assert match is None
+
+        match = regex.match('gcc10.1 foo')
+        assert match is not None
+        assert match.group(0) == 'gcc10.1 foo'
+
+        match = regex.match('gcc10.1<<<foo')
+        assert match is not None
+        assert match.group(0) == 'gcc10.1<<<foo'
 
     def test_literal_has_precendence_over_other_operations(self, context):
         contents = r''''foo@.-    '''


### PR DESCRIPTION
The tilde flag of the cmdline processor will now correctly match `python<<<foo` and also `python2 foo`. It will not match `python foo`.