### PR TITLE
feat: add relevant info for java-classes.data

### DIFF
--- a/rules/java-classes.data
+++ b/rules/java-classes.data
@@ -1,3 +1,14 @@
+# Java Classes for use with Java RCEs
+# 
+# Used With Rule 944130 in Apache Struts and Oracle Weblogic RCEs Detection:
+#
+# CVE-2017-5638  (2017.01.29) https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5638
+# CVE-2017-9791  (2017.06.21) https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-9791
+# CVE-2017-9805  (2017.06.21) https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-9805
+# CVE-2017-10271 (2017.06.21) https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-10271
+# CVE-2018-11776 (2018.06.05) https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11776
+#
+
 com.opensymphony.xwork2
 com.sun.org.apache
 java.io.BufferedInputStream

--- a/rules/java-classes.data
+++ b/rules/java-classes.data
@@ -7,10 +7,15 @@
 # CVE-2017-9805  (2017.06.21) https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-9805
 # CVE-2017-10271 (2017.06.21) https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-10271
 # CVE-2018-11776 (2018.06.05) https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11776
-#
+# 
+# Additional Resources
+# Apache S2-057 (2019.01.20) https://cwiki.apache.org/confluence/display/WW/S2-057
 
 com.opensymphony.xwork2
 com.sun.org.apache
+freemarker.core
+freemarker.template
+freemarker.ext.rhino
 java.io.BufferedInputStream
 java.io.BufferedReader
 java.io.ByteArrayInputStream
@@ -46,9 +51,11 @@ java.lang.Runtime
 java.lang.String
 java.lang.StringBuilder
 java.lang.System
+javassist
 javax.script.ScriptEngineManager
 org.apache.commons
 org.apache.struts
 org.apache.struts2
 org.omg.CORBA
 java.beans.XMLDecode
+sun.reflect


### PR DESCRIPTION
Added the relevant information needed to explain the use and need for the java-classes.data file. Since information on the exploit tester and CVEs already exist in the 944 file, I simply mentioned the rule, and the associated CVEs with links. 

Being the first PR, I'm not sure if this is the correct syntax style, and if the information added gives enough information. 