### PR TITLE
Add status page test for rule 920250

### DIFF
--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920250.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920250.yaml
@@ -57,3 +57,20 @@ tests:
               Proxy-Connection: "keep-alive"
           output:
             log_contains: "id \"920250\""
+  - test_title: 920250-4
+    desc: "Status Page Test - Invalid UTF-8 encoding: %C2%A3 is a valid Pound sign; %E2%A3 is invalid UTF-8 (incorrect starting binary sequence)"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            uri: "/?param=%E2%A3"
+            headers:
+              User-Agent: "OWASP ModSecurity Core Rule Set"
+              Host: "localhost"
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Accept-Language: "en-us,en;q=0.5"
+              Keep-Alive: "300"
+              Proxy-Connection: "keep-alive"
+          output:
+            log_contains: "id \"920250\""


### PR DESCRIPTION
PR adds a status page test for rule 920250 (a new test which only triggers this specific rule).

### Note:

**Important:** The 920250 tests are _disabled_ by default (see `enabled: false` at the top of the test file). I don't know why they're disabled, but this is important to be aware of if attempting to use this new test.