### PR TITLE
fix(data): optimized regex for 933211 w/ crs-toolchain

### DIFF
--- a/regex-assembly/933210.ra
+++ b/regex-assembly/933210.ra
@@ -8,24 +8,24 @@
 ##!$ ;
 
 ##!> assemble
-    ##! example payload: (system)(ls);
-    {{string_in_round_brackets}}{{string_in_round_brackets}}
+  ##! example payload: (system)(ls);
+  {{string_in_round_brackets}}{{string_in_round_brackets}}
 
-    ##! example payload: (sys)"tem"(ls);
-    {{string_in_round_brackets}}{{single_or_double_quotes}}[a-zA-Z-_0-9]+{{single_or_double_quotes}}{{string_in_round_brackets}}
-    
-    ##! example payload: a=system&b=$_GET[0](ls);
-    \[\d+\]{{string_in_round_brackets}}
+  ##! example payload: (sys)"tem"(ls);
+  {{string_in_round_brackets}}{{single_or_double_quotes}}[a-zA-Z-_0-9]+{{single_or_double_quotes}}{{string_in_round_brackets}}
 
-    ##! example payload: {0}("ls")
-    \{\d+\}{{string_in_round_brackets}}
+  ##! example payload: a=system&b=$_GET[0](ls);
+  \[\d+\]{{string_in_round_brackets}}
 
-    ##! example payload: $a("ls")
-    \$[^(\),.;\x5c/]+{{string_in_round_brackets}}
+  ##! example payload: {0}("ls")
+  \{\d+\}{{string_in_round_brackets}}
 
-    ##! example payload: "system"("ls")
-    {{single_or_double_quotes}}[a-zA-Z0-9-_\x5c]+{{single_or_double_quotes}}{{string_in_round_brackets}}
+  ##! example payload: $a("ls")
+  \$[^(\),.;\x5c/]+{{string_in_round_brackets}}
 
