### PR TITLE
fix(9P5LL13Y): sh injection bypass 

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -693,6 +693,48 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
+#
+# -=[ sh command injection ]=-
+#
+# Detects attempts to inject "sh" unix command in order to execute
+# command on the remote web application (BB code 9P5LL13Y).
+#
+# This rule matches the following payloads:
+#
+# - echo "foo;whxam"i | tr x o | sh #"
+# - foo;whxam"i | tr x o | sh #
+# - foo;xcat -lvp 80 -e ba"sh | tr x n | sh #
+# - whxami|tr x o||sh #
+# - echo "whoami" | sh;
+# - echo "whoami" | sh | grep foo
+# - echo "whoami" | sh ${foo} #
+# - echo "whoami" | sh $() #
+# - echo "whoami" | sh ``
+# - echo "whoami" | sh `foo`
+# - echo "whoami" | sh -a
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx |\s*sh\s*[#;|$`-]?" \
+    "id:932220,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:lowercase,t:urlDecodeUni,\
+    msg:'Remote Command Execution: shell command injection',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/248/88',\
+    tag:'PCI/6.5.2',\
+    ver:'OWASP_CRS/4.0.0-rc1',\
+    severity:'CRITICAL',\
+    setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:932013,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:932014,phase:2,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 #

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -712,8 +712,9 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
 # - echo "whoami" | sh ``
 # - echo "whoami" | sh `foo`
 # - echo "whoami" | sh -a
+# - "find /bin" | rbash #
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx |\s*sh\s*[#;|$`-]?" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \|\s*(?:sh|rbash)\s*[#;|$`-]?" \
     "id:932220,\
     phase:2,\
     block,\

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -714,7 +714,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
 # - echo "whoami" | sh -a
 # - "find /bin" | rbash #
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \|\s*(?:sh|rbash)\s*[#;|$`-]?" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \|\s*(?:ash|capsh|rbash|sh)\s*[#;|$`-]?" \
     "id:932220,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932220.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932220.yaml
@@ -197,3 +197,35 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "932220"
+  - test_title: 932220-13
+    desc: "inject sh command"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: GET
+            port: 80
+            uri: /?format=%22find%20%2Fbin%22%7Cash%20%23
+            version: HTTP/1.0
+          output:
+            log_contains: id "932220"
+  - test_title: 932220-14
+    desc: "inject sh command"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: GET
+            port: 80
+            uri: /?format=%22find%20%2Fbin%22%7Ccapsh%20--
+            version: HTTP/1.0
+          output:
+            log_contains: id "932220"

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932220.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932220.yaml
@@ -1,0 +1,183 @@
+---
+meta:
+  author: "Andrea Menin"
+  description: RCE shell command injection
+  enabled: true
+  name: 932220.yaml
+tests:
+  - test_title: 932220-1
+    desc: "inject sh command"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: GET
+            port: 80
+            uri: /?format=whxami%7Ctr%2Bx%2Bo%7Csh%20%23%22
+            version: HTTP/1.0
+          output:
+            log_contains: id "932220"
+  - test_title: 932220-2
+    desc: "inject sh command"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: GET
+            port: 80
+            uri: /?format=foo%3Bwhxami%7Ctr%2Bx%2Bo%7Csh%20%23
+            version: HTTP/1.0
+          output:
+            log_contains: id "932220"
+  - test_title: 932220-3
+    desc: "inject sh command"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: GET
+            port: 80
+            uri: /?format=foo%3Bxcat%20-lvp%2080%20-e%20ba%22sh%20%7C%20tr%20x%20n%20%7C%20sh%20%23
+            version: HTTP/1.0
+          output:
+            log_contains: id "932220"
+  - test_title: 932220-4
+    desc: "inject sh command"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: GET
+            port: 80
+            uri: /?format=whxami%7Ctr%20x%20o%7C%7Csh%20%23
+            version: HTTP/1.0
+          output:
+            log_contains: id "932220"
+  - test_title: 932220-5
+    desc: "inject sh command"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: GET
+            port: 80
+            uri: /?format=whxami%7Ctr%2Bx%2Bo%7Csh%3B
+            version: HTTP/1.0
+          output:
+            log_contains: id "932220"
+  - test_title: 932220-6
+    desc: "inject sh command"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: GET
+            port: 80
+            uri: /?format=whxami%7Ctr%2Bx%2Bo%20%7C%20sh%20%7C%20grep%20foo
+            version: HTTP/1.0
+          output:
+            log_contains: id "932220"
+  - test_title: 932220-7
+    desc: "inject sh command"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: GET
+            port: 80
+            uri: /?format=whxami%7Ctr%2Bx%2Bo%20%7C%20sh%20%24%7Bfoo%7D%20%23
+            version: HTTP/1.0
+          output:
+            log_contains: id "932220"
+  - test_title: 932220-8
+    desc: "inject sh command"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: GET
+            port: 80
+            uri: /?format=whxami%7Ctr%2Bx%2Bo%20%7C%20sh%20%24%28%29%20%23
+            version: HTTP/1.0
+          output:
+            log_contains: id "932220"
+  - test_title: 932220-9
+    desc: "inject sh command"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: GET
+            port: 80
+            uri: /?format=whxami%7Ctr%2Bx%2Bo%20%7C%20sh%20%60%60
+            version: HTTP/1.0
+          output:
+            log_contains: id "932220"
+  - test_title: 932220-10
+    desc: "inject sh command"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: GET
+            port: 80
+            uri: /?format=whxami%7Ctr%2Bx%2Bo%20%7C%20sh%20%60foo%60
+            version: HTTP/1.0
+          output:
+            log_contains: id "932220"
+  - test_title: 932220-11
+    desc: "inject sh command"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: GET
+            port: 80
+            uri: /?format=whxami%7Ctr%2Bx%2Bo%20%7C%20sh%20-a
+            version: HTTP/1.0
+          output:
+            log_contains: id "932220"

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932220.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932220.yaml
@@ -181,3 +181,19 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "932220"
+  - test_title: 932220-12
+    desc: "inject sh command"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: GET
+            port: 80
+            uri: /?format=%22find%20%2Fbin%22%7Crbash%20%23
+            version: HTTP/1.0
+          output:
+            log_contains: id "932220"


### PR DESCRIPTION
This PR matches a specific `sh` command injection bypass syntax at PL1.

Fixes #2793.