### PR TITLE
fix: match all occurrences of template regex on a single line

### DIFF
--- a/util/regexp-assemble/lib/processors/template.py
+++ b/util/regexp-assemble/lib/processors/template.py
@@ -36,8 +36,8 @@ class Template(Processor):
 
     # override
     def process_line(self, line: str):
-        match = self.template_regex.search(line)
-        if match and match.group(1) == self.identifier:
+        matches = self.template_regex.findall(line)
+        if self.identifier in matches:
             self.logger.debug('Found template %s in line %s', self.identifier, line)
             # need to use a function as the replacement to prevent Python from parsing
             # escape sequences

--- a/util/regexp-assemble/tests/preprocessor_test.py
+++ b/util/regexp-assemble/tests/preprocessor_test.py
@@ -575,7 +575,7 @@ regex with {{slashes}} and {{dots}}
         # character classes. They should either be consistently escaped or not.
         assert output == r'regex with [\/\] and {{dots}}'
 
-    def test_template_replaces_all(self, context):
+    def test_template_replaces_all_normal_order(self, context):
         contents = r'''##!> template slashes [/\]
 ##!> template dots [.,;]
 regex with {{slashes}} and {{dots}}
@@ -587,6 +587,20 @@ regex with {{slashes}} and {{dots}}
         # TODO: Regexp::Assemble is inconsistent with escaping forward slashes in
         # character classes. They should either be consistently escaped or not.
         assert output == r'regex with [/\] and [.,;]'
+
+    def test_template_replaces_all_inverse_order(self, context):
+        contents = r'''##!> template slashes [/\]
+##!> template dots [.,;]
+regex with {{dots}} and {{slashes}}
+'''
+        assembler = Assembler(context)
+
+        output = assembler._run(Peekerator(contents.splitlines()))
+
+        # TODO: Regexp::Assemble is inconsistent with escaping forward slashes in
+        # character classes. They should either be consistently escaped or not.
+        assert output == r'regex with [.,;] and [\/\]'
+
 
     def test_template_replaces_on_all_lines(self, context):
         contents = r'''##!> template slashes [/\]


### PR DESCRIPTION
See https://github.com/theseion/crs-toolchain/issues/24