### PR TITLE
fix(ruleset scoring and tagging): Fix PL related issues in v3.2/dev

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -835,7 +835,7 @@ SecCollectionTimeout 600
 SecAction \
     "id:900990,\
     phase:1,\
-    nolog,\
     pass,\
     t:none,\
+    nolog,\
     setvar:tx.crs_setup_version=323"

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -219,6 +219,33 @@ SecRule &TX:enforce_bodyproc_urlencoded "@eq 0" \
     nolog,\
     setvar:'tx.enforce_bodyproc_urlencoded=0'"
 
+# Default check for UTF8 encoding validation
+SecRule &TX:crs_validate_utf8_encoding "@eq 0" \
+    "id:901169,\
+    phase:1,\
+    pass,\
+    nolog,\
+    ver:'OWASP_CRS/3.3.4',\
+    setvar:'tx.crs_validate_utf8_encoding=0'"
+
+# Default check for country codes with risk
+SecRule &TX:high_risk_country_codes "@eq 0" \
+    "id:901170,\
+    phase:1,\
+    pass,\
+    nolog,\
+    ver:'OWASP_CRS/3.3.4',\
+    setvar:'tx.high_risk_country_codes='"
+
+# Default monitor_anomaly_score value
+SecRule &TX:monitor_anomaly_score "@eq 0" \
+    "id:901171,\
+    phase:1,\
+    pass,\
+    nolog,\
+    ver:'OWASP_CRS/3.3.4',\
+    setvar:'tx.monitor_anomaly_score=0'"
+
 #
 # -=[ Initialize internal variables ]=-
 #

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -225,7 +225,6 @@ SecRule &TX:crs_validate_utf8_encoding "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.4',\
     setvar:'tx.crs_validate_utf8_encoding=0'"
 
 # Default check for country codes with risk
@@ -234,7 +233,6 @@ SecRule &TX:high_risk_country_codes "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.4',\
     setvar:'tx.high_risk_country_codes='"
 
 # Default monitor_anomaly_score value
@@ -243,7 +241,6 @@ SecRule &TX:monitor_anomaly_score "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.4',\
     setvar:'tx.monitor_anomaly_score=0'"
 
 #

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -227,17 +227,9 @@ SecRule &TX:crs_validate_utf8_encoding "@eq 0" \
     nolog,\
     setvar:'tx.crs_validate_utf8_encoding=0'"
 
-# Default check for country codes with risk
-SecRule &TX:high_risk_country_codes "@eq 0" \
-    "id:901170,\
-    phase:1,\
-    pass,\
-    nolog,\
-    setvar:'tx.high_risk_country_codes='"
-
 # Default monitor_anomaly_score value
 SecRule &TX:monitor_anomaly_score "@eq 0" \
-    "id:901171,\
+    "id:901170,\
     phase:1,\
     pass,\
     nolog,\

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -296,7 +296,6 @@ SecRule REQBODY_PROCESSOR "!@rx (?:URLENCODED|MULTIPART|XML|JSON)" \
     nolog,\
     noauditlog,\
     msg:'Enabling body inspection',\
-    tag:'paranoia-level/1',\
     ctl:forceRequestBodyVariable=On,\
     ver:'OWASP_CRS/3.2.3'"
 

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -61,7 +61,7 @@ SecRule REQUEST_LINE "!@rx ^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+
     tag:'CAPEC-272',\
     ver:'OWASP_CRS/3.2.3',\
     severity:'WARNING',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.notice_anomaly_score}'"
+    setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
 
 #
@@ -235,7 +235,7 @@ SecRule REQUEST_METHOD "@rx ^POST$" \
     SecRule &REQUEST_HEADERS:Content-Length "@eq 0" \
         "chain"
         SecRule &REQUEST_HEADERS:Transfer-Encoding "@eq 0" \
-            "setvar:'tx.anomaly_score_pl1=+%{tx.notice_anomaly_score}'"
+            "setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
 
 #
