### PR TITLE
fix(xss): bypass JavaScript function without parentheses

### DIFF
--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -684,6 +684,36 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
+#
+# JavaScript function without parentheses
+# Reference: https://portswigger.net/research/the-seventh-way-to-call-a-javascript-function-without-parentheses
+#
+# Example Payloads:
+# [].sort.call`${alert}1337`
+# [].map.call`${eval}\\u{61}lert\x281337\x29`
+# Reflect.apply.call`${navigation.navigate}${navigation}${[name]}`
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx ((?:\[[^\]]*\][^.]*\.)|Reflect[^.]*\.).*(?:map|sort|apply)[^.]*\..*call[^`]*`.*`" \
+    "id:941400,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:urlDecodeUni,t:compressWhitespace,\
+    msg:'XSS JavaScript function without parentheses',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'attack-xss',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/242',\
+    ctl:auditLogParts=+E,\
+    ver:'OWASP_CRS/4.0.0-rc1',\
+    severity:'CRITICAL',\
+    setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:941013,phase:1,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:941014,phase:2,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
 #

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941400.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941400.yaml
@@ -1,0 +1,103 @@
+---
+meta:
+  author: "Andrea Menin"
+  description: None
+  enabled: true
+  name: 941400.yaml
+tests:
+  - test_title: 941400-1
+    desc: "JavaScript function without parentheses"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+            method: GET
+            port: 80
+            uri: '/?xss=%5B%5D.sort.call%60%24%7Balert%7D1337%60'
+            version: HTTP/1.1
+          output:
+            log_contains: id "941400"
+  - test_title: 941400-2
+    desc: "JavaScript function without parentheses"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+            method: GET
+            port: 80
+            uri: '/?xss=%5B%20%20%5D%20.%20sort%20.%20call%20%60%20%24%7B%20alert%20%7D%201337%20%60'
+            version: HTTP/1.1
+          output:
+            log_contains: id "941400"
+  - test_title: 941400-3
+    desc: "JavaScript function without parentheses"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+            method: GET
+            port: 80
+            uri: '/?xss=%5B%20%20%5D%20.%20%2F%2A%2A%2F%20sort%20.%20call%20%60%20%24%7B%20alert%20%7D%201337%20%60'
+            version: HTTP/1.1
+          output:
+            log_contains: id "941400"
+  - test_title: 941400-4
+    desc: "JavaScript function without parentheses"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+            method: GET
+            port: 80
+            uri: '/?xss=%5B%5D.map.call%60%24%7Beval%7D%5C%5Cu%7B61%7Dlert%5Cx281337%5Cx29%60'
+            version: HTTP/1.1
+          output:
+            log_contains: id "941400"
+  - test_title: 941400-5
+    desc: "JavaScript function without parentheses"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+            method: GET
+            port: 80
+            uri: '/?xss=%5B%201234%20%5D.%20map%20.%20call%60%24%7Beval%7D%2F%2A%20asd%20%2A%2F%5C%5Cu%7B61%7Dlert%5Cx281337%5Cx29%60'
+            version: HTTP/1.1
+          output:
+            log_contains: id "941400"
+  - test_title: 941400-6
+    desc: "JavaScript function without parentheses"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+            method: GET
+            port: 80
+            uri: '/?xss=Reflect.apply.call%60%24%7Bnavigation.navigate%7D%24%7Bnavigation%7D%24%7B%5Bname%5D%7D%60'
+            version: HTTP/1.1
+          output:
+            log_contains: id "941400"


### PR DESCRIPTION
This PR fixes a XSS bypass technique that could bypass the ruleset at PL3
since the syntax is really simple and well known (now) I decided to put the rule at PL1.

Fixes #2777.