### PR TITLE
feat(test) - add status page test for 942270

### DIFF
--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942270.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942270.yaml
@@ -21,3 +21,19 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942270"
+  - test_title: 942270-2
+    desc: "Status Page Test - SQL injection test with Xunionselectfrom (missing word boundary at the beginning)"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/?test=Xunionselectfrom"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942270"


### PR DESCRIPTION
This PR adds the test 942270-2 that only triggers this one rule. Intentionally missing word boundary at the start so that this test does not trigger other sqli detection rules.