@@ -480,7 +480,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 1-255" \
     tag:'OWASP_CRS/PROTOCOL_VIOLATION/EVASION',\
     ver:'OWASP_CRS/3.2.3',\
     severity:'CRITICAL',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -354,7 +354,6 @@ SecRule ARGS_NAMES "@rx ." \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
-    tag:'paranoia-level/3',\
     tag:'CAPEC-460',\
     ver:'OWASP_CRS/3.2.3',\
     setvar:'TX.paramcounter_%{MATCHED_VAR_NAME}=+1'"

--- a/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
+++ b/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
@@ -117,13 +117,13 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?)://(.*)$" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/RFI',\
     tag:'paranoia-level/2',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.3',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_parameter_%{MATCHED_VAR_NAME}=%{tx.1}',\
     chain"
     SecRule TX:/rfi_parameter_.*/ "!@beginsWith %{request_headers.host}" \
-        "setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
+        "ctl:auditLogParts=+E,\
+        setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -128,12 +128,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
     tag:'OWASP_TOP_10/A1',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.3',\
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VARS "@pm =" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -543,12 +543,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'OWASP_CRS/WEB_ATTACK/PHP_INJECTION',\
     tag:'OWASP_TOP_10/A1',\
     tag:'paranoia-level/2',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.3',\
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VARS "@pm (" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 

--- a/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
+++ b/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
@@ -67,7 +67,6 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
     tag:'OWASP_CRS/WEB_ATTACK/SESSION_FIXATION',\
     tag:'WASCTC/WASC-37',\
     tag:'CAPEC-61',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.3',\
     severity:'CRITICAL',\
     chain"
@@ -75,7 +74,8 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
         "capture,\
         chain"
         SecRule TX:1 "!@endsWith %{request_headers.host}" \
-            "setvar:'tx.session_fixation_score=+%{tx.critical_anomaly_score}',\
+            "ctl:auditLogParts=+E,\
+            setvar:'tx.session_fixation_score=+%{tx.critical_anomaly_score}',\
             setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
@@ -95,12 +95,12 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
     tag:'OWASP_CRS/WEB_ATTACK/SESSION_FIXATION',\
     tag:'WASCTC/WASC-37',\
     tag:'CAPEC-61',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.3',\
     severity:'CRITICAL',\
     chain"
     SecRule &REQUEST_HEADERS:Referer "@eq 0" \
