### PR TITLE
test: new test in 932200 for individual variables assignment

### DIFF
--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932200.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932200.yaml
@@ -213,3 +213,20 @@ tests:
             version: HTTP/1.0
           output:
             no_log_contains: found within MATCHED_VAR
+  - test_title: 932200-14
+    desc: "Test variable assignment ('cat /etc/passwd' assigned via individual variables, cat in reverse order)"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            data: exec=c4%3D%5C%20%3Bc3%3Dt%3Bc2%3Da%3Bc1%3Dc%3Ba1%3D%2F%3Ba2%3De%3Ba3%3Dt%3Ba4%3Dc%3Ba5%3D%2F%3Ba6%3Dp%3Ba7%3Da%3Ba8%3Ds%3Ba9%3Ds%3Ba10%3Dw%3Ba11%3Dd%3B%24c1%24c2%24c3%24c4%24a1%24a2%24a3%24a4%24a5%24a6%24a7%24a8%24a9%24a10%24a11%0A
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+            method: POST
+            port: 80
+            uri: /
+            version: HTTP/1.0
+          output:
+            log_contains: id "932200"


### PR DESCRIPTION
'cat /etc/passwd' assigned via individual variables, cat in reverse order:

```
exec=c4=\ ;c3=t;c2=a;c1=c;a1=/;a2=e;a3=t;a4=c;a5=/;a6=p;a7=a;a8=s;a9=s;a10=w;a11=d;$c1$c2$c3$c4$a1$a2$a3$a4$a5$a6$a7$a8$a9$a10$a11
```
