### PR TITLE
feat(ci): only close issues awaiting for feedback

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,8 +13,8 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue has been open 120 days with no activity. Remove the stale label or comment, or this will be closed in 14 days'
+        stale-issue-message: 'This issue has been open 30 days waiting for feedback. Remove the stale label or comment, or this will be closed in 14 days'
         stale-issue-label: 'Stale issue'
         days-before-stale: 30
         days-before-close: 14
-        only-issue-labels: 'awaiting feedback'
+        only-issue-labels: ':hourglass_flowing_sand: awaiting feedback'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,5 +15,6 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has been open 120 days with no activity. Remove the stale label or comment, or this will be closed in 14 days'
         stale-issue-label: 'Stale issue'
-        days-before-stale: 120
+        days-before-stale: 30
         days-before-close: 14
+        only-issue-labels: 'awaiting feedback'


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Per dialog and decision in our DEV retreat, let's mark as stale only issues that are labeled `awaiting feedback` only, and shorten times to closing.