### PR TITLE
fix(regex 942240) - disassembled data file

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -279,7 +279,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # (consult util/regexp-assemble/README.md for details):
 #   util/regexp-assemble/regexp-assemble.py update 942240
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:[\"'`];(?:*?\s*?waitfor\s+(?:delay|time)\s+[\"'`]|.*?:\s*?goto)|alter\s*?\w+.*?char(?:acter)?\s+set\s+\w+)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:[\"'`](?:;*?\s*?waitfor\s+(?:delay|time)\s+[\"'`]|;.*?:\s*?goto)|alter\s*?\w+.*?char(?:acter)?\s+set\s+\w+)" \
     "id:942240,\
     phase:2,\
     block,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -279,7 +279,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # (consult util/regexp-assemble/README.md for details):
 #   util/regexp-assemble/regexp-assemble.py update 942240
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:[\"'`];*?(?:\s*?waitfor\s+(?:delay|time)\s+[\"'`]|:\s*?goto)|alter\s*?\w+.*?char(?:acter)?\s+set\s+\w+)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:[\"'`](?:;*?\s*?waitfor\s+(?:delay|time)\s+[\"'`]|;.*?:\s*?goto)|alter\s*?\w+.*?char(?:acter)?\s+set\s+\w+)" \
     "id:942240,\
     phase:2,\
     block,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -279,7 +279,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # (consult util/regexp-assemble/README.md for details):
 #   util/regexp-assemble/regexp-assemble.py update 942240
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:[\"'`];.*?(?:\s*?waitfor\s+(?:delay|time)\s+[\"'`]|:\s*?goto)|alter\s*?\w+.*?char(?:acter)?\s+set\s+\w+)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:[\"'`];*?(?:\s*?waitfor\s+(?:delay|time)\s+[\"'`]|:\s*?goto)|alter\s*?\w+.*?char(?:acter)?\s+set\s+\w+)" \
     "id:942240,\
     phase:2,\
     block,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -279,7 +279,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # (consult util/regexp-assemble/README.md for details):
 #   util/regexp-assemble/regexp-assemble.py update 942240
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:[\"'`](?:;*?\s*?waitfor\s+(?:delay|time)\s+[\"'`]|;.*?:\s*?goto)|alter\s*?\w+.*?char(?:acter)?\s+set\s+\w+)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:[\"'`];.*?(?:\s*?waitfor\s+(?:delay|time)\s+[\"'`]|:\s*?goto)|alter\s*?\w+.*?char(?:acter)?\s+set\s+\w+)" \
     "id:942240,\
     phase:2,\
     block,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -279,7 +279,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # (consult util/regexp-assemble/README.md for details):
 #   util/regexp-assemble/regexp-assemble.py update 942240
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:[\"'`](?:;*?\s*?waitfor\s+(?:delay|time)\s+[\"'`]|;.*?:\s*?goto)|alter\s*?\w+.*?cha(?:racte)?r\s+set\s+\w+)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:[\"'`];(?:*?\s*?waitfor\s+(?:delay|time)\s+[\"'`]|.*?:\s*?goto)|alter\s*?\w+.*?char(?:acter)?\s+set\s+\w+)" \
     "id:942240,\
     phase:2,\
     block,\

--- a/util/regexp-assemble/data/942240.data
+++ b/util/regexp-assemble/data/942240.data
@@ -10,7 +10,7 @@
 
 ##!> template ticks [\"'`]
 
-##!> template waitfor *?\s*?waitfor\s+
+##!> template waitfor .*?\s*?waitfor\s+
 
 ##! Main assembly
   ##!> assemble

--- a/util/regexp-assemble/data/942240.data
+++ b/util/regexp-assemble/data/942240.data
@@ -3,8 +3,30 @@
 
 ##!+ i
 
-alter\s*?\w+.*?character\s+set\s+\w+
-alter\s*?\w+.*?char\s+set\s+\w+
-[\"'`];*?\s*?waitfor\s+time\s+[\"'`]
-[\"'`];*?\s*?waitfor\s+delay\s+[\"'`]
-[\"'`];.*?:\s*?goto
+##! Helpers
+##!> template alter alter\s*?\w+.*?
+
+##!> template set \s+set\s+\w+
+
+##!> template ticks [\"'`]
+
+##!> template waitfor *?\s*?waitfor\s+
+
+##! Main assembly
+  ##!> assemble
+{{alter}}
+  ##!=>
+char
+character
+  ##!=>
+{{set}}
+  ##!<
+
+  ##!> assemble
+{{ticks}};
+  ##!=>
+{{waitfor}}time\s+[\"'`]
+{{waitfor}}delay\s+[\"'`]
+.*?:\s*?goto
+  ##!=>
+  ##!<

--- a/util/regexp-assemble/data/942240.data
+++ b/util/regexp-assemble/data/942240.data
@@ -25,7 +25,7 @@ character
   ##!> assemble
 {{ticks}};
   ##!=>
-;{{waitfor}}time\s+[\"'`]
+{{waitfor}}time\s+[\"'`]
 ;{{waitfor}}delay\s+[\"'`]
 ;.*?:\s*?goto
   ##!=>

--- a/util/regexp-assemble/data/942240.data
+++ b/util/regexp-assemble/data/942240.data
@@ -8,7 +8,7 @@
 
 ##!> template set \s+set\s+\w+
 
-##!> template ticks-semicolon-lazy [\"'`];*?
+##!> template ticks [\"'`]
 
 ##!> template waitfor \s*?waitfor\s+
 
@@ -23,10 +23,10 @@ character
   ##!<
 
   ##!> assemble
-{{ticks-semicolon-lazy}}
+{{ticks}}
   ##!=>
-{{waitfor}}time\s+[\"'`]
-{{waitfor}}delay\s+[\"'`]
-:\s*?goto
+;*?{{waitfor}}time\s+[\"'`]
+;*?{{waitfor}}delay\s+[\"'`]
+;.*?:\s*?goto
   ##!=>
   ##!<

--- a/util/regexp-assemble/data/942240.data
+++ b/util/regexp-assemble/data/942240.data
@@ -23,7 +23,7 @@ character
   ##!<
 
   ##!> assemble
-{{ticks}}
+{{ticks}};
   ##!=>
 ;{{waitfor}}time\s+[\"'`]
 ;{{waitfor}}delay\s+[\"'`]

--- a/util/regexp-assemble/data/942240.data
+++ b/util/regexp-assemble/data/942240.data
@@ -27,6 +27,6 @@ character
   ##!=>
 {{waitfor}}time\s+[\"'`]
 {{waitfor}}delay\s+[\"'`]
-;.*?:\s*?goto
+.*?:\s*?goto
   ##!=>
   ##!<

--- a/util/regexp-assemble/data/942240.data
+++ b/util/regexp-assemble/data/942240.data
@@ -26,7 +26,7 @@ character
 {{ticks}};
   ##!=>
 {{waitfor}}time\s+[\"'`]
-;{{waitfor}}delay\s+[\"'`]
+{{waitfor}}delay\s+[\"'`]
 ;.*?:\s*?goto
   ##!=>
   ##!<

--- a/util/regexp-assemble/data/942240.data
+++ b/util/regexp-assemble/data/942240.data
@@ -23,10 +23,10 @@ character
   ##!<
 
   ##!> assemble
-{{ticks}};
+{{ticks}}
   ##!=>
-{{waitfor}}time\s+[\"'`]
-{{waitfor}}delay\s+[\"'`]
-.*?:\s*?goto
+;{{waitfor}}time\s+[\"'`]
+;{{waitfor}}delay\s+[\"'`]
+;.*?:\s*?goto
   ##!=>
   ##!<

--- a/util/regexp-assemble/data/942240.data
+++ b/util/regexp-assemble/data/942240.data
@@ -8,9 +8,9 @@
 
 ##!> template set \s+set\s+\w+
 
-##!> template ticks [\"'`]
+##!> template ticks-semicolon-lazy [\"'`];*?
 
-##!> template waitfor .*?\s*?waitfor\s+
+##!> template waitfor \s*?waitfor\s+
 
 ##! Main assembly
   ##!> assemble
@@ -23,10 +23,10 @@ character
   ##!<
 
   ##!> assemble
-{{ticks}};
+{{ticks-semicolon-lazy}}
   ##!=>
 {{waitfor}}time\s+[\"'`]
 {{waitfor}}delay\s+[\"'`]
-.*?:\s*?goto
+:\s*?goto
   ##!=>
   ##!<


### PR DESCRIPTION
This PR closes #2859 by disassembling data file of 942240. @theseion confirmed that it doesn't make sense to disassemble 94230. So I did not touch this one.

The generated rule looks a bit different (also according to `regexp-assemble.py compare`) but it's still valid.