### PR TITLE
chore: update 934101 to use regex-assembly

### DIFF
--- a/regex-assembly/934101.ra
+++ b/regex-assembly/934101.ra
@@ -1,12 +1,14 @@
 ##! Please refer to the documentation at
 ##! https://coreruleset.org/docs/development/regex_assembly/.
 
-close\s*\(
-exists\s*\(
-fork\s*\(
-open\s*\(
-read\s*\(
-spawn\s*\(
-watch\s*\(
-write\s*\(
-require\s*\(
+##!$ \s*\(
+
+close
+exists
+fork
+open
+read
+spawn
+watch
+write
+require


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Move to regex-assembly.