### PR TITLE
fix: remove reputation variables

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -167,24 +167,6 @@ SecRule &TX:notice_anomaly_score "@eq 0" \
     ver:'OWASP_CRS/4.0.0-rc1',\
     setvar:'tx.notice_anomaly_score=2'"
 
-# Default do_reput_block
-SecRule &TX:do_reput_block "@eq 0" \
-    "id:901150,\
-    phase:1,\
-    pass,\
-    nolog,\
-    ver:'OWASP_CRS/4.0.0-rc1',\
-    setvar:'tx.do_reput_block=0'"
-
-# Default block duration
-SecRule &TX:reput_block_duration "@eq 0" \
-    "id:901152,\
-    phase:1,\
-    pass,\
-    nolog,\
-    ver:'OWASP_CRS/4.0.0-rc1',\
-    setvar:'tx.reput_block_duration=300'"
-
 # Default HTTP policy: allowed_methods (rule 900200 in crs-setup.conf)
 SecRule &TX:allowed_methods "@eq 0" \
     "id:901160,\


### PR DESCRIPTION
PR fixes #2812.

Removes the rules checking and setting the now redundant variables `TX:do_reput_block` and `TX:reput_block_duration` (they were moved into a plugin and out of the core CRS).