### PR TITLE
fix(unicode bypass) issue #2512

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1406,6 +1406,27 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
         "t:none,\
         setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
+#
+# See reported bypass in issue:
+# https://github.com/coreruleset/coreruleset/issues/2512
+#
+SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@rx \x5cu[0-9a-fA-F]{4}" \
+    "id:920540,\
+    phase:2,\
+    block,\
+    t:none,\
+    msg:'Possible Unicode character bypass detected',\
+    logdata:'%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    tag:'paranoia-level/2',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/255/153/267/72',\
+    ver:'OWASP_CRS/4.0.0-rc1',\
+    severity:'CRITICAL',\
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:920015,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:920016,phase:2,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1217,6 +1217,32 @@ SecRule REQUEST_HEADERS:Accept "!@rx ^(?:(?:\*|[^\"(),\/:;<=>?![\x5c\]{}]+)\/(?:
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
+#
+# Unicode character bypass check for non JSON requests
+# See reported bypass in issue:
+# https://github.com/coreruleset/coreruleset/issues/2512
+#
+SecRule REQBODY_PROCESSOR "!@streq JSON" \
+    "id:920540,\
+    phase:2,\
+    block,\
+    t:none,\
+    msg:'Possible Unicode character bypass detected',\
+    logdata:'%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/255/153/267/72',\
+    ver:'OWASP_CRS/4.0.0-rc1',\
+    severity:'CRITICAL',\
+    chain"
+    SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@rx (?i)\x5cu[0-9a-f]{4}" \
+        "setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:920013,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:920014,phase:2,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
@@ -1406,27 +1432,6 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
         "t:none,\
         setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
-#
-# See reported bypass in issue:
-# https://github.com/coreruleset/coreruleset/issues/2512
-#
-SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@rx \x5cu[0-9a-fA-F]{4}" \
-    "id:920540,\
-    phase:2,\
-    block,\
-    t:none,\
-    msg:'Possible Unicode character bypass detected',\
-    logdata:'%{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-multi',\
-    tag:'attack-protocol',\
-    tag:'paranoia-level/2',\
-    tag:'OWASP_CRS',\
-    tag:'capec/1000/255/153/267/72',\
-    ver:'OWASP_CRS/4.0.0-rc1',\
-    severity:'CRITICAL',\
-    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:920015,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:920016,phase:2,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920540.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920540.yaml
@@ -18,7 +18,7 @@ tests:
               Host: "localhost"
               Content-Type: "application/x-www-form-urlencoded; charset=utf-8"
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            data: "%5Cu0061lert"
+            data: "testarg=%5Cu0061lert"
           output:
             log_contains: "id \"920540\""
   - test_title: 920540-2
@@ -34,6 +34,22 @@ tests:
               Host: "localhost"
               Content-Type: "application/x-www-form-urlencoded; charset=utf-8"
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            data: "%5Cu0065val%28%29"
+            data: "testarg=%5Cu0065val%28%29"
           output:
             log_contains: "id \"920540\""
+  - test_title: 920540-3
+    desc: "Unicode character bypass: negative test for JSON (double encoded as JSON parser decodes it)"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            method: "POST"
+            headers:
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Host: "localhost"
+              Content-Type: "application/json"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            data: "{\"testarg\": \"\x5c\x5cu0065val\"}"
+          output:
+            no_log_contains: "id \"920540\""

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920540.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920540.yaml
@@ -1,0 +1,39 @@
+---
+meta:
+  author: "Franziska Bühler"
+  description: "Unicode character bypass"
+  enabled: true
+  name: "920540.yaml"
+tests:
+  - test_title: 920540-1
+    desc: "Unicode character bypass issue #2512: alert() \u0061lert"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            method: "POST"
+            headers:
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Host: "localhost"
+              Content-Type: "application/x-www-form-urlencoded; charset=utf-8"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            data: "%5Cu0061lert"
+          output:
+            log_contains: "id \"920540\""
+  - test_title: 920540-2
+    desc: "Unicode character bypass issue #2512: eval() \u0065val()"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            method: "POST"
+            headers:
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Host: "localhost"
+              Content-Type: "application/x-www-form-urlencoded; charset=utf-8"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            data: "%5Cu0065val%28%29"
+          output:
+            log_contains: "id \"920540\""


### PR DESCRIPTION
This PR resolves the second part of issue #2512 by adding a new rule and tests.

I'm not sure how common Unicode characters are in requests. Therefore I added detection of Unicode characters in form `\u0061` as new rule at PL2. We can move this rule to an other PL if needed.

There is a similar rule I found at PL1 which detects Unicode in the form `%uff00`: [920260](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf#L457).

See referenced issue for more info and conversation.