### PR TITLE
Fix rule ID 921110 in REQUEST-921-PROTOCOL-ATTACK.conf

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -31,7 +31,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:921012,phase:2,pass,nolog,skipAf
 # [ References ]
 # http://projects.webappsec.org/HTTP-Request-Smuggling
 #
-SecRule ARGS_NAMES|ARGS|REQUEST_BODY|XML:/* "@rx (?:get|post|head|options|connect|put|delete|trace|track|patch|propfind|propatch|mkcol|copy|move|lock|unlock)\s+[^\s]+\s+http/\d" \
+SecRule ARGS_NAMES|ARGS|REQUEST_BODY|XML:/* "@rx (?:get|post|head|options|connect|put|delete|trace|track|patch|propfind|propatch|mkcol|copy|move|lock|unlock)\s+[^\s]+\s+http\/\d" \
     "id:921110,\
     phase:2,\
     block,\


### PR DESCRIPTION
* Fixing regular expression with missing escape character on rule ID id:921110 - HTTP Request Smuggling