### PR TITLE
fix(0FA9HCGT): rce alias builtin detection

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -615,6 +615,49 @@ SecRule ARGS_NAMES|ARGS|FILES_NAMES "@rx ^\(\s*\)\s+{" \
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
+# [ Unix shell alias detection ]
+#
+# Detects Unix shell alias invocations in any context.
+#
+# Example:
+#   GET /?rce=alias%20a=b
+#
+# Shell aliasing can be performed to substitute anything in commands, escaping
+#
+# References: https://pubs.opengroup.org/onlinepubs/007904975/basedefs/xbd_chap03.html#tag_03_10 :
+# "In the shell command language, a word consisting solely of underscores, digits, and alphabetics
+# from the portable character set and any of the following characters: '!', '%', ',', '@'."
+#
+# Implementations may allow other characters within alias names as an extension.
+#
+# Regular expression generated from util/regexp-assemble/data/932175.data.
+# To update the regular expression run the following shell script
+# (consult util/regexp-assemble/README.md for details):
+#   util/regexp-assemble/regexp-assemble.py update 932175
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \ba[\x5c'\"]*l[\x5c'\"]*i[\x5c'\"]*a[\x5c'\"]*s\b\s+['\"\w!%,@]+=\S" \
+    "id:932175,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'Remote Command Execution: Unix shell alias invocation',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-shell',\
+    tag:'platform-unix',\
+    tag:'attack-rce',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/248/88',\
+    tag:'PCI/6.5.2',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/4.0.0-rc1',\
+    severity:'CRITICAL',\
+    setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+
 #
 # -=[ Restricted File Upload ]=-
 #

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932175.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932175.yaml
@@ -1,0 +1,149 @@
+---
+meta:
+  author: "Felipe Zipitria"
+  description: "Remote Command Execution: shell aliasing detection"
+  enabled: true
+  name: 932175.yaml
+tests:
+  - test_title: 932175-1
+    desc: "Test for 0FA9HCGT alias eennvv=env&eennvv whoami"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: GET
+            port: 80
+            uri: /get?rce=alias%20eennvv%3Denv%26eennvv%20whoami
+            version: HTTP/1.1
+          output:
+            log_contains: id "932175"
+  - test_title: 932175-2
+    desc: "Test for alias with shell tricks"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: POST
+            port: 80
+            uri: /post
+            data: |
+              rce=alias a=c${KK}url&a google.com
+            version: HTTP/1.1
+          output:
+            log_contains: id "932175"
+  - test_title: 932175-3
+    desc: "Test for alias name with single quoting"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: POST
+            port: 80
+            uri: /post
+            data: |
+              rce=alias 'letter'=curl&letter google.com
+            version: HTTP/1.1
+          output:
+            log_contains: id "932175"
+  - test_title: 932175-4
+    desc: "Test for alias name with double quotes"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: POST
+            port: 80
+            uri: /post
+            data: |
+              rce=alias "quote"=curl&quote google.com
+            version: HTTP/1.1
+          output:
+            log_contains: id "932175"
+  - test_title: 932175-5
+    desc: "Test for alias value with single quoting"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: POST
+            port: 80
+            uri: /post
+            data: |
+              rce=alias alias='curl'&letter google.com
+            version: HTTP/1.1
+          output:
+            log_contains: id "932175"
+  - test_title: 932175-6
+    desc: "Test for alias value with double quotes"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: POST
+            port: 80
+            uri: /post
+            data: |
+              rce=alias double="curl"&quote google.com
+            version: HTTP/1.1
+          output:
+            log_contains: id "932175"
+  - test_title: 932175-7
+    desc: "Negative test alias"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: POST
+            port: 80
+            uri: /post
+            data: |
+              "text=I%20see%2C%20so%20your%20alias%20is%20not%20%3D%20to%20your%20name"
+            version: HTTP/1.1
+          output:
+            no_log_contains: id "932175"
+  - test_title: 932175-8
+    desc: "Negative test alias with quotes"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: POST
+            port: 80
+            uri: /post
+            data: |
+              "text=The%20pizza%20vendor%20was%20known%20by%20the%20alias%20%22pineapple%22%20online."
+            version: HTTP/1.1
+          output:
+            no_log_contains: id "932175"

--- a/util/regexp-assemble/data/932175.data
+++ b/util/regexp-assemble/data/932175.data
@@ -1,0 +1,27 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regexp_assemble/.
+
+##! Prevent command aliasing
+
+##! starting tokens prefix
+##!> assemble
+\b
+##!=>
+    ##!> cmdline unix
+alias
+    ##!<
+##!=>
+
+##! match white space between command and arguments
+\b\s+
+##!=>
+
+##! match the alias name
+['"\w!%,@]+
+##!=>
+
+##! match equals something
+=\S
+##!=>
+
+##!<


### PR DESCRIPTION
Add new rule to include `alias` builtin detection.

Fixes #2670.