### PR TITLE
feat(test) - add status page test for 942500

### DIFF
--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942500.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942500.yaml
@@ -15,9 +15,25 @@ tests:
               Host: localhost
               User-Agent: OWASP ModSecurity Core Rule Set
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            method: POST
+            method: GET
             port: 80
             uri: "/?id=9999+or+{if+length((/*!5000select+username/*!50000from*/user+where+id=1))>0}"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942500"
+  - test_title: 942500-2
+    desc: "Status Page Test - MySQL inline comment detected"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/?test=9999+or+{if+length((/*!5000select+username/*!comment*/"
             version: HTTP/1.0
           output:
             log_contains: id "942500"


### PR DESCRIPTION
This PR adds test for status page 942500-2 and also fixes 942500-1 so that this only triggers one rule.
It was accidentally POST request without request body.