### PR TITLE
test: enable utf8 encoding validation

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -13,7 +13,6 @@ services:
       PORT: "80"
       MODSEC_RULE_ENGINE: DetectionOnly
       BLOCKING_PARANOIA: 4
-      TZ: "${TZ}"
       ERRORLOG: "/var/log/error.log"
       ACCESSLOG: "/var/log/access.log"
       MODSEC_AUDIT_LOG_FORMAT: Native
@@ -25,6 +24,7 @@ services:
       MAX_FILE_SIZE: "64100"
       COMBINED_FILE_SIZES: "65535"
       CRS_ENABLE_TEST_MARKER: 1
+      VALIDATE_UTF8_ENCODING: 1
     volumes:
       - ./logs/modsec2-apache:/var/log:rw
       - ../rules:/opt/owasp-crs/rules:ro
@@ -46,7 +46,6 @@ services:
       PORT: "80"
       MODSEC_RULE_ENGINE: DetectionOnly
       BLOCKING_PARANOIA: 4
-      TZ: "${TZ}"
       ERRORLOG: "/var/log/error.log"
       LOGLEVEL: "info"
       ACCESSLOG: "/var/log/access.log"
@@ -58,6 +57,7 @@ services:
       MAX_FILE_SIZE: "64100"
       COMBINED_FILE_SIZES: "65535"
       CRS_ENABLE_TEST_MARKER: 1
+      VALIDATE_UTF8_ENCODING: 1
     volumes:
       - ./logs/modsec3-nginx:/var/log:rw
       - ../rules:/opt/owasp-crs/rules:ro

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920250.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920250.yaml
@@ -1,7 +1,7 @@
 ---
 meta:
   author: "csanders-git"
-  enabled: false
+  enabled: true
   name: "920250.yaml"
   description: "Description"
 tests:


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

- enable variable `VALIDATE_UTF8_ENCODING`
- now that tests use markers, remove unused `TZ`

Fixes #2983.