### PR TITLE
fix(sqli): add finding N9FKP2XQ

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -781,7 +781,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # (consult util/regexp-assemble/README.md for details):
 #   util/regexp-assemble/regexp-assemble.py update 932210
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx ;\s*\.\s*(?:s(?:e(?:parator|lftest|ssion)|c(?:anstats|hema)|h(?:a3sum|ell|ow)|ystem|tats|ave)|t(?:estc(?:ase|trl)|ime(?:out|r)|ables|race)|e(?:x(?:p(?:lain|ert)|cel|it)|cho|qp)|p(?:r(?:o(?:gress|mpt)|int)|arameter)|c(?:h(?:anges|eck)|onnection|lone|d)|d(?:b(?:config|info)|atabases|ump)|(?:n(?:ullvalu|onc)|unmodul|mod)e|i(?:mpo(?:ster|rt)|ndexes|otrace)|l(?:i(?:mi|n)t|o(?:ad|g))|b(?:a(?:ckup|il)|inary)|f(?:ullschema|ilectrl)|vfs(?:info|list|name)|re(?:cover|store|ad)|o(?:utput|nce|pen)|a(?:rchive|uth)|he(?:aders|lp)|width|quit)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx ;\s*\.\s*(?:s(?:e(?:parator|lftest|ssion)|h(?:a3sum|ell|ow)?|c(?:anstats|hema)|ystem|tats|ave)|t(?:estc(?:ase|trl)|ime(?:out|r)|ables|race)|e(?:x(?:p(?:lain|ert)|cel|it)|cho|qp)|p(?:r(?:o(?:gress|mpt)|int)|arameter)|c(?:h(?:anges|eck)|onnection|lone|d)|d(?:b(?:config|info)|atabases|ump)|(?:n(?:ullvalu|onc)|unmodul|mod)e|i(?:mpo(?:ster|rt)|ndexes|otrace)|l(?:i(?:mi|n)t|o(?:ad|g))|b(?:a(?:ckup|il)|inary)|f(?:ullschema|ilectrl)|vfs(?:info|list|name)|re(?:cover|store|ad)|o(?:utput|nce|pen)|a(?:rchive|uth)|he(?:aders|lp)|width|quit)" \
     "id:932210,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932210.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932210.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: flo405
+  author: "flo405, Franziska Bühler"
   description: SQLite System Command Execution
   enabled: true
   name: 932210.yaml
@@ -66,6 +66,22 @@ tests:
             method: GET
             port: 80
             uri: /?foo=;\n.databases
+            version: HTTP/1.0
+          output:
+            log_contains: id "932210"
+  - test_title: 932210-5
+    desc: "Fix N9FKP2XQ: .sh whoami"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: GET
+            port: 80
+            uri: /juiceshop?s=1;.sh+whoami
             version: HTTP/1.0
           output:
             log_contains: id "932210"

--- a/util/regexp-assemble/data/932210.data
+++ b/util/regexp-assemble/data/932210.data
@@ -58,6 +58,7 @@ schema
 selftest
 separator
 session
+sh
 sha3sum
 shell
 show


### PR DESCRIPTION
This PR resolves BB finding N9FKP2XQ in issue #2735 by adding `sh`, instead of only `shell`, to rule 932210.
And this PR also adds the BB test string.