### PR TITLE
Fix (932180): Correct multipart headers in test 932180-2

### DIFF
--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932180.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932180.yaml
@@ -46,6 +46,8 @@ tests:
 
               ... Some content ...
               ------WebKitFormBoundaryABCDEFGIJKLMNOPQ
+              Content-Disposition: form-data; name="image"; filename="test.png"
+              Content-Type: image/png
 
               BINARYDATA
               ------WebKitFormBoundaryABCDEFGIJKLMNOPQ--


### PR DESCRIPTION
932180-2 has a broken MIME header. This breaks the test unless the server is configured to ignore recommended rules 200002 and 200003. This fixes the MIME header.