### PR TITLE
fix 942190 : Update 942190.data and rebuild rule with crs-toolchain.

### DIFF
--- a/regex-assembly/942190.ra
+++ b/regex-assembly/942190.ra
@@ -3,25 +3,27 @@
 
 ##!+ i
 
-[\"'`]\s*?!\s*?[\"'`\w]
-[\"'`];?\s*?having\b\s*?[^\s]
-[\"'`];?\s*?select\b\s*?[^\s]
-[\"'`];?\s*?union\b\s*?all\b\s*?[^\s]
-[\"'`];?\s*?union\b\s*?distinct\b\s*?[^\s]
-[\"'`];?\s*?union\b\s*?select\b\s*?[^\s]
+##!> template quotes [\"'`]
+
+{{quotes}}\s*!\s*[\"'`\w]
+{{quotes}};?\s*having\b\s*[^\s]
+{{quotes}};?\s*select\b\s*[^\s]
+{{quotes}};?\s*union\b\s*all\b\s*[^\s]
+{{quotes}};?\s*union\b\s*distinct\b\s*[^\s]
+{{quotes}};?\s*union\b\s*select\b\s*[^\s]
 \s*?exec.*?\Wxp_cmdshell
 \s*?execute.*?\Wxp_cmdshell
 \Wiif\s*?\(
-\bconnection_id\s*?\([^\)]*?
-\bcurrent_user\s*?\([^\)]*?
-\bdatabase\s*?\([^\)]*?
+\bconnection_id\s*?\(
+\bcurrent_user\s*?\(
+\bdatabase\s*?\(
 \bexec\s+master\.
 \bexecute\s+master\.
 \bfrom\W+information_schema\W
-\binto[\s+]+dumpfile\s*?[\"'`]
-\binto[\s+]+outfile\s*?[\"'`]
-\bschema\s*?\([^\)]*?
+\binto[\s+]+dumpfile\s*?{{quotes}}
+\binto[\s+]+outfile\s*?{{quotes}}
+\bschema\s*?\(
 \bselect.*?\w?user\(
 \bunion\sselect\s@
 \bunion[\w(\s]*?select
-\buser\s*?\([^\)]*?
+\buser\s*\(

--- a/regex-assembly/942190.ra
+++ b/regex-assembly/942190.ra
@@ -3,7 +3,7 @@
 
 ##!+ i
 
-##!> template quotes [\"'`]
+##!> define quotes [\"'`]
 
 {{quotes}}\s*!\s*[\"'`\w]
 {{quotes}};?\s*having\b\s*[^\s]

--- a/regex-assembly/942190.ra
+++ b/regex-assembly/942190.ra
@@ -5,25 +5,57 @@
 
 ##!> define quotes [\"'`]
 
-{{quotes}}\s*!\s*[\"'`\w]
-{{quotes}};?\s*having\b\s*[^\s]
-{{quotes}};?\s*select\b\s*[^\s]
-{{quotes}};?\s*union\b\s*all\b\s*[^\s]
-{{quotes}};?\s*union\b\s*distinct\b\s*[^\s]
-{{quotes}};?\s*union\b\s*select\b\s*[^\s]
+##!> assemble
+  {{quotes}}
+  ##!=>
+  \s*!\s*[\"'`\w]
+  ##!> assemble
+    ;?\s*
+    ##!=>
+    having
+    select
+    ##!> assemble
+      union\b\s*
+      ##!=>
+      all
+      distinct
+      select
+    ##!<
+    ##!=>
+    \b\s*[^\s]
+  ##!<
+##!<
+
+##!> assemble
+  \b
+  ##!=>
+  ##!> assemble
+    connection_id
+    current_user
+    database
+    schema
+    user
+    ##!=>
+    \s*?\(
+  ##!<
+
+  exec\s+master\.
+  execute\s+master\.
+  from\W+information_schema\W
+  ##!> assemble
+    into[\s+]+
+    ##!=>
+    dumpfile
+    outfile
+    ##!=>
+    \s*?{{quotes}}
+  ##!<
+
+  select.*?\w?user\(
+  union\sselect\s@
+  union[\w(\s]*?select
+##!<
+
 \s*?exec.*?\Wxp_cmdshell
 \s*?execute.*?\Wxp_cmdshell
 \Wiif\s*?\(
-\bconnection_id\s*?\(
-\bcurrent_user\s*?\(
-\bdatabase\s*?\(
-\bexec\s+master\.
-\bexecute\s+master\.
-\bfrom\W+information_schema\W
-\binto[\s+]+dumpfile\s*?{{quotes}}
-\binto[\s+]+outfile\s*?{{quotes}}
-\bschema\s*?\(
-\bselect.*?\w?user\(
-\bunion\sselect\s@
-\bunion[\w(\s]*?select
-\buser\s*\(

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -203,7 +203,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 942190
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\"'`](?:[\s\v]*![\s\v]*[\"'0-9A-Z_-z]|;?[\s\v]*(?:having|select|union\b[\s\v]*(?:all|(?:distin|sele)ct))\b[\s\v]*[^\s\v])|[\s\v]*?exec(?:ute)?.*?[^0-9A-Z_a-z]xp_cmdshell|[^0-9A-Z_a-z]iif[\s\v]*?\(|\b(?:(?:(?:c(?:onnection_id|urrent_user)|database)[\s\v]*?|s(?:chema[\s\v]*?|elect.*?[0-9A-Z_a-z]?user))\(|exec(?:ute)?[\s\v]+master\.|from[^0-9A-Z_a-z]+information_schema[^0-9A-Z_a-z]|into[\s\v\+]+(?:dump|out)file[\s\v]*?[\"'`]|u(?:nion(?:[\s\v]select[\s\v]@|[\s\v\(0-9A-Z_a-z]*?select)|ser[\s\v]*\())" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\"'`](?:[\s\v]*![\s\v]*[\"'0-9A-Z_-z]|;?[\s\v]*(?:having|select|union\b[\s\v]*(?:all|(?:distin|sele)ct))\b[\s\v]*[^\s\v])|\b(?:(?:(?:c(?:onnection_id|urrent_user)|database|schema|user)[\s\v]*?|select.*?[0-9A-Z_a-z]?user)\(|exec(?:ute)?[\s\v]+master\.|from[^0-9A-Z_a-z]+information_schema[^0-9A-Z_a-z]|into[\s\v\+]+(?:dump|out)file[\s\v]*?[\"'`]|union(?:[\s\v]select[\s\v]@|[\s\v\(0-9A-Z_a-z]*?select))|[\s\v]*?exec(?:ute)?.*?[^0-9A-Z_a-z]xp_cmdshell|[^0-9A-Z_a-z]iif[\s\v]*?\(" \
     "id:942190,\
     phase:2,\
     block,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -203,7 +203,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 942190
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\"'`](?:[\s\v]*?![\s\v]*?[\"'0-9A-Z_-z]|;?[\s\v]*?(?:having|select|union\b[\s\v]*?(?:all|(?:distin|sele)ct))\b[\s\v]*?[^\s\v])|[\s\v]*?exec(?:ute)?.*?[^0-9A-Z_a-z]xp_cmdshell|[^0-9A-Z_a-z]iif[\s\v]*?\(|\b(?:(?:c(?:onnection_id|urrent_user)|database)[\s\v]*?\([^\)]*?|exec(?:ute)?[\s\v]+master\.|from[^0-9A-Z_a-z]+information_schema[^0-9A-Z_a-z]|into[\s\v\+]+(?:dump|out)file[\s\v]*?[\"'`]|s(?:chema[\s\v]*?\([^\)]*?|elect.*?[0-9A-Z_a-z]?user\()|u(?:nion(?:[\s\v]select[\s\v]@|[\s\v\(0-9A-Z_a-z]*?select)|ser[\s\v]*?\([^\)]*?))" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\"'`](?:[\s\v]*![\s\v]*[\"'0-9A-Z_-z]|;?[\s\v]*(?:having|select|union\b[\s\v]*(?:all|(?:distin|sele)ct))\b[\s\v]*[^\s\v])|[\s\v]*?exec(?:ute)?.*?[^0-9A-Z_a-z]xp_cmdshell|[^0-9A-Z_a-z]iif[\s\v]*?\(|\b(?:(?:(?:c(?:onnection_id|urrent_user)|database)[\s\v]*?|s(?:chema[\s\v]*?|elect.*?[0-9A-Z_a-z]?user))\(|exec(?:ute)?[\s\v]+master\.|from[^0-9A-Z_a-z]+information_schema[^0-9A-Z_a-z]|into[\s\v\+]+(?:dump|out)file[\s\v]*?[\"'`]|u(?:nion(?:[\s\v]select[\s\v]@|[\s\v\(0-9A-Z_a-z]*?select)|ser[\s\v]*\())" \
     "id:942190,\
     phase:2,\
     block,\


### PR DESCRIPTION
Update 942190.data and rebuild rule with crs-toolchain. Needed to replace :space: :^space: due to apache incompatibility. Needed to remove nested bracket for :space: and :nospace: inside character class"
[i2856 4967794a] Update 942190.data and rebuild rule with crs-toolchain. Needed to replace :space: :^space: due to apache incompatibility. Needed to remove nested bracket for :space: and :nospace: inside character class