-        "setvar:'tx.session_fixation_score=+%{tx.critical_anomaly_score}',\
+        "ctl:auditLogParts=+E,\
+        setvar:'tx.session_fixation_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -54,12 +54,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.3',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:JET Database Engine|Access Database Engine|\[Microsoft\]\[ODBC Microsoft Access Driver\])" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -79,12 +79,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.3',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:ORA-[0-9][0-9][0-9][0-9]|java\.sql\.SQLException|Oracle error|Oracle.*Driver|Warning.*oci_.*|Warning.*ora_.*)" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -104,12 +104,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.3',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:DB2 SQL error:|\[IBM\]\[CLI Driver\]\[DB2/6000\]|CLI Driver.*DB2|DB2 SQL error|db2_\w+\()" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -129,12 +129,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.3',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:\[DM_QUERY_E_SYNTAX\]|has occurred in the vicinity of:)" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -154,12 +154,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.3',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)Dynamic SQL Error" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -180,12 +180,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.3',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)Exception (?:condition )?\d+\. Transaction rollback\." \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -205,12 +205,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.3',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)org\.hsqldb\.jdbc" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -230,12 +230,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.3',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:An illegal character has been found in the statement|com\.informix\.jdbc|Exception.*Informix)" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -256,12 +256,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.3',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:Warning.*ingres_|Ingres SQLSTATE|Ingres\W.*Driver)" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -282,12 +282,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.3',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:<b>Warning</b>: ibase_|Unexpected end of command in statement)" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -307,12 +307,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.3',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:SQL error.*POS[0-9]+.*|Warning.*maxdb.*)" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -332,12 +332,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.3',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)(?:System\.Data\.OleDb\.OleDbException|\[Microsoft\]\[ODBC SQL Server Driver\]|\[Macromedia\]\[SQLServer JDBC Driver\]|\[SqlException|System\.Data\.SqlClient\.SqlException|Unclosed quotation mark after the character string|'80040e14'|mssql_query\(\)|Microsoft OLE DB Provider for ODBC Drivers|Microsoft OLE DB Provider for SQL Server|Incorrect syntax near|Sintaxis incorrecta cerca de|Syntax error in string in query expression|Procedure or function .* expects parameter|Unclosed quotation mark before the character string|Syntax error .* in query expression|Data type mismatch in criteria expression\.|ADODB\.Field \(0x800A0BCD\)|the used select statements have different number of columns|OLE DB.*SQL Server|Warning.*mssql_.*|Driver.*SQL[\-\_\ ]*Server|SQL Server.*Driver|SQL Server.*[0-9a-fA-F]{8}|Exception.*\WSystem\.Data\.SqlClient\.)" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -357,12 +357,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.3',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)(?:supplied argument is not a valid MySQL|Column count doesn't match value count at row|mysql_fetch_array\(\)|on MySQL result index|You have an error in your SQL syntax;|You have an error in your SQL syntax near|MySQL server version for the right syntax to use|\[MySQL\]\[ODBC|Column count doesn't match|Table '[^']+' doesn't exist|SQL syntax.*MySQL|Warning.*mysql_.*|valid MySQL result|MySqlClient\.)" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -382,12 +382,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.3',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:PostgreSQL query failed:|pg_query\(\) \[:|pg_exec\(\) \[:|PostgreSQL.*ERROR|Warning.*pg_.*|valid PostgreSQL result|Npgsql\.|PG::[a-zA-Z]*Error|Supplied argument is not a valid PostgreSQL .*? resource|Unable to connect to PostgreSQL server)" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -407,12 +407,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.3',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)(?:Warning.*sqlite_.*|Warning.*SQLite3::|SQLite/JDBCDriver|SQLite\.Exception|System\.Data\.SQLite\.SQLiteException)" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -432,12 +432,12 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/LEAKAGE/ERRORS_SQL',\
     tag:'CWE-209',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.3',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)(?:Sybase message:|Warning.*sybase.*|Sybase.*Server message.*)" \
         "capture,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"

--- a/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -100,13 +100,13 @@ SecRule RESPONSE_BODY "@rx <\?(?!xml)" \
     tag:'WASCTC/WASC-13',\
     tag:'OWASP_TOP_10/A6',\
     tag:'PCI/6.5.6',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.3',\
     severity:'ERROR',\
     chain"
     SecRule RESPONSE_BODY "!@rx (?:\x1f\x8b\x08|\b(?:(?:i(?:nterplay|hdr|d3)|m(?:ovi|thd)|r(?:ar!|iff)|(?:ex|jf)if|f(?:lv|ws)|varg|cws)\b|gif)|B(?:%pdf|\.ra)\b|^wOF(?:F|2))" \
         "capture,\
         t:none,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 

--- a/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+++ b/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
@@ -108,13 +108,13 @@ SecRule RESPONSE_STATUS "!@rx ^404$" \
     tag:'WASCTC/WASC-13',\
     tag:'OWASP_TOP_10/A6',\
     tag:'PCI/6.5.6',\
-    ctl:auditLogParts=+E,\
     ver:'OWASP_CRS/3.2.3',\
     severity:'ERROR',\
     chain"
     SecRule RESPONSE_BODY "@rx \bServer Error in.{0,50}?\bApplication\b" \
         "capture,\
         t:none,\
+        ctl:auditLogParts=+E,\
         setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
         setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 


### PR DESCRIPTION
These commits fixed few issues:

* Fix action order in crs-setup.conf.example
* Removed paranoia-level/N tags from rules, which contains `nolog` action
* Set default value for uninitialized TX variables
* Set correct TX score variable, according to rule's `severity` value
* Moved audit log part E if there is a chained rule, see [#2531](https://github.com/coreruleset/coreruleset/pull/2531)
    
