### PR TITLE
ci: be less verbose in ftw tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
           docker-compose -f ./tests/docker-compose.yml logs
           [ $(docker inspect ${{ matrix.modsec_version }} --format='{{.State.Running}}') = 'true' ]
           # Use mounted volume path
-          py.test -vs --tb=short tests/regression/CRS_Tests.py \
+          py.test --tb=no -ra tests/regression/CRS_Tests.py \
             --config="${{ matrix.modsec_version }}" \
             --ruledir_recurse=./tests/regression/tests/
 


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

We don't need to know which tests passed, we only need to know the failed tests. This PR adds that to the ftw pipeline. Go-ftw still needs to have the feature built.