### PR TITLE
New rule 942550 (PL1) JSON in SQL

### DIFF
--- a/regex-assembly/942550.ra
+++ b/regex-assembly/942550.ra
@@ -24,8 +24,13 @@
 
 ##!> assemble
   ##! example: SELECT id FROM users WHERE '{"a":1}'/**/::/**/jSonb/**/<@'{"a":1}'::jsonb;
+  ##! example: SELECT id FROM users WHERE '{"a":1}'/**/::/**/jSonb/**/<@'{"a":1}';
+  ##! example: SELECT id FROM users WHERE '{"a":1}'/**/<@'{"a":1}'::jsonb;
   ##! <@, @>, <, >, @ are all valid operators
   {{json_ending_brackets}}{{quotes}}.*::.*jsonb.*{{psql_operator}}.*{{json_ending_brackets}}{{quotes}}.*::.*jsonb
+  {{json_ending_brackets}}{{quotes}}.*::.*jsonb.*{{psql_operator}}.*{{json_ending_brackets}}{{quotes}}
+  {{json_ending_brackets}}{{quotes}}.*{{psql_operator}}.*{{json_ending_brackets}}{{quotes}}.*::.*jsonb
+  {{psql_operator}}{{quotes}}{{json_starting_brackets}}.*{{json_ending_brackets}}{{quotes}}
 
   ##! example: SELECT id FROM users WHERE id='{"a":2,"c":[4,5,{"f":7}]}' -> '$.c[2].f'
   ##! sqlite> SELECT '{"a":2,"c":[4,5,{"f":7}]}' -> '$.c[2].f' = 7;   

--- a/regex-assembly/942550.ra
+++ b/regex-assembly/942550.ra
@@ -1,0 +1,26 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Referring to https://claroty.com/team82/research/js-on-security-off-abusing-json-based-sql-to-bypass-waf
+##! this rule tries to match the following payload:
+##! 
+##! PostgreSQL: '{"b":2}'::jsonb <@ '{"a":1, "b":2}'::jsonb
+##! SQLite: '{"a":2,"c":[4,5,{"f":7}]}' -> '$.c[2].f' = 7
+##! MySQL: JSON_EXTRACT('{"id": 14, "name": "Aztalan"}', '$.name') = 'Aztalan'
+
+##!> define quotes [\"'`]
+##!> define not_quotes [^\"'`]*
+##!> define psql_operator [@<>]+
+##!> define sqlite_operator [>\-]+
+##!> define json_ending_brackets [\]\}]
+
+##!> assemble
+  ##! example: SELECT id FROM users WHERE '{"a":1}'/**/::/**/jSonb/**/<@'{"a":1}'::jsonb;
+  {{json_ending_brackets}}{{quotes}}.*::.*jsonb.*{{psql_operator}}.*{{json_ending_brackets}}{{quotes}}.*::.*jsonb
+  
+  ##! example: SELECT id FROM users WHERE id='{"a":2,"c":[4,5,{"f":7}]}' -> '$.c[2].f'
+  {{json_ending_brackets}}{{quotes}}.*{{sqlite_operator}}.*{{quotes}}
+  
+  ##! example: SELECT id FROM users WHERE id=JsoN_EXTraCT/**/(/**/'  {"a":1}  '/**/,/**/' $.a '/**/);
+  json_extract.*\(.*{{json_ending_brackets}}{{quotes}}.*\)
+##!<

--- a/regex-assembly/942550.ra
+++ b/regex-assembly/942550.ra
@@ -16,26 +16,14 @@
 ##! MySQL: JSON_EXTRACT('{"id": 14, "name": "Aztalan"}', '$.name') = 'Aztalan'
 
 ##!> define quotes [\"'`]
-##!> define not_quotes [^\"'`]*
-##!> define psql_operator [@<>]+
-##!> define sqlite_operator [<>\-]+
+##!> define operators (@>|<@|\?|\?\||\?&|#>|#>>|->>|<|>|->|<-)
 ##!> define json_ending_brackets [\]\}]
 ##!> define json_starting_brackets [\[\{]
 
 ##!> assemble
-  ##! example: SELECT id FROM users WHERE '{"a":1}'/**/::/**/jSonb/**/<@'{"a":1}'::jsonb;
-  ##! example: SELECT id FROM users WHERE '{"a":1}'/**/::/**/jSonb/**/<@'{"a":1}';
-  ##! example: SELECT id FROM users WHERE '{"a":1}'/**/<@'{"a":1}'::jsonb;
-  ##! <@, @>, <, >, @ are all valid operators
-  {{json_ending_brackets}}{{quotes}}.*::.*jsonb.*{{psql_operator}}.*{{json_ending_brackets}}{{quotes}}.*::.*jsonb
-  {{json_ending_brackets}}{{quotes}}.*::.*jsonb.*{{psql_operator}}.*{{json_ending_brackets}}{{quotes}}
-  {{json_ending_brackets}}{{quotes}}.*{{psql_operator}}.*{{json_ending_brackets}}{{quotes}}.*::.*jsonb
-  {{psql_operator}}{{quotes}}{{json_starting_brackets}}.*{{json_ending_brackets}}{{quotes}}
-
-  ##! example: SELECT id FROM users WHERE id='{"a":2,"c":[4,5,{"f":7}]}' -> '$.c[2].f'
-  ##! sqlite> SELECT '{"a":2,"c":[4,5,{"f":7}]}' -> '$.c[2].f' = 7;   
-  ##! 0
-  {{quotes}}{{json_starting_brackets}}.*{{json_ending_brackets}}{{quotes}}.*{{sqlite_operator}}.*{{quotes}}\$.*{{quotes}}
+  ##! https://regex101.com/r/mzG5Fg/1
+  {{quotes}}{{json_starting_brackets}}.*{{json_ending_brackets}}{{quotes}}.*(::.*jsonb?)?.*{{operators}}
+  {{operators}}{{quotes}}{{json_starting_brackets}}.*{{json_ending_brackets}}{{quotes}}
 
   ##! example: SELECT id FROM users WHERE id=JsoN_EXTraCT/**/(/**/'  {"a":1}  '/**/,/**/' $.a '/**/);
   json_extract.*\(.*\)

--- a/regex-assembly/942550.ra
+++ b/regex-assembly/942550.ra
@@ -17,10 +17,10 @@
 ##!> assemble
   ##! example: SELECT id FROM users WHERE '{"a":1}'/**/::/**/jSonb/**/<@'{"a":1}'::jsonb;
   {{json_ending_brackets}}{{quotes}}.*::.*jsonb.*{{psql_operator}}.*{{json_ending_brackets}}{{quotes}}.*::.*jsonb
-  
+
   ##! example: SELECT id FROM users WHERE id='{"a":2,"c":[4,5,{"f":7}]}' -> '$.c[2].f'
   {{json_ending_brackets}}{{quotes}}.*{{sqlite_operator}}.*{{quotes}}
-  
+
   ##! example: SELECT id FROM users WHERE id=JsoN_EXTraCT/**/(/**/'  {"a":1}  '/**/,/**/' $.a '/**/);
   json_extract.*\(.*{{json_ending_brackets}}{{quotes}}.*\)
 ##!<

--- a/regex-assembly/942550.ra
+++ b/regex-assembly/942550.ra
@@ -5,22 +5,33 @@
 ##! this rule tries to match the following payload:
 ##! 
 ##! PostgreSQL: '{"b":2}'::jsonb <@ '{"a":1, "b":2}'::jsonb
+##! PostgreSQL: '{"b":2}'::jsonb @> '{"a":1, "b":2}'::jsonb
+##! PostgreSQL: '{"b":2}'::jsonb @ '{"a":1, "b":2}'::jsonb
+##! PostgreSQL: '{"b":2}'::jsonb < '{"a":1, "b":2}'::jsonb
+##! PostgreSQL: '{"b":2}'::jsonb > '{"a":1, "b":2}'::jsonb
 ##! SQLite: '{"a":2,"c":[4,5,{"f":7}]}' -> '$.c[2].f' = 7
+##! SQLite: '{"a":2,"c":[4,5,{"f":7}]}' <- '$.c[2].f' = 7
+##! SQLite: '{"a":2,"c":[4,5,{"f":7}]}' < '$.c[2].f' = 7
+##! SQLite: '{"a":2,"c":[4,5,{"f":7}]}' > '$.c[2].f' = 7
 ##! MySQL: JSON_EXTRACT('{"id": 14, "name": "Aztalan"}', '$.name') = 'Aztalan'
 
 ##!> define quotes [\"'`]
 ##!> define not_quotes [^\"'`]*
 ##!> define psql_operator [@<>]+
-##!> define sqlite_operator [>\-]+
+##!> define sqlite_operator [<>\-]+
 ##!> define json_ending_brackets [\]\}]
