### PR TITLE
feat: add method override headers to restricted headers, rules 900250 and 901165

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -532,7 +532,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  nolog,\
 #  pass,\
 #  t:none,\
-#  setvar:'tx.restricted_headers=/accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/'"
+#  setvar:'tx.restricted_headers=/accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/'"
 
 # Content-Types charsets that a client is allowed to send in a request.
 # The content-types are enclosed by |pipes| as delimiters to guarantee exact matches.

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -525,6 +525,9 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #
 # Note: Blocking Proxy header prevents 'httpoxy' vulnerability: https://httpoxy.org
 #
+# Note: Blocking the x-http-method-override,x-http-method and x-method-override headers
+# prevents attacks as described here: https://www.sidechannel.blog/en/http-method-override-what-it-is-and-how-a-pentester-can-use-it
+#
 # Uncomment this rule to change the default.
 #SecAction \
 # "id:900250,\

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -219,7 +219,7 @@ SecRule &TX:restricted_headers "@eq 0" \
     pass,\
     nolog,\
     ver:'OWASP_CRS/4.0.0-rc1',\
-    setvar:'tx.restricted_headers=/accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/'"
+    setvar:'tx.restricted_headers=/accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/'"
 
 # Default enforcing of body processor URLENCODED (rule 900010 in crs-setup.conf)
 SecRule &TX:enforce_bodyproc_urlencoded "@eq 0" \


### PR DESCRIPTION
As mentioned in the slack channel, these headers should not be used by legitimate requests. They can however be used for attacks, as described f.ex. here: https://www.sidechannel.blog/en/http-method-override-what-it-is-and-how-a-pentester-can-use-it/

Signed-off-by: Mark Zeman <zeman@puzzle.ch>