### PR TITLE
feat(CVE-2021-40438): add rule 921240 mod_proxy attack detection

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -286,6 +286,32 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s,]+[;\s,].*?(?:(?:application(?:
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
+#
+# Rule against CVE-2021-40438:
+# A crafted request uri-path can cause mod_proxy to forward the request to an origin server choosen by the remote user.
+# This issue affects Apache HTTP Server 2.4.48 and earlier.
+# GET /?unix:AAAAAAAAAAAAA|http://coreruleset.org/
+#
+SecRule REQUEST_URI "@rx unix:[^|]*\|" \
+    "id:921240,\
+    phase:1,\
+    block,\
+    capture,\
+    t:none,t:lowercase,\
+    msg:'mod_proxy attack attempt detected',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-apache',\
+    tag:'attack-protocol',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/210/272/220/33',\
+    ver:'OWASP_CRS/4.0.0-rc1',\
+    severity:'CRITICAL',\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:921013,phase:1,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:921014,phase:2,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 #

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921240.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921240.yaml
@@ -1,0 +1,21 @@
+---
+meta:
+  author: "Franziska Bühler"
+  description: "Rule against CVE-2021-40438"
+  enabled: true
+  name: 921240.yaml
+tests:
+  - test_title: 921240-1
+    desc: "Detect attacks against mod_proxy: CVE-2021-40438"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: "/?unix:AAAAAAAAA|http://coreruleset.org/"
+          output:
+            log_contains: id "921240"


### PR DESCRIPTION
This PR resolves issue #2509 by adding a new rule 921240 at PL1 and a test.

The rule detects `unix:[^|]*\|` in `REQUEST_URI` and the reported attack `GET /?unix:AAAAAAAAAAAAA|http://coreruleset.org/` is detected.

See referenced issue for more information and conversation.