### PR TITLE
fix(nginx setvar syntax) Remove initialize rule as libmodsecurity does not support empty value ginivg

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -248,18 +248,9 @@ SecRule &TX:crs_validate_utf8_encoding "@eq 0" \
     ver:'OWASP_CRS/3.3.4',\
     setvar:'tx.crs_validate_utf8_encoding=0'"
 
-# Default check for country codes with risk
-SecRule &TX:high_risk_country_codes "@eq 0" \
-    "id:901170,\
-    phase:1,\
-    pass,\
-    nolog,\
-    ver:'OWASP_CRS/3.3.4',\
-    setvar:'tx.high_risk_country_codes='"
-
 # Default monitor_anomaly_score value
 SecRule &TX:monitor_anomaly_score "@eq 0" \
-    "id:901171,\
+    "id:901170,\
     phase:1,\
     pass,\
     nolog,\


### PR DESCRIPTION
This PR removes the rule which initialized the `TX:high_risk_country_codes variable`, because libmodsecurity3 does not support that form of value giving - see this [comment](https://github.com/coreruleset/coreruleset/pull/2921#issuecomment-1299089649). It was just a cosmetic rule, it is not necessary for the correct working of rule set.

With that, Nginx couldn't start - now everything is fine. The PR is ready for review and merge.