### PR TITLE
Add missing entries to php-confi-directives.data

### DIFF
--- a/rules/php-config-directives.data
+++ b/rules/php-config-directives.data
@@ -91,6 +91,7 @@ docref_ext
 docref_root
 enable_dl
 enable_post_data_reading
+engine
 error_append_string
 error_log
 error_prepend_string
@@ -102,6 +103,7 @@ exif.decode_unicode_motorola
 exif.encode_jis
 exif.encode_unicode
 exit_on_timeout
+extension
 expect.logfile
 expect.loguser
 expect.match_max
@@ -180,6 +182,8 @@ mbstring.http_output
 mbstring.http_output_conv_mimetypes
 mbstring.internal_encoding
 mbstring.language
+mbstring.regex_retry_limit
+mbstring.regex_stack_limit
 mbstring.strict_detection
 mbstring.substitute_character
 mcrypt.algorithms_dir
@@ -360,6 +364,7 @@ phar.readonly
 phar.require_hash
 phpdbg.eol
 phpdbg.path
+precision
 post_max_size
 realpath_cache_size
 realpath_cache_ttl
@@ -433,6 +438,7 @@ session.use_only_cookies
 session.use_strict_mode
 session.use_trans_sid
 short_open_tag
+smtp
 smtp_port
 soap.wsdl_cache
 soap.wsdl_cache_dir
@@ -469,6 +475,7 @@ track_errors
 trader.real_precision
 trader.real_round_mode
 unserialize_callback_func
+unserialize_max_depth
 uopz.disable
 uopz.exit
 uopz.overloads

--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933120.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933120.yaml
@@ -41,3 +41,129 @@ tests:
             version: HTTP/1.0
           output:
             no_log_contains: = found within
+  - test_title: 933120-3
+    desc: "PHP Injection Attack: Configuration Directive: engine"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: "localhost"
+              Cache-Control: "no-cache, no-store, must-revalidate"
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            uri: '/post'
+            port: 80
+            data: "var=engine%3dtrue"
+            version: HTTP/1.0
+          output:
+            log_contains: id "933120"
+  - test_title: 933120-4
+    desc: "PHP Injection Attack: Configuration Directive: extension"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: "localhost"
+              Cache-Control: "no-cache, no-store, must-revalidate"
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            uri: '/post'
+            port: 80
+            data: "var=extension%3dtrue"
+            version: HTTP/1.0
+          output:
+            log_contains: id "933120"
+  - test_title: 933120-5
+    desc: "PHP Injection Attack: Configuration Directive: mbstring.regex_retry_limit"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: "localhost"
+              Cache-Control: "no-cache, no-store, must-revalidate"
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            uri: '/post'
+            port: 80
+            data: "var=mbstring.regex_retry_limit%3dtrue"
+            version: HTTP/1.0
+          output:
+            log_contains: id "933120"
+  - test_title: 933120-6
+    desc: "PHP Injection Attack: Configuration Directive: mbstring.regex_stack_limit"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: "localhost"
+              Cache-Control: "no-cache, no-store, must-revalidate"
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            uri: '/post'
+            port: 80
+            data: "var=mbstring.regex_stack_limit%3dtrue"
+            version: HTTP/1.0
+          output:
+            log_contains: id "933120"
+  - test_title: 933120-7
+    desc: "PHP Injection Attack: Configuration Directive: precision"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: "localhost"
+              Cache-Control: "no-cache, no-store, must-revalidate"
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            uri: '/post'
+            port: 80
+            data: "var=precision%3dtrue"
+            version: HTTP/1.0
+          output:
+            log_contains: id "933120"
+  - test_title: 933120-8
+    desc: "PHP Injection Attack: Configuration Directive: smtp"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: "localhost"
+              Cache-Control: "no-cache, no-store, must-revalidate"
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            uri: '/post'
+            port: 80
+            data: "var=smtp%3dtrue"
+            version: HTTP/1.0
+          output:
+            log_contains: id "933120"
+  - test_title: 933120-9
+    desc: "PHP Injection Attack: Configuration Directive: unserialize_max_depth"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: "localhost"
+              Cache-Control: "no-cache, no-store, must-revalidate"
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            uri: '/post'
+            port: 80
+            data: "var=unserialize_max_depth%3dtrue"
+            version: HTTP/1.0
+          output:
+            log_contains: id "933120"


### PR DESCRIPTION
Fixes failing curl calls from NFKUWKBD.

@theMiddleBlue I'm not entirely sure that all of these directives pose security threats. But they were part of the original report and @azurit put them into the curl calls.