### PR TITLE
Use tagged release for go-ftw download

### DIFF
--- a/.github/workflows/go-ftw.yml
+++ b/.github/workflows/go-ftw.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: "Install dependencies"
         run: |
-          curl -skLo - https://github.com/coreruleset/go-ftw/releases/latest/download/ftw_Linux_x86_64.tar.gz | tar -xzf - ftw
+          curl -skLo - https://github.com/coreruleset/go-ftw/releases/download/v0.4.0/ftw_Linux_x86_64.tar.gz | tar -xzf - ftw
 
       - name: "Run tests for ${{ matrix.modsec_version }}"
         run: |


### PR DESCRIPTION
This makes sure changes to the artifacts like filename don't affect the workflow