### PR TITLE
feat(ci): show logs from containers startup

### DIFF
--- a/.github/workflows/go-ftw.yml
+++ b/.github/workflows/go-ftw.yml
@@ -31,6 +31,8 @@ jobs:
         run: |
           mkdir -p tests/logs/${{ matrix.modsec_version }}/{nginx,apache2}
           docker-compose -f ./tests/docker-compose.yml up -d "${{ matrix.modsec_version }}"
+          docker-compose -f ./tests/docker-compose.yml logs
+          [ $(docker inspect ${{ matrix.modsec_version }} --format='{{.State.Running}}') = 'true' ]
           ./ftw check -d tests/regression/tests
           ./ftw run -d tests/regression/tests
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,8 @@ jobs:
         run: |
           mkdir -p tests/logs/${{ matrix.modsec_version }}/{nginx,apache2}
           docker-compose -f ./tests/docker-compose.yml up -d "${{ matrix.modsec_version }}"
+          docker-compose -f ./tests/docker-compose.yml logs
+          [ $(docker inspect ${{ matrix.modsec_version }} --format='{{.State.Running}}') = 'true' ]
           # Use mounted volume path
           py.test -vs --tb=short tests/regression/CRS_Tests.py \
             --config="${{ matrix.modsec_version }}" \


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

There are failures sometimes when containers start because we mess with variables or files that might affect modsec when starting. This PR should at least show logs of the start process so we can see the errors in the CI logs.