-    ##! example payload: (string)system("ls")
-    \([^\)]*string[^\)]*\)[a-zA-Z-_0-9\"'.{}\[\]\s]+\([^\)]*\)
+  ##! example payload: "system"("ls")
+  {{single_or_double_quotes}}[a-zA-Z0-9-_\x5c]+{{single_or_double_quotes}}{{string_in_round_brackets}}
+
+  ##! example payload: (string)system("ls")
+  \([^\)]*string[^\)]*\)[a-zA-Z-_0-9\"'.{}\[\]\s]+\([^\)]*\)
 ##!<

--- a/regex-assembly/933210.ra
+++ b/regex-assembly/933210.ra
@@ -1,0 +1,31 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Helpers
+##!> define single_or_double_quotes ['"]
+##!> define string_in_round_brackets \(.+\)
+
+##!$ ;
+
+##!> assemble
+    ##! example payload: (system)(ls);
+    {{string_in_round_brackets}}{{string_in_round_brackets}}
+
+    ##! example payload: (sys)"tem"(ls);
+    {{string_in_round_brackets}}{{single_or_double_quotes}}[a-zA-Z-_0-9]+{{single_or_double_quotes}}{{string_in_round_brackets}}
+    
+    ##! example payload: a=system&b=$_GET[0](ls);
+    \[\d+\]{{string_in_round_brackets}}
+
+    ##! example payload: {0}("ls")
+    \{\d+\}{{string_in_round_brackets}}
+
+    ##! example payload: $a("ls")
+    \$[^(\),.;\x5c/]+{{string_in_round_brackets}}
+
+    ##! example payload: "system"("ls")
+    {{single_or_double_quotes}}[a-zA-Z0-9-_\x5c]+{{single_or_double_quotes}}{{string_in_round_brackets}}
+
+    ##! example payload: (string)system("ls")
+    \([^\)]*string[^\)]*\)[a-zA-Z-_0-9\"'.{}\[\]\s]+\([^\)]*\)
+##!<

--- a/regex-assembly/933211.ra
+++ b/regex-assembly/933211.ra
@@ -1,0 +1,30 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Helpers
+##!> define single_or_double_quotes ['"]
+##!> define string_in_round_brackets \(.+\)
+##!$ (?:;|$)?
+
+##!> assemble
+  ##! example payload: (system)(ls)
+  {{string_in_round_brackets}}{{string_in_round_brackets}}
+  
+  ##! example payload: (sys)"tem"(ls)
+  {{string_in_round_brackets}}{{single_or_double_quotes}}[a-zA-Z-_0-9]+{{single_or_double_quotes}}{{string_in_round_brackets}}
+  
+  ##! example payload: $_GET[0]("ls")
+  \[\d+\]{{string_in_round_brackets}}
+  
+  ##! example payload: {0}("ls")
+  \{\d+\}{{string_in_round_brackets}}
+  
+  ##! example payload: $a("ls")
+  \$[^(\),.;\x5c/]+{{string_in_round_brackets}}
+  
+  ##! example payload: "system"("ls")
+  {{single_or_double_quotes}}[a-zA-Z0-9-_\x5c]+{{single_or_double_quotes}}{{string_in_round_brackets}}
+  
+  ##! example payload: (string)system("ls")
+  \([^\)]*string[^\)]*\)[a-zA-Z-_0-9\"'.{}\[\]\s]+\([^\)]*\)
+##!<

--- a/regex-assembly/933211.ra
+++ b/regex-assembly/933211.ra
@@ -9,22 +9,22 @@
 ##!> assemble
   ##! example payload: (system)(ls)
   {{string_in_round_brackets}}{{string_in_round_brackets}}
-  
+
   ##! example payload: (sys)"tem"(ls)
   {{string_in_round_brackets}}{{single_or_double_quotes}}[a-zA-Z-_0-9]+{{single_or_double_quotes}}{{string_in_round_brackets}}
-  
+
   ##! example payload: $_GET[0]("ls")
   \[\d+\]{{string_in_round_brackets}}
-  
+
   ##! example payload: {0}("ls")
   \{\d+\}{{string_in_round_brackets}}
-  
+
   ##! example payload: $a("ls")
   \$[^(\),.;\x5c/]+{{string_in_round_brackets}}
-  
+
   ##! example payload: "system"("ls")
   {{single_or_double_quotes}}[a-zA-Z0-9-_\x5c]+{{single_or_double_quotes}}{{string_in_round_brackets}}
-  
+
   ##! example payload: (string)system("ls")
   \([^\)]*string[^\)]*\)[a-zA-Z-_0-9\"'.{}\[\]\s]+\([^\)]*\)
 ##!<

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -490,7 +490,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
 # - [ACME] this is a test (just a test)
 # - Test (with two) rounded (brackets)
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@rx (\(.+\)\(.+\)|\(.+\)['\"][a-zA-Z-_0-9]+['\"]\(.+\)|\[\d+\]\(.+\)|\{\d+\}\(.+\)|\$[^(\),.;\x5c/]+\(.+\)|[\"'][a-zA-Z0-9-_\x5c]+[\"']\(.+\)|\([^\)]*string[^\)]*\)[a-zA-Z-_0-9\"'.{}\[\]\s]+\([^\)]*\));" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@rx (?:\((?:.+\)(?:[\"'][\-0-9A-Z_a-z]+[\"'])?\(.+|[^\)]*string[^\)]*\)[\s\v\"'\--\.0-9A-\[\]_a-\{\}]+\([^\)]*)|(?:\[[0-9]+\]|\{[0-9]+\}|\$[^\(-\),\.-/;\x5c]+|[\"'][\-0-9A-Z\x5c_a-z]+[\"'])\(.+)\);" \
     "id:933210,\
     phase:2,\
     block,\

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -490,6 +490,11 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
 # - [ACME] this is a test (just a test)
 # - Test (with two) rounded (brackets)
 #
+# Regular expression generated from regex-assembly/933210.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 933210
+#
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@rx (?:\((?:.+\)(?:[\"'][\-0-9A-Z_a-z]+[\"'])?\(.+|[^\)]*string[^\)]*\)[\s\v\"'\--\.0-9A-\[\]_a-\{\}]+\([^\)]*)|(?:\[[0-9]+\]|\{[0-9]+\}|\$[^\(-\),\.-/;\x5c]+|[\"'][\-0-9A-Z\x5c_a-z]+[\"'])\(.+)\);" \
     "id:933210,\
     phase:2,\

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -739,7 +739,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #
 # Any potential function calls not at the end of a string will require a semi-colon to form valid PHP, which is automatically covered by 933210.
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@rx (\(.+\)\(.+\)|\(.+\)['\"][a-zA-Z-_0-9]+['\"]\(.+\)|\[\d+\]\(.+\)|\{\d+\}\(.+\)|\$[^(\),.;\x5c/]+\(.+\)|[\"'][a-zA-Z0-9-_\x5c]+[\"']\(.+\)|\([^\)]*string[^\)]*\)[a-zA-Z-_0-9\"'.{}\[\]\s]+\([^\)]*\))(?:;|$)" \
+# Regular expression generated from regex-assembly/933211.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 933211
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@rx (?:\((?:.+\)(?:[\"'][\-0-9A-Z_a-z]+[\"'])?\(.+|[^\)]*string[^\)]*\)[\s\v\"'\--\.0-9A-\[\]_a-\{\}]+\([^\)]*)|(?:\[[0-9]+\]|\{[0-9]+\}|\$[^\(-\),\.-/;\x5c]+|[\"'][\-0-9A-Z\x5c_a-z]+[\"'])\(.+)\)(?:;|$)?" \
     "id:933211,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933211.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933211.yaml
@@ -287,7 +287,7 @@ tests:
             uri: /?code=%22%5Cx73y%5Cx73tem%22%28ls%29%3B
           output:
             log_contains: id "933211"
-  - test_title: 933211-22
+  - test_title: 933211-21
     desc: Block function call bypass '(sy.(st).em)(@id)' (without trailing semi-colon)
     stages:
       - stage:

--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933211.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933211.yaml
@@ -287,20 +287,6 @@ tests:
             uri: /?code=%22%5Cx73y%5Cx73tem%22%28ls%29%3B
           output:
             log_contains: id "933211"
-  - test_title: 933211-21
-    desc: Check false-positive for "this is a 'dog' (not a cat)."
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            uri: /?code=this%20is%20a%20'dog'%20(not%20a%20cat).
-          output:
-            no_log_contains: id "933211"
   - test_title: 933211-22
     desc: Block function call bypass '(sy.(st).em)(@id)' (without trailing semi-colon)
     stages:


### PR DESCRIPTION
referring to #2581 
the bb test works as expected on sandbox (payload blocked at PL3 by 933211)

```
$ curl -i -H "x-format-output: txt-matched-rules" -H "x-backend: apache" -H "x-crs-version: nightly" -H "x-crs-paranoia-level: 3" "https://sandbox.coreruleset.org" -G --data-urlencode "code=(sy.(st).em)(@id)"
HTTP/1.1 200 OK
Date: Wed, 23 Nov 2022 09:20:17 GMT
Content-Type: text/plain
Transfer-Encoding: chunked
Connection: keep-alive
X-Unique-ID: Y33l0Z2dMj7W2sk7D7FPGQAAAJI
x-backend: apache-nightly

933211 PL3 PHP Injection Attack: Variable Function Call Found
942431 PL3 Restricted SQL Character Anomaly Detection (args): # of special characters exceeded (6)
949110 PL1 Inbound Anomaly Score Exceeded (Total Score: 8)
980170 PL1 Anomaly Scores: (Inbound Scores: blocking=8, detection=8, per_pl=0-0-8-0, threshold=5) - (Outbound Scores: blocking=0, detection=0, per_pl=0-0-0-0, threshold=4) - (SQLI=3, XSS=0, RFI=0, LFI=0, RCE=0, PHPI=5, HTTP=0, SESS=0)
```

this PR adds data file for a better description and optimization of the regex