### PR TITLE
fix: update PL TX variables to new naming

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -758,7 +758,7 @@ SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer "@rx (?:\$(?:\((?:\(.
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 #
 # -=[ Rule 932200 ]=-
@@ -911,7 +911,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # =[ IMAP Command Execution ]=
 #
@@ -944,7 +944,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # =[ POP3 Command Execution ]=
 #
@@ -979,7 +979,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # [ Unix direct remote command execution ]
 #

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -127,7 +127,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 #
@@ -636,7 +636,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s'\"`()]*?\b([\d\w]+)\b[\s'\"`()]*?(?:
     SecRule TX:942130_lhs "@streq %{TX.2}" \
         "t:none,\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # Rule Targeting logical inequalities that return TRUE (e.g. 1 != 2)
 #

--- a/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -178,7 +178,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 # Log4J / Log4Shell Defense
@@ -226,7 +226,7 @@ SecRule REQUEST_LINE|ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUE
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:944013,phase:1,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
@@ -264,7 +264,7 @@ SecRule REQUEST_LINE|ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUE
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # [ Java deserialization vulnerability/Apache Commons (CVE-2015-4852) ]
 #
@@ -388,7 +388,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:944015,phase:1,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
@@ -458,7 +458,7 @@ SecRule REQUEST_LINE|ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUE
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.inbound_anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
 
 #
 # -= Paranoia Levels Finished =-


### PR DESCRIPTION
Looks like somehow these variables were not updated with the big renaming. This PR updates the name.