### PR TITLE
fix(ruleset scoring and tagging): Fix PL related issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,7 +263,7 @@ The types of rules that are allowed at each paranoia level are as follows:
 
 **PL 2:**
 
-* [Chain](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual(v2.x)#chain) usage is allowed
+* [Chain](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-%28v2.x%29#chain) usage is allowed
 * Confirmed matches use score critical
 * Matches that cause false positives are limited to using scores notice or warning
 * Low false positive rates
@@ -286,6 +286,8 @@ The types of rules that are allowed at each paranoia level are as follows:
 * False positive rates are higher (even on single strings)
 * False negatives should not happen at this level
 * Check everything against RFCs and allow listed values for the most popular elements
+
+Each rule which placed into a paranoia level must contain tag `paranoia-level/N`, where N is the PL value, but this tag can only be added if rule does **not** have `nolog` action.
 
 ## ID Numbering Scheme
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@
 * No trailing blank lines at EOF (only the required single EOF newline character is allowed).
 * Add comments where possible and clearly explain any new rules.
 * Adhere to an 80 character line length limit where possible.
-* All [chained rules](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual(v2.x)#chain) should be indented like so, for readability:
+* All [chained rules](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-%28v2.x%29#chain) should be indented like so, for readability:
 ```
 SecRule .. .. \
     "..."

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -717,7 +717,7 @@ SecCollectionTimeout 600
 SecAction \
     "id:900990,\
     phase:1,\
-    nolog,\
     pass,\
     t:none,\
+    nolog,\
     setvar:tx.crs_setup_version=400"

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -336,7 +336,6 @@ SecRule REQBODY_PROCESSOR "!@rx (?:URLENCODED|MULTIPART|XML|JSON)" \
     nolog,\
     noauditlog,\
     msg:'Enabling body inspection',\
-    tag:'paranoia-level/1',\
     ctl:forceRequestBodyVariable=On,\
     ver:'OWASP_CRS/4.0.0-rc1'"
 

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -419,7 +419,6 @@ SecRule ARGS_NAMES "@rx ." \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
-    tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/137/15/460',\
     ver:'OWASP_CRS/4.0.0-rc1',\
@@ -534,7 +533,7 @@ SecRule ARGS_NAMES "@rx \[" \
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
 
 
 

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -729,7 +729,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # This is a stricter sibling of rule 932130.
 #
@@ -1200,7 +1200,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:932017,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -758,7 +758,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:933017,phase:1,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"

--- a/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
+++ b/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
@@ -86,7 +86,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-rce',\
     tag:'attack-injection-generic',\
-    tag:'paranoia-level/2',\
+    tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1004,7 +1004,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 # This rule is a sibling of 942330. See that rule for a description and overview.

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -36,7 +36,6 @@ SecRule RESPONSE_BODY "!@pmFromFile sql-errors.data" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-disclosure',\
-    tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
     ver:'OWASP_CRS/4.0.0-rc1',\


### PR DESCRIPTION
These commits fixed few issues:

* Removed `paranoia-level/N` tags from rules, which contains `nolog` action
* Set correct `paranoia-level/N` tag values according to PL value
* Set correct TX score variable, according to PL value
* Added information about 'paranoia-level/N' tags to CONTRIBUTING.md
* Fix action order in crs-setup.conf.example