### PR TITLE
fix(test): fix encoded square bracket

### DIFF
--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932130.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932130.yaml
@@ -146,7 +146,7 @@ tests:
             method: GET
             port: 80
             # cat /[?]tc/pa[?]swd
-            uri: "/?cmd=cat%20/%5B%3F%Dtc/pa%5B%3F%5Dswd"
+            uri: "/?cmd=cat%20/%5B%3F%5Dtc/pa%5B%3F%5Dswd"
             version: HTTP/1.0
           output:
             log_contains: id "932130"


### PR DESCRIPTION
If I'm not missing something, we need a `%5D` here instead of `%D`.
I wonder how the test 032130-9 could pass as is...

maybe we need to investigate, isn't it?