### PR TITLE
Cleaning up TX variables

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -301,8 +301,7 @@ SecAction \
     nolog,\
     ver:'OWASP_CRS/4.0.0-rc1',\
     initcol:global=global,\
-    initcol:ip=%{remote_addr}_%{tx.ua_hash},\
-    setvar:'tx.real_ip=%{remote_addr}'"
+    initcol:ip=%{remote_addr}_%{tx.ua_hash}"
 
 #
 # -=[ Initialize Correct Body Processing ]=-

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -273,7 +273,8 @@ SecAction \
     setvar:'tx.outbound_anomaly_score_pl1=0',\
     setvar:'tx.outbound_anomaly_score_pl2=0',\
     setvar:'tx.outbound_anomaly_score_pl3=0',\
-    setvar:'tx.outbound_anomaly_score_pl4=0'"
+    setvar:'tx.outbound_anomaly_score_pl4=0',\
+    setvar:'tx.anomaly_score=0'"
 
 
 #

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1473,7 +1473,6 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i)^(?:[^']*?(?:'[^']*?'[^']*?)*?'|[^\"]*?(
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.942521_lhs=%{TX.1}',\
-    setvar:'tx.942521_full=%{TX.0}',\
     chain"
     SecRule TX:942521_lhs "@rx ^(?:and|or)$" \
         "t:none,\

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -91,7 +91,7 @@ SecAction \
     msg:'Anomaly Scores: \
 (Inbound Scores: blocking=%{tx.blocking_inbound_anomaly_score}, detection=%{tx.detection_inbound_anomaly_score}, per_pl=%{tx.inbound_anomaly_score_pl1}-%{tx.inbound_anomaly_score_pl2}-%{tx.inbound_anomaly_score_pl3}-%{tx.inbound_anomaly_score_pl4}, threshold=%{tx.inbound_anomaly_score_threshold}) - \
 (Outbound Scores: blocking=%{tx.blocking_outbound_anomaly_score}, detection=%{tx.detection_outbound_anomaly_score}, per_pl=%{tx.outbound_anomaly_score_pl1}-%{tx.outbound_anomaly_score_pl2}-%{tx.outbound_anomaly_score_pl3}-%{tx.outbound_anomaly_score_pl4}, threshold=%{tx.outbound_anomaly_score_threshold}) - \
-(SQLI=%{tx.sql_injection_score}, XSS=%{tx.xss_score}, RFI=%{tx.rfi_score}, LFI=%{tx.lfi_score}, RCE=%{tx.rce_score}, PHPI=%{tx.php_injection_score}, HTTP=%{tx.http_violation_score}, SESS=%{tx.session_fixation_score})',\
+(SQLI=%{tx.sql_injection_score}, XSS=%{tx.xss_score}, RFI=%{tx.rfi_score}, LFI=%{tx.lfi_score}, RCE=%{tx.rce_score}, PHPI=%{tx.php_injection_score}, HTTP=%{tx.http_violation_score}, SESS=%{tx.session_fixation_score}, COMBINED_SCORE=%{tx.anomaly_score})',\
     tag:'reporting',\
     ver:'OWASP_CRS/4.0.0-rc1'"
 


### PR DESCRIPTION
This PR contains two small commits:
* Removed unused TX variables (`real_ip` and `942521_full`)
* Initialize and use once `anomaly_score` TX variable

With this PR, all TX variables in CRS will be initialized and used at least once.

This will close #2990.