### PR TITLE
fix(test): missing encoding on % char

### DIFF
--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932140.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932140.yaml
@@ -49,7 +49,7 @@ tests:
               User-Agent: OWASP ModSecurity Core Rule Set
             method: GET
             port: 80
-            uri: /?foo=for%20%2fd%20%variable%20in%20%28set%29%20do%20command
+            uri: /?foo=for%20%2fd%20%25variable%20in%20%28set%29%20do%20command
             version: HTTP/1.0
           output:
             log_contains: id "932140"


### PR DESCRIPTION
this PR fixes the 932140-3 test, by encoding character % to %25