+##!> define json_starting_brackets [\[\{]
 
 ##!> assemble
   ##! example: SELECT id FROM users WHERE '{"a":1}'/**/::/**/jSonb/**/<@'{"a":1}'::jsonb;
+  ##! <@, @>, <, >, @ are all valid operators
   {{json_ending_brackets}}{{quotes}}.*::.*jsonb.*{{psql_operator}}.*{{json_ending_brackets}}{{quotes}}.*::.*jsonb
 
   ##! example: SELECT id FROM users WHERE id='{"a":2,"c":[4,5,{"f":7}]}' -> '$.c[2].f'
-  {{json_ending_brackets}}{{quotes}}.*{{sqlite_operator}}.*{{quotes}}
+  ##! sqlite> SELECT '{"a":2,"c":[4,5,{"f":7}]}' -> '$.c[2].f' = 7;   
+  ##! 0
+  {{quotes}}{{json_starting_brackets}}.*{{json_ending_brackets}}{{quotes}}.*{{sqlite_operator}}.*{{quotes}}\$.*{{quotes}}
 
   ##! example: SELECT id FROM users WHERE id=JsoN_EXTraCT/**/(/**/'  {"a":1}  '/**/,/**/' $.a '/**/);
-  json_extract.*\(.*{{json_ending_brackets}}{{quotes}}.*\)
+  json_extract.*\(.*\)
 ##!<

--- a/regex-assembly/942550.ra
+++ b/regex-assembly/942550.ra
@@ -2,7 +2,7 @@
 ##! https://coreruleset.org/docs/development/regex_assembly/.
 
 ##! Referring to https://claroty.com/team82/research/js-on-security-off-abusing-json-based-sql-to-bypass-waf
-##! this rule tries to match the following payload:
+##! this rule tries to match the following payloads:
 ##! 
 ##! PostgreSQL: '{"b":2}'::jsonb <@ '{"a":1, "b":2}'::jsonb
 ##! PostgreSQL: '{"b":2}'::jsonb @> '{"a":1, "b":2}'::jsonb
@@ -16,7 +16,7 @@
 ##! MySQL: JSON_EXTRACT('{"id": 14, "name": "Aztalan"}', '$.name') = 'Aztalan'
 
 ##!> define quotes [\"'`]
-##!> define operators (@>|<@|\?|\?\||\?&|#>|#>>|->>|<|>|->|<-)
+##!> define operators (?:@>|<@|\?|\?\||\?&|#>|#>>|->>|<|>|->|<-)
 ##!> define json_ending_brackets [\]\}]
 ##!> define json_starting_brackets [\[\{]
 

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -567,7 +567,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 942550
 #
