### PR TITLE
fix(920610): CI is complaining about indented comment

### DIFF
--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920610.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920610.yaml
@@ -19,18 +19,18 @@ tests:
               Accept: text/html;q=0.9,*/*;q=0.8
           output:
             no_log_contains: "id \"920610\""
-  # Commented test because Apache errors before processing the rules, meaning it will always fail in our CI environment.
-  # - test_title: 920610-2
-  #  desc: Raw URL fragment test
-  #  stages:
-  #    - stage:
-  #        input:
-  #          dest_addr: "127.0.0.1"
-  #          port: 80
-  #          uri: "/#fragment"
-  #          headers:
-  #            User-Agent: "OWASP ModSecurity Core Rule Set"
-  #            Host: "localhost"
-  #            Accept: text/html;q=0.9,*/*;q=0.8
-  #        output:
-  #          log_contains: "id \"920610\""
+# Commented test because Apache errors before processing the rules, meaning it will always fail in our CI environment.
+#  - test_title: 920610-2
+#   desc: Raw URL fragment test
+#   stages:
+#     - stage:
+#         input:
+#           dest_addr: "127.0.0.1"
+#           port: 80
+#           uri: "/#fragment"
+#           headers:
+#             User-Agent: "OWASP ModSecurity Core Rule Set"
+#             Host: "localhost"
+#             Accept: text/html;q=0.9,*/*;q=0.8
+#         output:
+#           log_contains: "id \"920610\""


### PR DESCRIPTION
Every CI run is now outputting a warning:

```
Check warning on line 22 in tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920610.yaml
GitHub Actions / check-syntax
22:3 [comments-indentation] comment not indented like content
```

I hope this fixes it?