### PR TITLE
Add sql data conversion ::int and ::bool

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -399,7 +399,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # (consult util/regexp-assemble/README.md for details):
 #   util/regexp-assemble/regexp-assemble.py update 942320
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:create\s+(?:procedure|function)\s*?\w+\s*?\(\s*?\)\s*?-|;\s*?(?:declare|open)\s+[\w-]+|procedure\s+analyse\s*?\(|declare[^\w]+[@#]\s*?\w+|exec\s*?\(\s*?@)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:create\s+(?:procedure|function)\s*?\w+\s*?\(\s*?\)\s*?-|;\s*?(?:declare|open)\s+[\w-]+|procedure\s+analyse\s*?\(|declare[^\w]+[@#]\s*?\w+|exec\s*?\(\s*?@|::(?:bool|int))" \
     "id:942320,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942320.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942320.yaml
@@ -72,3 +72,35 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942320"
+  - test_title: 942320-5
+    desc: "Detects PostgreSQL data conversion with ::int"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/index.php?id=password::int"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942320"
+  - test_title: 942320-6
+    desc: "Detects PostgreSQL data conversion with ::bool"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/index.php?no=2&id=1%27%20and%20unistr(password)::bool--"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942320"

--- a/util/regexp-assemble/data/942320.data
+++ b/util/regexp-assemble/data/942320.data
@@ -10,3 +10,5 @@ exec\s*?\(\s*?@
 procedure\s+analyse\s*?\(
 ;\s*?declare\s+[\w-]+
 ;\s*?open\s+[\w-]+
+::int
+::bool


### PR DESCRIPTION
This PR resolves issue #2870 (SQLi bypass submitted by Shivam Bathla) by adding detection of `::bool` and `::int` data conversion in PostgreSQL.

Rule 942320 is the only PostgreSQL rule that I think is a good match for this extension.
I think `::int` and `::bool` are not so prone to FP, so I think extending this PL1 makes sense.

This rule will solve most of Shivam's reported findings.
I'll ask him over email if he can take a look too.

Closes #2870.

