### PR TITLE
Remove unnecessary escaping

### DIFF
--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -727,7 +727,7 @@ SecRule REQUEST_FILENAME|REQUEST_HEADERS:Referer "@detectXSS" \
 #
 # This rule has been moved to PL2 since it has a tendency to trigger on random input.
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\"'`;\/0-9=\x0B\x09\x0C\x3B\x2C\x28\x3B]on[a-zA-Z]{3,25}[\s\x0B\x09\x0C\x3B\x2C\x28\x3B]*?=[^=]" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\"'`;/0-9=\x0B\x09\x0C\x3B\x2C\x28\x3B]on[a-zA-Z]{3,25}[\s\x0B\x09\x0C\x3B\x2C\x28\x3B]*?=[^=]" \
     "id:941120,\
     phase:2,\
     block,\


### PR DESCRIPTION
PR resolves #2657 by removing all unnecessary escapes of forward slashes in regular expression patterns (excludes compiled/optimised patterns, which may still escape forward slashes).

Only one instance of an unnecessary escape was found.