### PR TITLE
Fixes 932130 tests urls

### DIFF
--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932130.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932130.yaml
@@ -195,7 +195,7 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             method: GET
             port: 80
-            uri: "?s=/etc/%5Bp%5Dasswd"
+            uri: "/?s=/etc/%5Bp%5Dasswd"
             version: HTTP/1.0
           output:
             log_contains: id "932130"
@@ -211,7 +211,7 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             method: GET
             port: 80
-            uri: "?s=/etc/%5B!q%5Dasswd"
+            uri: "/?s=/etc/%5B!q%5Dasswd"
             version: HTTP/1.0
           output:
             log_contains: id "932130"
@@ -227,7 +227,7 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             method: GET
             port: 80
-            uri: "?s=/etc/%5Bm-z%5Dasswd"
+            uri: "/?s=/etc/%5Bm-z%5Dasswd"
             version: HTTP/1.0
           output:
             log_contains: id "932130"
@@ -243,7 +243,7 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             method: GET
             port: 80
-            uri: "?s=/usr/bin/%5Bu%5Dname+-a"
+            uri: "/?s=/usr/bin/%5Bu%5Dname+-a"
             version: HTTP/1.0
           output:
             log_contains: id "932130"
@@ -259,7 +259,7 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             method: GET
             port: 80
-            uri: "?exec=/bi%5Bn%5D/bash"
+            uri: "/?exec=/bi%5Bn%5D/bash"
             version: HTTP/1.0
           output:
             log_contains: id "932130"


### PR DESCRIPTION
Hello! 
Similar to https://github.com/coreruleset/coreruleset/pull/2168, I found that tests from `932130-12` to `932130-16` have the `uri` parameter that does not start with a path like `/`. Looking at rule [`932130`](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf#L370) and relative [tests](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932130.yaml), seems to me that the missing path is not related to what the tests are intended for (command injections inside URI parameters).

All the affected tests are true tests, and, with this fix, they are correctly detected by Coraza running on a simple Go-http server.

Setting PR Draft status because I wish to test it against other servers, but I guess that they would also fail against `nginx` and `Envoy`.
