### PR TITLE
fix: cleanup initial comment

### DIFF
--- a/data/932151.data
+++ b/data/932151.data
@@ -1,25 +1,5 @@
-##! This is a data file used to generate a regular expression for a CRS rule.
-##! The generation of the regular expression happens with the help of
-##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file.
-##! Read more about the format of this data file and the use of the assembly
-##! script in util/regexp-assemble/README.md.
-##!
-##! Lines starting with `##!` are comments and will be skipped,
-##! empty lines will be ignored completely.
-##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##!
-##! Five special comments are at your disposal to influence the assembled expression:
-##! - `##!+`: the flag comment
-##! - `##!^`: the prefix comment
-##! - `##!$`: the suffix comment
-##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
-##!
-##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation.
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regexp_assemble/.
 
 ##! RegEx list for rule 932151 (RCE Unix command injection)
 

--- a/data/934101.data
+++ b/data/934101.data
@@ -1,26 +1,5 @@
-##! This is a data file used to generate a regular expression for a CRS rule.
-##! The generation of the regular expression happens with the help of
-##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file.
-##! Read more about the format of this data file and the use of the assembly
-##! script in util/regexp-assemble/README.md.
-##!
-##! Lines starting with `##!` are comments and will be skipped,
-##! empty lines will be ignored completely.
-##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##!
-##! Five special comments are at your disposal to influence the assembled expression:
-##! - `##!+`: the flag comment
-##! - `##!^`: the prefix comment
-##! - `##!$`: the suffix comment
-##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
-##!
-##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation
-
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regexp_assemble/.
 
 close\s*\(
 exists\s*\(

--- a/data/934140.data
+++ b/data/934140.data
@@ -1,25 +1,5 @@
-##! This is a data file used to generate a regular expression for a CRS rule.
-##! The generation of the regular expression happens with the help of
-##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file.
-##! Read more about the format of this data file and the use of the assembly
-##! script in util/regexp-assemble/README.md.
-##!
-##! Lines starting with `##!` are comments and will be skipped,
-##! empty lines will be ignored completely.
-##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##!
-##! Five special comments are at your disposal to influence the assembled expression:
-##! - `##!+`: the flag comment
-##! - `##!^`: the prefix comment
-##! - `##!$`: the suffix comment
-##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
-##!
-##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation.
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regexp_assemble/.
 
 ##! RegEx list for rule 934140
 

--- a/data/934150.data
+++ b/data/934150.data
@@ -1,25 +1,5 @@
-##! This is a data file used to generate a regular expression for a CRS rule.
-##! The generation of the regular expression happens with the help of
-##! util/regexp-assemble/regexp-assemble.py.
-##! The ID of the rule in question is part of the file name of this data file.
-##! Read more about the format of this data file and the use of the assembly
-##! script in util/regexp-assemble/README.md.
-##!
-##! Lines starting with `##!` are comments and will be skipped,
-##! empty lines will be ignored completely.
-##! In addition, the quote character `'` at the beginning of a line will
-##! cause the line to be interpreted as literal by the cmdline preprocessor only.
-##!
-##! Five special comments are at your disposal to influence the assembled expression:
-##! - `##!+`: the flag comment
-##! - `##!^`: the prefix comment
-##! - `##!$`: the suffix comment
-##! - `##!>`: the preprocessor comment
-##! - `##!<`: the block preprocessor end comment
-##!
-##! Currently supported preprocessors:
-##! - cmdline [windows|unix] (file scope)
-##! Please refer to util/regexp-assemble/README.md for a full explanation.
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regexp_assemble/.
 
 ##! RegEx list for rule 934150
 


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Cleanup old commented header versions.