-SecRule REQUEST_FILENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx [\]\}][\"'`].*(?:::.*jsonb.*[<>@]+.*[\]\}][\"'`](?:.*::.*jsonb)?|[<>@]+.*[\]\}][\"'`].*::.*jsonb)|(?:[<>@]+[\"'`][\[\{].*[\]\}]|[\"'`][\[\{].*[\]\}][\"'`].*[\-<>]+.*[\"'`]\$.*)[\"'`]|json_extract.*\(.*\)" \
+SecRule REQUEST_FILENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx [\"'`][\[\{].*[\]\}][\"'`].*(::.*jsonb?)?.*((?:@|->?)>|<@|\?[&\|]?|#>>?|[<>]|<-)|((?:@|->?)>|<@|\?[&\|]?|#>>?|[<>]|<-)[\"'`][\[\{].*[\]\}][\"'`]|json_extract.*\(.*\)" \
     "id:942550,\
     phase:2,\
     block,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -567,7 +567,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 942550
 #
-SecRule REQUEST_FILENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx [\]\}][\"'`].*::.*jsonb.*[<>@]+.*[\]\}][\"'`].*::.*jsonb|[\"'`][\[\{].*[\]\}][\"'`].*[\-<>]+.*[\"'`]\$.*[\"'`]|json_extract.*\(.*\)" \
+SecRule REQUEST_FILENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx [\]\}][\"'`].*(?:::.*jsonb.*[<>@]+.*[\]\}][\"'`](?:.*::.*jsonb)?|[<>@]+.*[\]\}][\"'`].*::.*jsonb)|(?:[<>@]+[\"'`][\[\{].*[\]\}]|[\"'`][\[\{].*[\]\}][\"'`].*[\-<>]+.*[\"'`]\$.*)[\"'`]|json_extract.*\(.*\)" \
     "id:942550,\
     phase:2,\
     block,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -559,6 +559,36 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
+# This rule match JSON in SQL syntax that could be used as a bypass technique
+# Referring to this research: https://claroty.com/team82/research/js-on-security-off-abusing-json-based-sql-to-bypass-waf
+#
+# Regular expression generated from regex-assembly/942550.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 942550
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx [\]\}][\"'`].*(?:::.*jsonb.*[<>@]+.*[\]\}][\"'`].*::.*jsonb|[\->]+.*[\"'`])|json_extract.*\(.*[\]\}][\"'`].*\)" \
+    "id:942550,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:urlDecodeUni,t:lowercase,t:removeWhitespace,\
+    msg:'JSON-Based SQL Injection',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-sqli',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/248/66',\
+    tag:'PCI/6.5.2',\
+    tag:'paranoia-level/1',\
+    ver:'OWASP_CRS/4.0.0-rc1',\
+    severity:'CRITICAL',\
+    setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:942013,phase:1,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:942014,phase:2,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
 #

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -559,7 +559,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-# This rule match JSON in SQL syntax that could be used as a bypass technique
+# This rule tries to match JSON SQL syntax that could be used as a bypass technique.
 # Referring to this research: https://claroty.com/team82/research/js-on-security-off-abusing-json-based-sql-to-bypass-waf
 #
 # Regular expression generated from regex-assembly/942550.ra.
@@ -567,11 +567,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 942550
 #
-SecRule REQUEST_FILENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx [\"'`][\[\{].*[\]\}][\"'`].*(::.*jsonb?)?.*((?:@|->?)>|<@|\?[&\|]?|#>>?|[<>]|<-)|((?:@|->?)>|<@|\?[&\|]?|#>>?|[<>]|<-)[\"'`][\[\{].*[\]\}][\"'`]|json_extract.*\(.*\)" \
+SecRule REQUEST_FILENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx [\"'`][\[\{].*[\]\}][\"'`].*(::.*jsonb?)?.*(?:(?:@|->?)>|<@|\?[&\|]?|#>>?|[<>]|<-)|(?:(?:@|->?)>|<@|\?[&\|]?|#>>?|[<>]|<-)[\"'`][\[\{].*[\]\}][\"'`]|json_extract.*\(.*\)" \
     "id:942550,\
     phase:2,\
     block,\
-    capture,\
     t:none,t:urlDecodeUni,t:lowercase,t:removeWhitespace,\
     msg:'JSON-Based SQL Injection',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -567,7 +567,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 942550
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx [\]\}][\"'`].*(?:::.*jsonb.*[<>@]+.*[\]\}][\"'`].*::.*jsonb|[\->]+.*[\"'`])|json_extract.*\(.*[\]\}][\"'`].*\)" \
+SecRule REQUEST_FILENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx [\]\}][\"'`].*::.*jsonb.*[<>@]+.*[\]\}][\"'`].*::.*jsonb|[\"'`][\[\{].*[\]\}][\"'`].*[\-<>]+.*[\"'`]\$.*[\"'`]|json_extract.*\(.*\)" \
     "id:942550,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942550.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942550.yaml
@@ -59,3 +59,52 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
+  
+  - test_title: 942550-4
+    desc: "PostgreSQL JSON in SQL in path"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/1+OR+%27%7B%22a%22%3A1%7D%27%2F%2A%2A%2F%3A%3A%2F%2A%2A%2FjSonb%2F%2A%2A%2F%3C%40%27%7B%22a%22%3A1%7D%27%3A%3Ajsonb"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550"
+  - test_title: 942550-5
+    desc: "SQLite JSON in SQL in path"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/1+OR+%27%7B%22a%22%3A2%2C%22c%22%3A%5B4%2C5%2C%7B%22f%22%3A7%7D%5D%7D%27%20-%3E%20%27%24.c%5B2%5D.f%27%3D7"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550"
+  - test_title: 942550-6
+    desc: "MySQL JSON in SQL in path"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/1+OR+1%3DJsoN_EXTraCT%2F%2A%2A%2F%28%2F%2A%2A%2F%27%20%20%7B%22a%22%3A1%7D%20%20%27%2F%2A%2A%2F%2C%2F%2A%2A%2F%27%20%24.a%20%27%2F%2A%2A%2F%29"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550"

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942550.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942550.yaml
@@ -302,7 +302,7 @@ tests:
             data: "id=OR%20%27%7B%22a%22%3A2%2C%22c%22%3A%5B4%2C5%2C%7B%22f%22%3A7%7D%5D%7D%27%20-%3E%20%27%24.c%5B2%5D.f%27%20%3D%207"
             version: HTTP/1.0
           output:
-            log_contains: id "942550" 
+            log_contains: id "942550"
   - test_title: 942550-10
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR '{"a":2,"c":[4,5,{"f":7}]}' -> '$.c[2].f' = 7
@@ -319,7 +319,7 @@ tests:
             uri: "/OR%20%27%7B%22a%22%3A2%2C%22c%22%3A%5B4%2C5%2C%7B%22f%22%3A7%7D%5D%7D%27%20-%3E%20%27%24.c%5B2%5D.f%27%20%3D%207"
             version: HTTP/1.0
           output:
-            log_contains: id "942550" 
+            log_contains: id "942550"
   - test_title: 942550-10
     desc: "JSON in SQL (ARGS)"
     # decoded payload: OR '{"a":2,"c":[4,5,{"f":7}]}' <- '$.c[2].f' = 7
@@ -337,7 +337,7 @@ tests:
             data: "id=OR%20%27%7B%22a%22%3A2%2C%22c%22%3A%5B4%2C5%2C%7B%22f%22%3A7%7D%5D%7D%27%20%3C-%20%27%24.c%5B2%5D.f%27%20%3D%207"
             version: HTTP/1.0
           output:
-            log_contains: id "942550" 
+            log_contains: id "942550"
   - test_title: 942550-11
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR '{"a":2,"c":[4,5,{"f":7}]}' <- '$.c[2].f' = 7
@@ -354,7 +354,7 @@ tests:
             uri: "/OR%20%27%7B%22a%22%3A2%2C%22c%22%3A%5B4%2C5%2C%7B%22f%22%3A7%7D%5D%7D%27%20%3C-%20%27%24.c%5B2%5D.f%27%20%3D%207"
             version: HTTP/1.0
           output:
-            log_contains: id "942550" 
+            log_contains: id "942550"
   - test_title: 942550-11
     desc: "JSON in SQL (ARGS)"
     # decoded payload: OR json_extract('{"id": 14, "name": "Aztalan"}', '$.name') = 'Aztalan'
@@ -372,7 +372,7 @@ tests:
             data: "id=OR%20json_extract%28%27%7B%22id%22%3A%2014%2C%20%22name%22%3A%20%22Aztalan%22%7D%27%2C%20%27%24.name%27%29%20%3D%20%27Aztalan%27"
             version: HTTP/1.0
           output:
-            log_contains: id "942550" 
+            log_contains: id "942550"
   - test_title: 942550-12
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR json_extract('{"id": 14, "name": "Aztalan"}', '$.name') = 'Aztalan'
@@ -389,7 +389,7 @@ tests:
             uri: "/OR%20json_extract%28%27%7B%22id%22%3A%2014%2C%20%22name%22%3A%20%22Aztalan%22%7D%27%2C%20%27%24.name%27%29%20%3D%20%27Aztalan%27"
             version: HTTP/1.0
           output:
-            log_contains: id "942550" 
+            log_contains: id "942550"
   - test_title: 942550-12
     desc: "JSON in SQL (ARGS)"
     # decoded payload: blah/"}' and data @> '{"a":"a"}' union select ASCII(s.token) from unnset(string_to_array((select cookie from cookie limit 1 ),NULL)) s(token)--/state
@@ -407,7 +407,7 @@ tests:
             data: "id=blah/%22%7D%27%20and%20data%20%40%3E%20%27%7B%22a%22%3A%22a%22%7D%27%20union%20select%20ASCII%28s.token%29%20from%20unnset%28string_to_array%28%28select%20cookie%20from%20cookie%20limit%201%20%29%2CNULL%29%29%20s%28token%29--/state"
             version: HTTP/1.0
           output:
-            log_contains: id "942550" 
+            log_contains: id "942550"
   - test_title: 942550-13
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: blah/"}' and data @> '{"a":"a"}' union select ASCII(s.token) from unnset(string_to_array((select cookie from cookie limit 1 ),NULL)) s(token)--/state
@@ -424,7 +424,7 @@ tests:
             uri: "/blah/%22%7D%27%20and%20data%20%40%3E%20%27%7B%22a%22%3A%22a%22%7D%27%20union%20select%20ASCII%28s.token%29%20from%20unnset%28string_to_array%28%28select%20cookie%20from%20cookie%20limit%201%20%29%2CNULL%29%29%20s%28token%29--/state"
             version: HTTP/1.0
           output:
-            log_contains: id "942550" 
+            log_contains: id "942550"
   - test_title: 942550-13
     desc: "JSON in SQL (ARGS)"
     # decoded payload: OR '{"a":"b"}' ? 'a'
@@ -442,7 +442,7 @@ tests:
             data: "id=OR%20%27%7B%22a%22%3A%22b%22%7D%27%20%3F%20%27a%27"
             version: HTTP/1.0
           output:
-            log_contains: id "942550" 
+            log_contains: id "942550"
   - test_title: 942550-14
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR '{"a":"b"}' ? 'a'
@@ -459,7 +459,7 @@ tests:
             uri: "/OR%20%27%7B%22a%22%3A%22b%22%7D%27%20%3F%20%27a%27"
             version: HTTP/1.0
           output:
-            log_contains: id "942550" 
+            log_contains: id "942550"
   - test_title: 942550-14
     desc: "JSON in SQL (ARGS)"
     # decoded payload: OR '[1,2]' ? '1'
@@ -477,7 +477,7 @@ tests:
             data: "id=OR%20%27%5B1%2C2%5D%27%20%3F%20%271%27"
             version: HTTP/1.0
           output:
-            log_contains: id "942550" 
+            log_contains: id "942550"
   - test_title: 942550-15
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR '[1,2]' ? '1'
@@ -494,7 +494,7 @@ tests:
             uri: "/OR%20%27%5B1%2C2%5D%27%20%3F%20%271%27"
             version: HTTP/1.0
           output:
-            log_contains: id "942550" 
+            log_contains: id "942550"
   - test_title: 942550-15
     desc: "JSON in SQL (ARGS)"
     # decoded payload: OR '{"name":"asd"}' ?| array['a','name']
@@ -512,7 +512,7 @@ tests:
             data: "id=OR%20%27%7B%22name%22%3A%22asd%22%7D%27%20%3F%7C%20array%5B%27a%27%2C%27name%27%5D"
             version: HTTP/1.0
           output:
-            log_contains: id "942550" 
+            log_contains: id "942550"
   - test_title: 942550-16
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR '{"name":"asd"}' ?| array['a','name']
@@ -529,7 +529,7 @@ tests:
             uri: "/OR%20%27%7B%22name%22%3A%22asd%22%7D%27%20%3F%7C%20array%5B%27a%27%2C%27name%27%5D"
             version: HTTP/1.0
           output:
-            log_contains: id "942550" 
+            log_contains: id "942550"
   - test_title: 942550-16
     desc: "JSON in SQL (ARGS)"
     # decoded payload: OR '{"name":"asd"}' ?& array['a','name']
@@ -547,7 +547,7 @@ tests:
             data: "id=OR%20%27%7B%22name%22%3A%22asd%22%7D%27%20%3F%26%20array%5B%27a%27%2C%27name%27%5D"
             version: HTTP/1.0
           output:
-            log_contains: id "942550" 
+            log_contains: id "942550"
   - test_title: 942550-17
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR '{"name":"asd"}' ?& array['a','name']
@@ -564,7 +564,7 @@ tests:
             uri: "/OR%20%27%7B%22name%22%3A%22asd%22%7D%27%20%3F%26%20array%5B%27a%27%2C%27name%27%5D"
             version: HTTP/1.0
           output:
-            log_contains: id "942550" 
+            log_contains: id "942550"
   - test_title: 942550-17
     desc: "JSON in SQL (ARGS)"
     # decoded payload: OR '[1,2,3]'::json ->> 2='3'
@@ -582,7 +582,7 @@ tests:
             data: "id=OR%20%27%5B1%2C2%2C3%5D%27%3A%3Ajson%20-%3E%3E%202%3D%273%27"
             version: HTTP/1.0
           output:
-            log_contains: id "942550" 
+            log_contains: id "942550"
   - test_title: 942550-18
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR '[1,2,3]'::json ->> 2='3'
@@ -599,7 +599,7 @@ tests:
             uri: "/OR%20%27%5B1%2C2%2C3%5D%27%3A%3Ajson%20-%3E%3E%202%3D%273%27"
             version: HTTP/1.0
           output:
-            log_contains: id "942550" 
+            log_contains: id "942550"
   - test_title: 942550-18
     desc: "JSON in SQL (ARGS)"
     # decoded payload: OR '{"a":1}'::jsonb #> '{a,b}' ? 'c'
@@ -617,7 +617,7 @@ tests:
             data: "id=OR%20%27%7B%22a%22%3A1%7D%27%3A%3Ajsonb%20%23%3E%20%27%7Ba%2Cb%7D%27%20%3F%20%27c%27"
             version: HTTP/1.0
           output:
-            log_contains: id "942550" 
+            log_contains: id "942550"
   - test_title: 942550-19
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR '{"a":1}'::jsonb #> '{a,b}' ? 'c'

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942550.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942550.yaml
@@ -59,7 +59,6 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  
   - test_title: 942550-4
     desc: "PostgreSQL JSON in SQL in path"
     stages:

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942550.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942550.yaml
@@ -71,7 +71,7 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             method: GET
             port: 80
-            uri: "/1+OR+%27%7B%22a%22%3A1%7D%27%2F%2A%2A%2F%3A%3A%2F%2A%2A%2FjSonb%2F%2A%2A%2F%3C%40%27%7B%22a%22%3A1%7D%27%3A%3Ajsonb"
+            uri: "/1+OR+%27%7B%22b%22%3A2%7D%27%3A%3Ajsonb%20%40%3E%20%27%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%27%3A%3Ajsonb"
             version: HTTP/1.0
           output:
             log_contains: id "942550"
@@ -103,7 +103,23 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             method: GET
             port: 80
-            uri: "/1+OR+1%3DJsoN_EXTraCT%2F%2A%2A%2F%28%2F%2A%2A%2F%27%20%20%7B%22a%22%3A1%7D%20%20%27%2F%2A%2A%2F%2C%2F%2A%2A%2F%27%20%24.a%20%27%2F%2A%2A%2F%29"
+            uri: "/1+OR+1%3DJSON_EXTRACT%28%27%7B%22id%22%3A%201%7D%27%2C%20%27%24.id%27%29"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550"
+  - test_title: 942550-7
+    desc: "PostgreSQL JSON in SQL in path"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/blah/\"}'%20and%20data%20@>%20'{\"a\":\"a\"}'%20union%20select%20ASCII(s.token)%20from%20unnset(string_to_array((select%20cookie%20from%20cookie%20limit%201%20),NULL))%20s(token)--/state?sig=1&timeStamp=50"
             version: HTTP/1.0
           output:
             log_contains: id "942550"

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942550.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942550.yaml
@@ -6,7 +6,8 @@ meta:
   name: 942550.yaml
 tests:
   - test_title: 942550-1
-    desc: "PostgreSQL JSON in SQL"
+    desc: "JSON in SQL (ARGS)"
+    # decoded payload: OR '{"b":2}'::jsonb <@ '{"a":1, "b":2}'::jsonb
     stages:
       - stage:
           input:
@@ -18,13 +19,30 @@ tests:
             method: POST
             port: 80
             uri: "/"
-            # id=1+OR+'{"a":1}'/**/::/**/jSonb/**/<@'{"a":1}'::jsonb
-            data: "id=1+OR+%27%7B%22a%22%3A1%7D%27%2F%2A%2A%2F%3A%3A%2F%2A%2A%2FjSonb%2F%2A%2A%2F%3C%40%27%7B%22a%22%3A1%7D%27%3A%3Ajsonb"
+            data: "id=OR%20%27%7B%22b%22%3A2%7D%27%3A%3Ajsonb%20%3C%40%20%27%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%27%3A%3Ajsonb"
             version: HTTP/1.0
           output:
             log_contains: id "942550"
   - test_title: 942550-2
-    desc: "SQLite JSON in SQL"
+    desc: "JSON in SQL (REQUEST_FILENAME)"
+    # decoded payload: OR '{"b":2}'::jsonb <@ '{"a":1, "b":2}'::jsonb
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/OR%20%27%7B%22b%22%3A2%7D%27%3A%3Ajsonb%20%3C%40%20%27%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%27%3A%3Ajsonb"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550"
+  - test_title: 942550-2
+    desc: "JSON in SQL (ARGS)"
+    # decoded payload: OR '{"b":2}'::jsonb <@ '{"a":1, "b":2}'
     stages:
       - stage:
           input:
@@ -36,13 +54,30 @@ tests:
             method: POST
             port: 80
             uri: "/"
-            # id=1+OR+'{"a":2,"c":[4,5,{"f":7}]}' -> '$.c[2].f'=7
-            data: "id=1+OR+%27%7B%22a%22%3A2%2C%22c%22%3A%5B4%2C5%2C%7B%22f%22%3A7%7D%5D%7D%27%20-%3E%20%27%24.c%5B2%5D.f%27%3D7"
+            data: "id=OR%20%27%7B%22b%22%3A2%7D%27%3A%3Ajsonb%20%3C%40%20%27%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%27"
             version: HTTP/1.0
           output:
             log_contains: id "942550"
   - test_title: 942550-3
-    desc: "MySQL JSON in SQL"
+    desc: "JSON in SQL (REQUEST_FILENAME)"
+    # decoded payload: OR '{"b":2}'::jsonb <@ '{"a":1, "b":2}'
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/OR%20%27%7B%22b%22%3A2%7D%27%3A%3Ajsonb%20%3C%40%20%27%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%27"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550"
+  - test_title: 942550-3
+    desc: "JSON in SQL (ARGS)"
+    # decoded payload: OR '{"b":2}' <@ '{"a":1, "b":2}'::jsonb
     stages:
       - stage:
           input:
@@ -54,13 +89,13 @@ tests:
             method: POST
             port: 80
             uri: "/"
-            # id=1+OR+1=JsoN_EXTraCT/**/(/**/'  {"a":1}  '/**/,/**/' $.a '/**/)
-            data: "id=1+OR+1%3DJsoN_EXTraCT%2F%2A%2A%2F%28%2F%2A%2A%2F%27%20%20%7B%22a%22%3A1%7D%20%20%27%2F%2A%2A%2F%2C%2F%2A%2A%2F%27%20%24.a%20%27%2F%2A%2A%2F%29"
+            data: "id=OR%20%27%7B%22b%22%3A2%7D%27%20%3C%40%20%27%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%27%3A%3Ajsonb"
             version: HTTP/1.0
           output:
             log_contains: id "942550"
   - test_title: 942550-4
-    desc: "PostgreSQL JSON in SQL in path"
+    desc: "JSON in SQL (REQUEST_FILENAME)"
+    # decoded payload: OR '{"b":2}' <@ '{"a":1, "b":2}'::jsonb
     stages:
       - stage:
           input:
@@ -71,12 +106,31 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             method: GET
             port: 80
-            uri: "/1+OR+%27%7B%22b%22%3A2%7D%27%3A%3Ajsonb%20%40%3E%20%27%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%27%3A%3Ajsonb"
+            uri: "/OR%20%27%7B%22b%22%3A2%7D%27%20%3C%40%20%27%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%27%3A%3Ajsonb"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550"
+  - test_title: 942550-4
+    desc: "JSON in SQL (ARGS)"
+    # decoded payload: OR '{"b":2}'::json <@ '{"a":1, "b":2}'
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            data: "id=OR%20%27%7B%22b%22%3A2%7D%27%3A%3Ajson%20%3C%40%20%27%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%27"
             version: HTTP/1.0
           output:
             log_contains: id "942550"
   - test_title: 942550-5
-    desc: "SQLite JSON in SQL in path"
+    desc: "JSON in SQL (REQUEST_FILENAME)"
+    # decoded payload: OR '{"b":2}'::json <@ '{"a":1, "b":2}'
     stages:
       - stage:
           input:
@@ -87,12 +141,31 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             method: GET
             port: 80
-            uri: "/1+OR+%27%7B%22a%22%3A2%2C%22c%22%3A%5B4%2C5%2C%7B%22f%22%3A7%7D%5D%7D%27%20-%3E%20%27%24.c%5B2%5D.f%27%3D7"
+            uri: "/OR%20%27%7B%22b%22%3A2%7D%27%3A%3Ajson%20%3C%40%20%27%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%27"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550"
+  - test_title: 942550-5
+    desc: "JSON in SQL (ARGS)"
+    # decoded payload: OR '{"b":2}' <@ '{"a":1, "b":2}'::json
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            data: "id=OR%20%27%7B%22b%22%3A2%7D%27%20%3C%40%20%27%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%27%3A%3Ajson"
             version: HTTP/1.0
           output:
             log_contains: id "942550"
   - test_title: 942550-6
-    desc: "MySQL JSON in SQL in path"
+    desc: "JSON in SQL (REQUEST_FILENAME)"
+    # decoded payload: OR '{"b":2}' <@ '{"a":1, "b":2}'::json
     stages:
       - stage:
           input:
@@ -103,12 +176,31 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             method: GET
             port: 80
-            uri: "/1+OR+1%3DJSON_EXTRACT%28%27%7B%22id%22%3A%201%7D%27%2C%20%27%24.id%27%29"
+            uri: "/OR%20%27%7B%22b%22%3A2%7D%27%20%3C%40%20%27%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%27%3A%3Ajson"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550"
+  - test_title: 942550-6
+    desc: "JSON in SQL (ARGS)"
+    # decoded payload: OR '{"b":2}'::jsonb @> '{"a":1, "b":2}'::jsonb
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            data: "id=OR%20%27%7B%22b%22%3A2%7D%27%3A%3Ajsonb%20%40%3E%20%27%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%27%3A%3Ajsonb"
             version: HTTP/1.0
           output:
             log_contains: id "942550"
   - test_title: 942550-7
-    desc: "PostgreSQL JSON in SQL in path"
+    desc: "JSON in SQL (REQUEST_FILENAME)"
+    # decoded payload: OR '{"b":2}'::jsonb @> '{"a":1, "b":2}'::jsonb
     stages:
       - stage:
           input:
@@ -119,7 +211,427 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             method: GET
             port: 80
-            uri: "/blah/\"}'%20and%20data%20@>%20'{\"a\":\"a\"}'%20union%20select%20ASCII(s.token)%20from%20unnset(string_to_array((select%20cookie%20from%20cookie%20limit%201%20),NULL))%20s(token)--/state?sig=1&timeStamp=50"
+            uri: "/OR%20%27%7B%22b%22%3A2%7D%27%3A%3Ajsonb%20%40%3E%20%27%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%27%3A%3Ajsonb"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550"
+  - test_title: 942550-7
+    desc: "JSON in SQL (ARGS)"
+    # decoded payload: OR '{"b":2}'::jsonb < '{"a":1, "b":2}'::jsonb
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            data: "id=OR%20%27%7B%22b%22%3A2%7D%27%3A%3Ajsonb%20%3C%20%27%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%27%3A%3Ajsonb"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550"
+  - test_title: 942550-8
+    desc: "JSON in SQL (REQUEST_FILENAME)"
+    # decoded payload: OR '{"b":2}'::jsonb < '{"a":1, "b":2}'::jsonb
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/OR%20%27%7B%22b%22%3A2%7D%27%3A%3Ajsonb%20%3C%20%27%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%27%3A%3Ajsonb"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550"
+  - test_title: 942550-8
+    desc: "JSON in SQL (ARGS)"
+    # decoded payload: OR '{"b":2}'::jsonb > '{"a":1, "b":2}'::jsonb
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            data: "id=OR%20%27%7B%22b%22%3A2%7D%27%3A%3Ajsonb%20%3E%20%27%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%27%3A%3Ajsonb"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550"
+  - test_title: 942550-9
+    desc: "JSON in SQL (REQUEST_FILENAME)"
+    # decoded payload: OR '{"b":2}'::jsonb > '{"a":1, "b":2}'::jsonb
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/OR%20%27%7B%22b%22%3A2%7D%27%3A%3Ajsonb%20%3E%20%27%7B%22a%22%3A1%2C%20%22b%22%3A2%7D%27%3A%3Ajsonb"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550"
+  - test_title: 942550-9
+    desc: "JSON in SQL (ARGS)"
+    # decoded payload: OR '{"a":2,"c":[4,5,{"f":7}]}' -> '$.c[2].f' = 7
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            data: "id=OR%20%27%7B%22a%22%3A2%2C%22c%22%3A%5B4%2C5%2C%7B%22f%22%3A7%7D%5D%7D%27%20-%3E%20%27%24.c%5B2%5D.f%27%20%3D%207"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550" 
+  - test_title: 942550-10
+    desc: "JSON in SQL (REQUEST_FILENAME)"
+    # decoded payload: OR '{"a":2,"c":[4,5,{"f":7}]}' -> '$.c[2].f' = 7
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/OR%20%27%7B%22a%22%3A2%2C%22c%22%3A%5B4%2C5%2C%7B%22f%22%3A7%7D%5D%7D%27%20-%3E%20%27%24.c%5B2%5D.f%27%20%3D%207"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550" 
+  - test_title: 942550-10
+    desc: "JSON in SQL (ARGS)"
+    # decoded payload: OR '{"a":2,"c":[4,5,{"f":7}]}' <- '$.c[2].f' = 7
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            data: "id=OR%20%27%7B%22a%22%3A2%2C%22c%22%3A%5B4%2C5%2C%7B%22f%22%3A7%7D%5D%7D%27%20%3C-%20%27%24.c%5B2%5D.f%27%20%3D%207"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550" 
+  - test_title: 942550-11
+    desc: "JSON in SQL (REQUEST_FILENAME)"
+    # decoded payload: OR '{"a":2,"c":[4,5,{"f":7}]}' <- '$.c[2].f' = 7
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/OR%20%27%7B%22a%22%3A2%2C%22c%22%3A%5B4%2C5%2C%7B%22f%22%3A7%7D%5D%7D%27%20%3C-%20%27%24.c%5B2%5D.f%27%20%3D%207"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550" 
+  - test_title: 942550-11
+    desc: "JSON in SQL (ARGS)"
+    # decoded payload: OR json_extract('{"id": 14, "name": "Aztalan"}', '$.name') = 'Aztalan'
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            data: "id=OR%20json_extract%28%27%7B%22id%22%3A%2014%2C%20%22name%22%3A%20%22Aztalan%22%7D%27%2C%20%27%24.name%27%29%20%3D%20%27Aztalan%27"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550" 
+  - test_title: 942550-12
+    desc: "JSON in SQL (REQUEST_FILENAME)"
+    # decoded payload: OR json_extract('{"id": 14, "name": "Aztalan"}', '$.name') = 'Aztalan'
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/OR%20json_extract%28%27%7B%22id%22%3A%2014%2C%20%22name%22%3A%20%22Aztalan%22%7D%27%2C%20%27%24.name%27%29%20%3D%20%27Aztalan%27"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550" 
+  - test_title: 942550-12
+    desc: "JSON in SQL (ARGS)"
+    # decoded payload: blah/"}' and data @> '{"a":"a"}' union select ASCII(s.token) from unnset(string_to_array((select cookie from cookie limit 1 ),NULL)) s(token)--/state
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            data: "id=blah/%22%7D%27%20and%20data%20%40%3E%20%27%7B%22a%22%3A%22a%22%7D%27%20union%20select%20ASCII%28s.token%29%20from%20unnset%28string_to_array%28%28select%20cookie%20from%20cookie%20limit%201%20%29%2CNULL%29%29%20s%28token%29--/state"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550" 
+  - test_title: 942550-13
+    desc: "JSON in SQL (REQUEST_FILENAME)"
+    # decoded payload: blah/"}' and data @> '{"a":"a"}' union select ASCII(s.token) from unnset(string_to_array((select cookie from cookie limit 1 ),NULL)) s(token)--/state
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/blah/%22%7D%27%20and%20data%20%40%3E%20%27%7B%22a%22%3A%22a%22%7D%27%20union%20select%20ASCII%28s.token%29%20from%20unnset%28string_to_array%28%28select%20cookie%20from%20cookie%20limit%201%20%29%2CNULL%29%29%20s%28token%29--/state"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550" 
+  - test_title: 942550-13
+    desc: "JSON in SQL (ARGS)"
+    # decoded payload: OR '{"a":"b"}' ? 'a'
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            data: "id=OR%20%27%7B%22a%22%3A%22b%22%7D%27%20%3F%20%27a%27"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550" 
+  - test_title: 942550-14
+    desc: "JSON in SQL (REQUEST_FILENAME)"
+    # decoded payload: OR '{"a":"b"}' ? 'a'
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/OR%20%27%7B%22a%22%3A%22b%22%7D%27%20%3F%20%27a%27"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550" 
+  - test_title: 942550-14
+    desc: "JSON in SQL (ARGS)"
+    # decoded payload: OR '[1,2]' ? '1'
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            data: "id=OR%20%27%5B1%2C2%5D%27%20%3F%20%271%27"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550" 
+  - test_title: 942550-15
+    desc: "JSON in SQL (REQUEST_FILENAME)"
+    # decoded payload: OR '[1,2]' ? '1'
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/OR%20%27%5B1%2C2%5D%27%20%3F%20%271%27"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550" 
+  - test_title: 942550-15
+    desc: "JSON in SQL (ARGS)"
+    # decoded payload: OR '{"name":"asd"}' ?| array['a','name']
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            data: "id=OR%20%27%7B%22name%22%3A%22asd%22%7D%27%20%3F%7C%20array%5B%27a%27%2C%27name%27%5D"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550" 
+  - test_title: 942550-16
+    desc: "JSON in SQL (REQUEST_FILENAME)"
+    # decoded payload: OR '{"name":"asd"}' ?| array['a','name']
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/OR%20%27%7B%22name%22%3A%22asd%22%7D%27%20%3F%7C%20array%5B%27a%27%2C%27name%27%5D"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550" 
+  - test_title: 942550-16
+    desc: "JSON in SQL (ARGS)"
+    # decoded payload: OR '{"name":"asd"}' ?& array['a','name']
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            data: "id=OR%20%27%7B%22name%22%3A%22asd%22%7D%27%20%3F%26%20array%5B%27a%27%2C%27name%27%5D"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550" 
+  - test_title: 942550-17
+    desc: "JSON in SQL (REQUEST_FILENAME)"
+    # decoded payload: OR '{"name":"asd"}' ?& array['a','name']
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/OR%20%27%7B%22name%22%3A%22asd%22%7D%27%20%3F%26%20array%5B%27a%27%2C%27name%27%5D"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550" 
+  - test_title: 942550-17
+    desc: "JSON in SQL (ARGS)"
+    # decoded payload: OR '[1,2,3]'::json ->> 2='3'
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            data: "id=OR%20%27%5B1%2C2%2C3%5D%27%3A%3Ajson%20-%3E%3E%202%3D%273%27"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550" 
+  - test_title: 942550-18
+    desc: "JSON in SQL (REQUEST_FILENAME)"
+    # decoded payload: OR '[1,2,3]'::json ->> 2='3'
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/OR%20%27%5B1%2C2%2C3%5D%27%3A%3Ajson%20-%3E%3E%202%3D%273%27"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550" 
+  - test_title: 942550-18
+    desc: "JSON in SQL (ARGS)"
+    # decoded payload: OR '{"a":1}'::jsonb #> '{a,b}' ? 'c'
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            data: "id=OR%20%27%7B%22a%22%3A1%7D%27%3A%3Ajsonb%20%23%3E%20%27%7Ba%2Cb%7D%27%20%3F%20%27c%27"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550" 
+  - test_title: 942550-19
+    desc: "JSON in SQL (REQUEST_FILENAME)"
+    # decoded payload: OR '{"a":1}'::jsonb #> '{a,b}' ? 'c'
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/OR%20%27%7B%22a%22%3A1%7D%27%3A%3Ajsonb%20%23%3E%20%27%7Ba%2Cb%7D%27%20%3F%20%27c%27"
             version: HTTP/1.0
           output:
             log_contains: id "942550"

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942550.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942550.yaml
@@ -40,7 +40,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-2
+  - test_title: 942550-3
     desc: "JSON in SQL (ARGS)"
     # decoded payload: OR '{"b":2}'::jsonb <@ '{"a":1, "b":2}'
     stages:
@@ -58,7 +58,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-3
+  - test_title: 942550-4
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR '{"b":2}'::jsonb <@ '{"a":1, "b":2}'
     stages:
@@ -75,7 +75,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-3
+  - test_title: 942550-5
     desc: "JSON in SQL (ARGS)"
     # decoded payload: OR '{"b":2}' <@ '{"a":1, "b":2}'::jsonb
     stages:
@@ -93,7 +93,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-4
+  - test_title: 942550-6
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR '{"b":2}' <@ '{"a":1, "b":2}'::jsonb
     stages:
@@ -110,7 +110,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-4
+  - test_title: 942550-7
     desc: "JSON in SQL (ARGS)"
     # decoded payload: OR '{"b":2}'::json <@ '{"a":1, "b":2}'
     stages:
@@ -128,7 +128,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-5
+  - test_title: 942550-8
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR '{"b":2}'::json <@ '{"a":1, "b":2}'
     stages:
@@ -145,7 +145,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-5
+  - test_title: 942550-9
     desc: "JSON in SQL (ARGS)"
     # decoded payload: OR '{"b":2}' <@ '{"a":1, "b":2}'::json
     stages:
@@ -163,7 +163,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-6
+  - test_title: 942550-10
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR '{"b":2}' <@ '{"a":1, "b":2}'::json
     stages:
@@ -180,7 +180,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-6
+  - test_title: 942550-11
     desc: "JSON in SQL (ARGS)"
     # decoded payload: OR '{"b":2}'::jsonb @> '{"a":1, "b":2}'::jsonb
     stages:
@@ -198,7 +198,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-7
+  - test_title: 942550-12
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR '{"b":2}'::jsonb @> '{"a":1, "b":2}'::jsonb
     stages:
@@ -215,7 +215,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-7
+  - test_title: 942550-13
     desc: "JSON in SQL (ARGS)"
     # decoded payload: OR '{"b":2}'::jsonb < '{"a":1, "b":2}'::jsonb
     stages:
@@ -233,7 +233,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-8
+  - test_title: 942550-14
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR '{"b":2}'::jsonb < '{"a":1, "b":2}'::jsonb
     stages:
@@ -250,7 +250,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-8
+  - test_title: 942550-15
     desc: "JSON in SQL (ARGS)"
     # decoded payload: OR '{"b":2}'::jsonb > '{"a":1, "b":2}'::jsonb
     stages:
@@ -268,7 +268,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-9
+  - test_title: 942550-16
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR '{"b":2}'::jsonb > '{"a":1, "b":2}'::jsonb
     stages:
@@ -285,7 +285,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-9
+  - test_title: 942550-17
     desc: "JSON in SQL (ARGS)"
     # decoded payload: OR '{"a":2,"c":[4,5,{"f":7}]}' -> '$.c[2].f' = 7
     stages:
@@ -303,7 +303,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-10
+  - test_title: 942550-18
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR '{"a":2,"c":[4,5,{"f":7}]}' -> '$.c[2].f' = 7
     stages:
@@ -320,7 +320,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-10
+  - test_title: 942550-19
     desc: "JSON in SQL (ARGS)"
     # decoded payload: OR '{"a":2,"c":[4,5,{"f":7}]}' <- '$.c[2].f' = 7
     stages:
@@ -338,7 +338,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-11
+  - test_title: 942550-20
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR '{"a":2,"c":[4,5,{"f":7}]}' <- '$.c[2].f' = 7
     stages:
@@ -355,7 +355,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-11
+  - test_title: 942550-21
     desc: "JSON in SQL (ARGS)"
     # decoded payload: OR json_extract('{"id": 14, "name": "Aztalan"}', '$.name') = 'Aztalan'
     stages:
@@ -373,7 +373,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-12
+  - test_title: 942550-22
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR json_extract('{"id": 14, "name": "Aztalan"}', '$.name') = 'Aztalan'
     stages:
@@ -390,7 +390,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-12
+  - test_title: 942550-23
     desc: "JSON in SQL (ARGS)"
     # decoded payload: blah/"}' and data @> '{"a":"a"}' union select ASCII(s.token) from unnset(string_to_array((select cookie from cookie limit 1 ),NULL)) s(token)--/state
     stages:
@@ -408,7 +408,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-13
+  - test_title: 942550-24
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: blah/"}' and data @> '{"a":"a"}' union select ASCII(s.token) from unnset(string_to_array((select cookie from cookie limit 1 ),NULL)) s(token)--/state
     stages:
@@ -425,7 +425,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-13
+  - test_title: 942550-25
     desc: "JSON in SQL (ARGS)"
     # decoded payload: OR '{"a":"b"}' ? 'a'
     stages:
@@ -443,7 +443,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-14
+  - test_title: 942550-26
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR '{"a":"b"}' ? 'a'
     stages:
@@ -460,7 +460,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-14
+  - test_title: 942550-27
     desc: "JSON in SQL (ARGS)"
     # decoded payload: OR '[1,2]' ? '1'
     stages:
@@ -478,7 +478,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-15
+  - test_title: 942550-28
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR '[1,2]' ? '1'
     stages:
@@ -495,7 +495,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-15
+  - test_title: 942550-29
     desc: "JSON in SQL (ARGS)"
     # decoded payload: OR '{"name":"asd"}' ?| array['a','name']
     stages:
@@ -513,7 +513,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-16
+  - test_title: 942550-30
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR '{"name":"asd"}' ?| array['a','name']
     stages:
@@ -530,7 +530,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-16
+  - test_title: 942550-31
     desc: "JSON in SQL (ARGS)"
     # decoded payload: OR '{"name":"asd"}' ?& array['a','name']
     stages:
@@ -548,7 +548,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-17
+  - test_title: 942550-32
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR '{"name":"asd"}' ?& array['a','name']
     stages:
@@ -565,7 +565,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-17
+  - test_title: 942550-33
     desc: "JSON in SQL (ARGS)"
     # decoded payload: OR '[1,2,3]'::json ->> 2='3'
     stages:
@@ -583,7 +583,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-18
+  - test_title: 942550-34
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR '[1,2,3]'::json ->> 2='3'
     stages:
@@ -600,7 +600,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-18
+  - test_title: 942550-35
     desc: "JSON in SQL (ARGS)"
     # decoded payload: OR '{"a":1}'::jsonb #> '{a,b}' ? 'c'
     stages:
@@ -618,7 +618,7 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942550"
-  - test_title: 942550-19
+  - test_title: 942550-36
     desc: "JSON in SQL (REQUEST_FILENAME)"
     # decoded payload: OR '{"a":1}'::jsonb #> '{a,b}' ? 'c'
     stages:

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942550.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942550.yaml
@@ -1,0 +1,61 @@
+---
+meta:
+  author: "Andrea Menin (theMiddle)"
+  description: JSON in SQL bypass technique
+  enabled: true
+  name: 942550.yaml
+tests:
+  - test_title: 942550-1
+    desc: "PostgreSQL JSON in SQL"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            # id=1+OR+'{"a":1}'/**/::/**/jSonb/**/<@'{"a":1}'::jsonb
+            data: "id=1+OR+%27%7B%22a%22%3A1%7D%27%2F%2A%2A%2F%3A%3A%2F%2A%2A%2FjSonb%2F%2A%2A%2F%3C%40%27%7B%22a%22%3A1%7D%27%3A%3Ajsonb"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550"
+  - test_title: 942550-2
+    desc: "SQLite JSON in SQL"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            # id=1+OR+'{"a":2,"c":[4,5,{"f":7}]}' -> '$.c[2].f'=7
+            data: "id=1+OR+%27%7B%22a%22%3A2%2C%22c%22%3A%5B4%2C5%2C%7B%22f%22%3A7%7D%5D%7D%27%20-%3E%20%27%24.c%5B2%5D.f%27%3D7"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550"
+  - test_title: 942550-3
+    desc: "MySQL JSON in SQL"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: "/"
+            # id=1+OR+1=JsoN_EXTraCT/**/(/**/'  {"a":1}  '/**/,/**/' $.a '/**/)
+            data: "id=1+OR+1%3DJsoN_EXTraCT%2F%2A%2A%2F%28%2F%2A%2A%2F%27%20%20%7B%22a%22%3A1%7D%20%20%27%2F%2A%2A%2F%2C%2F%2A%2A%2F%27%20%24.a%20%27%2F%2A%2A%2F%29"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942550"

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942550.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942550.yaml
@@ -6,8 +6,9 @@ meta:
   name: 942550.yaml
 tests:
   - test_title: 942550-1
-    desc: "JSON in SQL (ARGS)"
-    # decoded payload: OR '{"b":2}'::jsonb <@ '{"a":1, "b":2}'::jsonb
+    desc: |
+      JSON in SQL (ARGS)
+      decoded payload: OR '{"b":2}'::jsonb <@ '{"a":1, "b":2}'::jsonb
     stages:
       - stage:
           input:
@@ -24,8 +25,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-2
-    desc: "JSON in SQL (REQUEST_FILENAME)"
-    # decoded payload: OR '{"b":2}'::jsonb <@ '{"a":1, "b":2}'::jsonb
+    desc: |
+      JSON in SQL (REQUEST_FILENAME)
+      decoded payload: OR '{"b":2}'::jsonb <@ '{"a":1, "b":2}'::jsonb
     stages:
       - stage:
           input:
@@ -41,8 +43,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-3
-    desc: "JSON in SQL (ARGS)"
-    # decoded payload: OR '{"b":2}'::jsonb <@ '{"a":1, "b":2}'
+    desc: |
+      JSON in SQL (ARGS)
+      decoded payload: OR '{"b":2}'::jsonb <@ '{"a":1, "b":2}'
     stages:
       - stage:
           input:
@@ -59,8 +62,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-4
-    desc: "JSON in SQL (REQUEST_FILENAME)"
-    # decoded payload: OR '{"b":2}'::jsonb <@ '{"a":1, "b":2}'
+    desc: |
+      JSON in SQL (REQUEST_FILENAME)
+      decoded payload: OR '{"b":2}'::jsonb <@ '{"a":1, "b":2}'
     stages:
       - stage:
           input:
@@ -76,8 +80,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-5
-    desc: "JSON in SQL (ARGS)"
-    # decoded payload: OR '{"b":2}' <@ '{"a":1, "b":2}'::jsonb
+    desc: |
+      JSON in SQL (ARGS)
+      decoded payload: OR '{"b":2}' <@ '{"a":1, "b":2}'::jsonb
     stages:
       - stage:
           input:
@@ -94,8 +99,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-6
-    desc: "JSON in SQL (REQUEST_FILENAME)"
-    # decoded payload: OR '{"b":2}' <@ '{"a":1, "b":2}'::jsonb
+    desc: |
+      JSON in SQL (REQUEST_FILENAME)
+      decoded payload: OR '{"b":2}' <@ '{"a":1, "b":2}'::jsonb
     stages:
       - stage:
           input:
@@ -111,8 +117,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-7
-    desc: "JSON in SQL (ARGS)"
-    # decoded payload: OR '{"b":2}'::json <@ '{"a":1, "b":2}'
+    desc: |
+      JSON in SQL (ARGS)
+      decoded payload: OR '{"b":2}'::json <@ '{"a":1, "b":2}'
     stages:
       - stage:
           input:
@@ -129,8 +136,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-8
-    desc: "JSON in SQL (REQUEST_FILENAME)"
-    # decoded payload: OR '{"b":2}'::json <@ '{"a":1, "b":2}'
+    desc: |
+      JSON in SQL (REQUEST_FILENAME)
+      decoded payload: OR '{"b":2}'::json <@ '{"a":1, "b":2}'
     stages:
       - stage:
           input:
@@ -146,8 +154,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-9
-    desc: "JSON in SQL (ARGS)"
-    # decoded payload: OR '{"b":2}' <@ '{"a":1, "b":2}'::json
+    desc: |
+      JSON in SQL (ARGS)
+      decoded payload: OR '{"b":2}' <@ '{"a":1, "b":2}'::json
     stages:
       - stage:
           input:
@@ -164,8 +173,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-10
-    desc: "JSON in SQL (REQUEST_FILENAME)"
-    # decoded payload: OR '{"b":2}' <@ '{"a":1, "b":2}'::json
+    desc: |
+      JSON in SQL (REQUEST_FILENAME)
+      decoded payload: OR '{"b":2}' <@ '{"a":1, "b":2}'::json
     stages:
       - stage:
           input:
@@ -181,8 +191,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-11
-    desc: "JSON in SQL (ARGS)"
-    # decoded payload: OR '{"b":2}'::jsonb @> '{"a":1, "b":2}'::jsonb
+    desc: |
+      JSON in SQL (ARGS)
+      decoded payload: OR '{"b":2}'::jsonb @> '{"a":1, "b":2}'::jsonb
     stages:
       - stage:
           input:
@@ -199,8 +210,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-12
-    desc: "JSON in SQL (REQUEST_FILENAME)"
-    # decoded payload: OR '{"b":2}'::jsonb @> '{"a":1, "b":2}'::jsonb
+    desc: |
+      JSON in SQL (REQUEST_FILENAME)
+      decoded payload: OR '{"b":2}'::jsonb @> '{"a":1, "b":2}'::jsonb
     stages:
       - stage:
           input:
@@ -216,8 +228,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-13
-    desc: "JSON in SQL (ARGS)"
-    # decoded payload: OR '{"b":2}'::jsonb < '{"a":1, "b":2}'::jsonb
+    desc: |
+      JSON in SQL (ARGS)
+      decoded payload: OR '{"b":2}'::jsonb < '{"a":1, "b":2}'::jsonb
     stages:
       - stage:
           input:
@@ -234,8 +247,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-14
-    desc: "JSON in SQL (REQUEST_FILENAME)"
-    # decoded payload: OR '{"b":2}'::jsonb < '{"a":1, "b":2}'::jsonb
+    desc: |
+      JSON in SQL (REQUEST_FILENAME)
+      decoded payload: OR '{"b":2}'::jsonb < '{"a":1, "b":2}'::jsonb
     stages:
       - stage:
           input:
@@ -251,8 +265,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-15
-    desc: "JSON in SQL (ARGS)"
-    # decoded payload: OR '{"b":2}'::jsonb > '{"a":1, "b":2}'::jsonb
+    desc: |
+      JSON in SQL (ARGS)
+      decoded payload: OR '{"b":2}'::jsonb > '{"a":1, "b":2}'::jsonb
     stages:
       - stage:
           input:
@@ -269,8 +284,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-16
-    desc: "JSON in SQL (REQUEST_FILENAME)"
-    # decoded payload: OR '{"b":2}'::jsonb > '{"a":1, "b":2}'::jsonb
+    desc: |
+      JSON in SQL (REQUEST_FILENAME)
+      decoded payload: OR '{"b":2}'::jsonb > '{"a":1, "b":2}'::jsonb
     stages:
       - stage:
           input:
@@ -286,8 +302,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-17
-    desc: "JSON in SQL (ARGS)"
-    # decoded payload: OR '{"a":2,"c":[4,5,{"f":7}]}' -> '$.c[2].f' = 7
+    desc: |
+      JSON in SQL (ARGS)
+      decoded payload: OR '{"a":2,"c":[4,5,{"f":7}]}' -> '$.c[2].f' = 7
     stages:
       - stage:
           input:
@@ -304,8 +321,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-18
-    desc: "JSON in SQL (REQUEST_FILENAME)"
-    # decoded payload: OR '{"a":2,"c":[4,5,{"f":7}]}' -> '$.c[2].f' = 7
+    desc: |
+      JSON in SQL (REQUEST_FILENAME)
+      decoded payload: OR '{"a":2,"c":[4,5,{"f":7}]}' -> '$.c[2].f' = 7
     stages:
       - stage:
           input:
@@ -321,8 +339,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-19
-    desc: "JSON in SQL (ARGS)"
-    # decoded payload: OR '{"a":2,"c":[4,5,{"f":7}]}' <- '$.c[2].f' = 7
+    desc: |
+      JSON in SQL (ARGS)
+      decoded payload: OR '{"a":2,"c":[4,5,{"f":7}]}' <- '$.c[2].f' = 7
     stages:
       - stage:
           input:
@@ -339,8 +358,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-20
-    desc: "JSON in SQL (REQUEST_FILENAME)"
-    # decoded payload: OR '{"a":2,"c":[4,5,{"f":7}]}' <- '$.c[2].f' = 7
+    desc: |
+      JSON in SQL (REQUEST_FILENAME)
+      decoded payload: OR '{"a":2,"c":[4,5,{"f":7}]}' <- '$.c[2].f' = 7
     stages:
       - stage:
           input:
@@ -356,8 +376,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-21
-    desc: "JSON in SQL (ARGS)"
-    # decoded payload: OR json_extract('{"id": 14, "name": "Aztalan"}', '$.name') = 'Aztalan'
+    desc: |
+      JSON in SQL (ARGS)
+      decoded payload: OR json_extract('{"id": 14, "name": "Aztalan"}', '$.name') = 'Aztalan'
     stages:
       - stage:
           input:
@@ -374,8 +395,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-22
-    desc: "JSON in SQL (REQUEST_FILENAME)"
-    # decoded payload: OR json_extract('{"id": 14, "name": "Aztalan"}', '$.name') = 'Aztalan'
+    desc: |
+      JSON in SQL (REQUEST_FILENAME)
+      decoded payload: OR json_extract('{"id": 14, "name": "Aztalan"}', '$.name') = 'Aztalan'
     stages:
       - stage:
           input:
@@ -391,8 +413,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-23
-    desc: "JSON in SQL (ARGS)"
-    # decoded payload: blah/"}' and data @> '{"a":"a"}' union select ASCII(s.token) from unnset(string_to_array((select cookie from cookie limit 1 ),NULL)) s(token)--/state
+    desc: |
+      JSON in SQL (ARGS)
+      decoded payload: blah/"}' and data @> '{"a":"a"}' union select ASCII(s.token) from unnset(string_to_array((select cookie from cookie limit 1 ),NULL)) s(token)--/state
     stages:
       - stage:
           input:
@@ -409,8 +432,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-24
-    desc: "JSON in SQL (REQUEST_FILENAME)"
-    # decoded payload: blah/"}' and data @> '{"a":"a"}' union select ASCII(s.token) from unnset(string_to_array((select cookie from cookie limit 1 ),NULL)) s(token)--/state
+    desc: |
+      JSON in SQL (REQUEST_FILENAME)
+      decoded payload: blah/"}' and data @> '{"a":"a"}' union select ASCII(s.token) from unnset(string_to_array((select cookie from cookie limit 1 ),NULL)) s(token)--/state
     stages:
       - stage:
           input:
@@ -426,8 +450,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-25
-    desc: "JSON in SQL (ARGS)"
-    # decoded payload: OR '{"a":"b"}' ? 'a'
+    desc: |
+      JSON in SQL (ARGS)
+      decoded payload: OR '{"a":"b"}' ? 'a'
     stages:
       - stage:
           input:
@@ -444,8 +469,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-26
-    desc: "JSON in SQL (REQUEST_FILENAME)"
-    # decoded payload: OR '{"a":"b"}' ? 'a'
+    desc: |
+      JSON in SQL (REQUEST_FILENAME)
+      decoded payload: OR '{"a":"b"}' ? 'a'
     stages:
       - stage:
           input:
@@ -461,8 +487,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-27
-    desc: "JSON in SQL (ARGS)"
-    # decoded payload: OR '[1,2]' ? '1'
+    desc: |
+      JSON in SQL (ARGS)
+      decoded payload: OR '[1,2]' ? '1'
     stages:
       - stage:
           input:
@@ -479,8 +506,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-28
-    desc: "JSON in SQL (REQUEST_FILENAME)"
-    # decoded payload: OR '[1,2]' ? '1'
+    desc: |
+      JSON in SQL (REQUEST_FILENAME)
+      decoded payload: OR '[1,2]' ? '1'
     stages:
       - stage:
           input:
@@ -496,8 +524,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-29
-    desc: "JSON in SQL (ARGS)"
-    # decoded payload: OR '{"name":"asd"}' ?| array['a','name']
+    desc: |
+      JSON in SQL (ARGS)
+      decoded payload: OR '{"name":"asd"}' ?| array['a','name']
     stages:
       - stage:
           input:
@@ -514,8 +543,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-30
-    desc: "JSON in SQL (REQUEST_FILENAME)"
-    # decoded payload: OR '{"name":"asd"}' ?| array['a','name']
+    desc: |
+      JSON in SQL (REQUEST_FILENAME)
+      decoded payload: OR '{"name":"asd"}' ?| array['a','name']
     stages:
       - stage:
           input:
@@ -531,8 +561,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-31
-    desc: "JSON in SQL (ARGS)"
-    # decoded payload: OR '{"name":"asd"}' ?& array['a','name']
+    desc: |
+      JSON in SQL (ARGS)
+      decoded payload: OR '{"name":"asd"}' ?& array['a','name']
     stages:
       - stage:
           input:
@@ -549,8 +580,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-32
-    desc: "JSON in SQL (REQUEST_FILENAME)"
-    # decoded payload: OR '{"name":"asd"}' ?& array['a','name']
+    desc: |
+      JSON in SQL (REQUEST_FILENAME)
+      decoded payload: OR '{"name":"asd"}' ?& array['a','name']
     stages:
       - stage:
           input:
@@ -566,8 +598,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-33
-    desc: "JSON in SQL (ARGS)"
-    # decoded payload: OR '[1,2,3]'::json ->> 2='3'
+    desc: |
+      JSON in SQL (ARGS)
+      decoded payload: OR '[1,2,3]'::json ->> 2='3'
     stages:
       - stage:
           input:
@@ -584,8 +617,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-34
-    desc: "JSON in SQL (REQUEST_FILENAME)"
-    # decoded payload: OR '[1,2,3]'::json ->> 2='3'
+    desc: |
+      JSON in SQL (REQUEST_FILENAME)
+      decoded payload: OR '[1,2,3]'::json ->> 2='3'
     stages:
       - stage:
           input:
@@ -601,8 +635,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-35
-    desc: "JSON in SQL (ARGS)"
-    # decoded payload: OR '{"a":1}'::jsonb #> '{a,b}' ? 'c'
+    desc: |
+      JSON in SQL (ARGS)
+      decoded payload: OR '{"a":1}'::jsonb #> '{a,b}' ? 'c'
     stages:
       - stage:
           input:
@@ -619,8 +654,9 @@ tests:
           output:
             log_contains: id "942550"
   - test_title: 942550-36
-    desc: "JSON in SQL (REQUEST_FILENAME)"
-    # decoded payload: OR '{"a":1}'::jsonb #> '{a,b}' ? 'c'
+    desc: |
+      JSON in SQL (REQUEST_FILENAME)
+      decoded payload: OR '{"a":1}'::jsonb #> '{a,b}' ? 'c'
     stages:
       - stage:
           input:


### PR DESCRIPTION
This PR contains a new rule at PL1 that tries to catch SQL in JSON payloads not covered at PL1. For more information about the bypass technique, please refer to https://claroty.com/team82/research/js-on-security-off-abusing-json-based-sql-to-bypass-waf