### PR TITLE
Set default value of crs_validate_utf8_encoding TX variable

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -248,6 +248,15 @@ SecRule &TX:enforce_bodyproc_urlencoded "@eq 0" \
     ver:'OWASP_CRS/4.0.0-rc1',\
     setvar:'tx.enforce_bodyproc_urlencoded=0'"
 
+# Default check for UTF8 encoding validation
+SecRule &TX:crs_validate_utf8_encoding "@eq 0" \
+    "id:901168,\
+    phase:1,\
+    pass,\
+    nolog,\
+    ver:'OWASP_CRS/4.0.0-rc1',\
+    setvar:'tx.crs_validate_utf8_encoding=0'"
+
 #
 # -=[ Initialize internal variables ]=-
 #

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -250,7 +250,7 @@ SecRule &TX:enforce_bodyproc_urlencoded "@eq 0" \
 
 # Default check for UTF8 encoding validation
 SecRule &TX:crs_validate_utf8_encoding "@eq 0" \
-    "id:901168,\
+    "id:901169,\
     phase:1,\
     pass,\
     nolog,\


### PR DESCRIPTION
I'm working on some new features for `util/crs-rules-check/rules-check.py` script. Before I push them, we need to fix some errors.

This fix sets up the missing default value of a TX variable. There is no other case like this, all other TX variable has default value.