### PR TITLE
fix(942320) - add postgres data types and multiple plus minus signs

### DIFF
--- a/regex-assembly/942320.ra
+++ b/regex-assembly/942320.ra
@@ -6,7 +6,7 @@
 create\s+function\s*?\w+\s*?\(\s*?\)\s*?-
 create\s+procedure\s*?\w+\s*?\(\s*?\)\s*?-
 declare[^\w]+[@#]\s*?\w+
-div\s*?\([+-]?[\d.\s]+,[+-]?[\d.\s]+\)
+div\s*?\([+-]*[\d.\s]+,[+-]*[\d.\s]+\)
 exec\s*?\(\s*?@
 lo_import\s*?\(
 lo_get\s*?\(

--- a/regex-assembly/942320.ra
+++ b/regex-assembly/942320.ra
@@ -13,6 +13,13 @@ lo_get\s*?\(
 procedure\s+analyse\s*?\(
 ;\s*?declare\s+[\w-]+
 ;\s*?open\s+[\w-]+
-::int
+::bigint
 ::bool
+::double\s+precision
+::int
+::integer
+::numeric
+::oid
+::real
 ::text
+::smallint

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -399,7 +399,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 942320
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)create[\s\v]+(?:function|procedure)[\s\v]*?[0-9A-Z_a-z]+[\s\v]*?\([\s\v]*?\)[\s\v]*?-|d(?:eclare[^0-9A-Z_a-z]+[#@][\s\v]*?[0-9A-Z_a-z]+|iv[\s\v]*?\([\+\-]?[\s\v\.0-9]+,[\+\-]?[\s\v\.0-9]+\))|exec[\s\v]*?\([\s\v]*?@|(?:lo_(?:impor|ge)t|procedure[\s\v]+analyse)[\s\v]*?\(|;[\s\v]*?(?:declare|open)[\s\v]+[\-0-9A-Z_a-z]+|::(?:b(?:igint|ool)|double[\s\v]+precision|int(?:eger)?|numeric|oid|real|(?:tex|smallin)t)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)create[\s\v]+(?:function|procedure)[\s\v]*?[0-9A-Z_a-z]+[\s\v]*?\([\s\v]*?\)[\s\v]*?-|d(?:eclare[^0-9A-Z_a-z]+[#@][\s\v]*?[0-9A-Z_a-z]+|iv[\s\v]*?\([\+\-]*[\s\v\.0-9]+,[\+\-]*[\s\v\.0-9]+\))|exec[\s\v]*?\([\s\v]*?@|(?:lo_(?:impor|ge)t|procedure[\s\v]+analyse)[\s\v]*?\(|;[\s\v]*?(?:declare|open)[\s\v]+[\-0-9A-Z_a-z]+|::(?:b(?:igint|ool)|double[\s\v]+precision|int(?:eger)?|numeric|oid|real|(?:tex|smallin)t)" \
     "id:942320,\
     phase:2,\
     block,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -399,7 +399,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 942320
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)create[\s\v]+(?:function|procedure)[\s\v]*?[0-9A-Z_a-z]+[\s\v]*?\([\s\v]*?\)[\s\v]*?-|d(?:eclare[^0-9A-Z_a-z]+[#@][\s\v]*?[0-9A-Z_a-z]+|iv[\s\v]*?\([\+\-]?[\s\v\.0-9]+,[\+\-]?[\s\v\.0-9]+\))|exec[\s\v]*?\([\s\v]*?@|(?:lo_(?:impor|ge)t|procedure[\s\v]+analyse)[\s\v]*?\(|;[\s\v]*?(?:declare|open)[\s\v]+[\-0-9A-Z_a-z]+|::(?:(?:in|tex)t|bool)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)create[\s\v]+(?:function|procedure)[\s\v]*?[0-9A-Z_a-z]+[\s\v]*?\([\s\v]*?\)[\s\v]*?-|d(?:eclare[^0-9A-Z_a-z]+[#@][\s\v]*?[0-9A-Z_a-z]+|iv[\s\v]*?\([\+\-]?[\s\v\.0-9]+,[\+\-]?[\s\v\.0-9]+\))|exec[\s\v]*?\([\s\v]*?@|(?:lo_(?:impor|ge)t|procedure[\s\v]+analyse)[\s\v]*?\(|;[\s\v]*?(?:declare|open)[\s\v]+[\-0-9A-Z_a-z]+|::(?:b(?:igint|ool)|double[\s\v]+precision|int(?:eger)?|numeric|oid|real|(?:tex|smallin)t)" \
     "id:942320,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942320.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942320.yaml
@@ -184,3 +184,35 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942320"
+  - test_title: 942320-12
+    desc: "Detects PostgreSQL bypass attempt function(foo)::text - issue #2924"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/index.php?id=function(foo)::bigint"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942320"
+  - test_title: 942320-13
+    desc: "Detects PostgreSQL bypass attempt function(foo)::text - issue #2924"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/index.php?id=function(foo)::double%20precision"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942320"

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942320.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942320.yaml
@@ -185,7 +185,7 @@ tests:
           output:
             log_contains: id "942320"
   - test_title: 942320-12
-    desc: "Detects PostgreSQL bypass attempt function(foo)::text - issue #2924"
+    desc: "Detects PostgreSQL bypass attempt function(foo)::bigint - issue #2924"
     stages:
       - stage:
           input:
@@ -201,7 +201,7 @@ tests:
           output:
             log_contains: id "942320"
   - test_title: 942320-13
-    desc: "Detects PostgreSQL bypass attempt function(foo)::text - issue #2924"
+    desc: "Detects PostgreSQL bypass attempt function(foo)::double precision - issue #2924"
     stages:
       - stage:
           input:


### PR DESCRIPTION
This PR adds additional PostgreSQL data types. Shivam reviewed my [latest changes](https://github.com/coreruleset/coreruleset/pull/2872) and found new data types. He also provided PoCs.
This PR here makes the coverage or the detection more robust.

Source is: https://www.postgresql.org/docs/current/datatype.html.
But not every data type can be used to craft an attack.

And this PR also fixes a bypass with multiple (`*`) + and - characters before numbers, not only 0 or 1 (`?`).

So this PR fixes 2 of the 6 new bypasses submitted by Shivam: https://github.com/coreruleset/security-tracker-private/issues/4
