### PR TITLE
V4.0/fixtxvars

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -717,7 +717,7 @@ SecCollectionTimeout 600
 SecAction \
     "id:900990,\
     phase:1,\
-    nolog,\
     pass,\
     t:none,\
+    nolog,\
     setvar:tx.crs_setup_version=400"

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -318,7 +318,6 @@ SecRule REQBODY_PROCESSOR "!@rx (?:URLENCODED|MULTIPART|XML|JSON)" \
     nolog,\
     noauditlog,\
     msg:'Enabling body inspection',\
-    tag:'paranoia-level/1',\
     ctl:forceRequestBodyVariable=On,\
     ver:'OWASP_CRS/4.0.0-rc1'"
 

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -445,7 +445,6 @@ SecRule ARGS_NAMES "@rx ." \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
-    tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/137/15/460',\
     ver:'OWASP_CRS/4.0.0-rc1',\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -559,7 +559,7 @@ SecRule ARGS_NAMES "@rx \[" \
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
 
 
 

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -729,7 +729,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # This is a stricter sibling of rule 932130.
 #
@@ -1200,7 +1200,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:932017,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -758,7 +758,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:933017,phase:1,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"

--- a/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
+++ b/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
@@ -86,7 +86,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-rce',\
     tag:'attack-injection-generic',\
-    tag:'paranoia-level/2',\
+    tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1004,7 +1004,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 # This rule is a sibling of 942330. See that rule for a description and overview.

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -36,7 +36,6 @@ SecRule RESPONSE_BODY "!@pmFromFile sql-errors.data" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-disclosure',\
-    tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
     ver:'OWASP_CRS/4.0.0-rc1',\


### PR DESCRIPTION
This PR contains four modifications:

* set the correct actions order at the `SecAction` id `900990`
* remove `paranoia-level/N` tags from rules where `nolog` action presented
* set the correct `anomaly_score_plN` variable for its PL
* set the correct `paranoia-level/N` tag for its PL

After approve it, I can go away to fix the #2835.