### PR TITLE
fix(ULYKOFYK-2): adds REQUEST_FILENAME to 942101, moves to PL2

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1664,7 +1664,7 @@ SecRule REQUEST_BASENAME|REQUEST_FILENAME "@detectSQLi" \
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 #

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -39,7 +39,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:942012,phase:2,pass,nolog,skipAf
 #
 # -=[ LibInjection Check ]=-
 #
-# There is a stricter sibling of this rule at 942101. It covers REQUEST_BASENAME.
+# There is a stricter sibling of this rule at 942101. It covers REQUEST_BASENAME and REQUEST_FILENAME.
 #
 # Ref: https://libinjection.client9.com/
 #
@@ -1630,18 +1630,22 @@ SecRule ARGS "@rx \W{4}" \
 
 
 #
-# This is a sibling of rule 942100 that adds checking of the last path segment.
+# This is a sibling of rule 942100 that adds checking of the path.
 #
-# libinjection is more likely to fail when passing the full path. E.g. the following
-# string produces a match:
-# 999999.1 union select unhex(hex(version())) -- and 1=1
-# while this doesn't:
-# /999999.1 union select unhex(hex(version())) -- and 1=1\.
-# Therefore, we capture the last segment of the path and only match that with
-# libinjection. Incidentally, the last path segment is also the most likely
-# to be used for injection, other segments will most likely not be affected.
+# REQUEST_BASENAME provides the last url segment (slash excluded).
+# This segment is the most likely to be used for injections. Stripping out
+# the slash permits libinjection to do not consider it as a payload starting
+# with not unary arithmetical operators (not a valid SQL command, e.g.
+# '/9 union all'). The latter would lead to do not detect malicious payloads.
 #
-SecRule REQUEST_BASENAME "@detectSQLi" \
+# REQUEST_FILENAME matches SQLi payloads inside (or across) other segments
+# of the path. Here, libinjection will detect a true positive only if
+# the url leading slash is considered as part of a comment block or part
+# of a string (with a quote or double quote after it). In these circumstances,
+# previous slashes do not affect libinjection result, making it able to detect
+# some SQLi inside the path.
+#
+SecRule REQUEST_BASENAME|REQUEST_FILENAME "@detectSQLi" \
     "id:942101,\
     phase:1,\
     block,\
@@ -1656,7 +1660,7 @@ SecRule REQUEST_BASENAME "@detectSQLi" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/3',\
+    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942101.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942101.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "Christian Folini"
+  author: "Christian Folini, Matteo Pace"
   description: Various SQL injection tests
   enabled: true
   name: 942101.yaml
@@ -113,7 +113,7 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             method: POST
             port: 80
-            uri: "/foo/24'union+all+select+1,2,3+from+aa/bar"
+            uri: "/foo/24'union+all+select+1,2,3+from+aa"
             version: HTTP/1.0
           output:
             log_contains: id "942101"

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942101.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942101.yaml
@@ -101,3 +101,83 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942101"
+  - test_title: 942101-7
+    desc: "SQL Injection at the last segment of the path (request_basename detection)"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/foo/24'union+all+select+1,2,3+from+aa/bar"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942101"
+  - test_title: 942101-8
+    desc: "SQL Injection inside the path (request_filename detection)"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/foo/24'union+all+select+1,2,3+from+aa/bar"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942101"
+  - test_title: 942101-9
+    desc: "SQL Injection inside the path with comment block (request_filename detection)"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/%2A/%2A/2+union+all/bar"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942101"
+  - test_title: 942101-10
+    desc: "Negative test with incomplete SQL command inside the path"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/foo/9'union+all/bar"
+            version: HTTP/1.0
+          output:
+            no_log_contains: id "942101"
+  - test_title: 942101-11
+    desc: "Negative test with complete SQL command inside the path, but without comma"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/foo/24+union+all+select+1,2,3+from+aa/bar"
+            version: HTTP/1.0
+          output:
+            no_log_contains: id "942101"


### PR DESCRIPTION
This PR:
- Adds `REQUEST_FILENAME` to `942101`: libinjection is usually not matching strings with a leading path (being interpreted as a not unary arithmetical operator), but quotes and comment blocks lead to correctly evaluating some SQLi crafted inside the URL (e.g. `/foo/24'union all select/bar`).
- Moves `942101` to PL2: although single quotes can be common in languages like French and Italian, after it, a valid SQL statement is required in order to match the rule. PL2 seems to be a good fit: it already assumes consciousness of possible false positives, but it is low enough to provide security in most real-life scenarios that are looking for it. 
As a side note, other libinjection SQLi checks are made at PL1 (rule `942100`).
- Adds related tests.