### PR TITLE
Make rule backreferences consistent and correct

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -116,7 +116,7 @@ SecRule &TX:blocking_paranoia_level "@eq 0" \
     ver:'OWASP_CRS/4.0.0-rc1',\
     setvar:'tx.blocking_paranoia_level=1'"
 
-# Default Detection Paranoia Level (rule 900000 in crs-setup.conf)
+# Default Detection Paranoia Level (rule 900001 in crs-setup.conf)
 SecRule &TX:detection_paranoia_level "@eq 0" \
     "id:901125,\
     phase:1,\
@@ -185,7 +185,7 @@ SecRule &TX:reput_block_duration "@eq 0" \
     ver:'OWASP_CRS/4.0.0-rc1',\
     setvar:'tx.reput_block_duration=300'"
 
-# Default HTTP policy: allowed_methods (rule 900200)
+# Default HTTP policy: allowed_methods (rule 900200 in crs-setup.conf)
 SecRule &TX:allowed_methods "@eq 0" \
     "id:901160,\
     phase:1,\
@@ -194,7 +194,7 @@ SecRule &TX:allowed_methods "@eq 0" \
     ver:'OWASP_CRS/4.0.0-rc1',\
     setvar:'tx.allowed_methods=GET HEAD POST OPTIONS'"
 
-# Default HTTP policy: allowed_request_content_type (rule 900220)
+# Default HTTP policy: allowed_request_content_type (rule 900220 in crs-setup.conf)
 SecRule &TX:allowed_request_content_type "@eq 0" \
     "id:901162,\
     phase:1,\
@@ -203,7 +203,7 @@ SecRule &TX:allowed_request_content_type "@eq 0" \
     ver:'OWASP_CRS/4.0.0-rc1',\
     setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |multipart/related| |text/xml| |application/xml| |application/soap+xml| |application/json| |application/cloudevents+json| |application/cloudevents-batch+json|'"
 
-# Default HTTP policy: allowed_request_content_type_charset (rule 900270)
+# Default HTTP policy: allowed_request_content_type_charset (rule 900280 in crs-setup.conf)
 SecRule &TX:allowed_request_content_type_charset "@eq 0" \
     "id:901168,\
     phase:1,\
@@ -212,7 +212,7 @@ SecRule &TX:allowed_request_content_type_charset "@eq 0" \
     ver:'OWASP_CRS/4.0.0-rc1',\
     setvar:'tx.allowed_request_content_type_charset=|utf-8| |iso-8859-1| |iso-8859-15| |windows-1252|'"
 
-# Default HTTP policy: allowed_http_versions (rule 900230)
+# Default HTTP policy: allowed_http_versions (rule 900230 in crs-setup.conf)
 SecRule &TX:allowed_http_versions "@eq 0" \
     "id:901163,\
     phase:1,\
@@ -221,7 +221,7 @@ SecRule &TX:allowed_http_versions "@eq 0" \
     ver:'OWASP_CRS/4.0.0-rc1',\
     setvar:'tx.allowed_http_versions=HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0'"
 
-# Default HTTP policy: restricted_extensions (rule 900240)
+# Default HTTP policy: restricted_extensions (rule 900240 in crs-setup.conf)
 SecRule &TX:restricted_extensions "@eq 0" \
     "id:901164,\
     phase:1,\
@@ -230,7 +230,7 @@ SecRule &TX:restricted_extensions "@eq 0" \
     ver:'OWASP_CRS/4.0.0-rc1',\
     setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .rdb/ .resources/ .resx/ .sql/ .swp/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'"
 
-# Default HTTP policy: restricted_headers (rule 900250)
+# Default HTTP policy: restricted_headers (rule 900250 in crs-setup.conf)
 SecRule &TX:restricted_headers "@eq 0" \
     "id:901165,\
     phase:1,\
@@ -239,7 +239,7 @@ SecRule &TX:restricted_headers "@eq 0" \
     ver:'OWASP_CRS/4.0.0-rc1',\
     setvar:'tx.restricted_headers=/accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/'"
 
-# Default enforcing of body processor URLENCODED
+# Default enforcing of body processor URLENCODED (rule 900010 in crs-setup.conf)
 SecRule &TX:enforce_bodyproc_urlencoded "@eq 0" \
     "id:901167,\
     phase:1,\
@@ -248,7 +248,7 @@ SecRule &TX:enforce_bodyproc_urlencoded "@eq 0" \
     ver:'OWASP_CRS/4.0.0-rc1',\
     setvar:'tx.enforce_bodyproc_urlencoded=0'"
 
-# Default check for UTF8 encoding validation
+# Default check for UTF8 encoding validation (rule 900950 in crs-setup.conf)
 SecRule &TX:crs_validate_utf8_encoding "@eq 0" \
     "id:901169,\
     phase:1,\


### PR DESCRIPTION
Most of the rules in `REQUEST-901-INITIALIZATION.conf` feature a reference back to the corresponding rule in `crs-setup.conf`.

This PR makes all of these backreferences consistent and corrects a handful of the rule IDs.

Associated issue: #2814.