### PR TITLE
Add REQUEST_FILENAME to 942120 to catch path SQLi

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -637,7 +637,7 @@ SecRule REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@rx (?:^\s*[\"'`;]+|[\"'`]+\s*$
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 942120
 #
-SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i)!=|&&|\|\||>[=->]|<(?:<|=>?|>(?:[\s\v]+binary)?)|\b(?:(?:xor|r(?:egexp|like)|i(?:snull|like)|notnull)\b|collate(?:[^0-9A-Z_a-z]*?(?:U&)?[\"'`]|[^0-9A-Z_a-z]+(?:(?:binary|nocase|rtrim)\b|[0-9A-Z_a-z]*?_))|(?:likel(?:ihood|y)|unlikely)[\s\v]*\()|r(?:egexp|like)[\s\v]+binary|not[\s\v]+between[\s\v]+(?:0[\s\v]+and|(?:'[^']*'|\"[^\"]*\")[\s\v]+and[\s\v]+(?:'[^']*'|\"[^\"]*\"))|is[\s\v]+null|like[\s\v]+(?:null|[0-9A-Z_a-z]+[\s\v]+escape\b)|(?:^|[^0-9A-Z_a-z])in[\s\v\+]*\([\s\v\"0-9]+[^\(-\)]*\)|[!<->]{1,2}[\s\v]*all\b" \
+SecRule ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@rx (?i)!=|&&|\|\||>[=->]|<(?:<|=>?|>(?:[\s\v]+binary)?)|\b(?:(?:xor|r(?:egexp|like)|i(?:snull|like)|notnull)\b|collate(?:[^0-9A-Z_a-z]*?(?:U&)?[\"'`]|[^0-9A-Z_a-z]+(?:(?:binary|nocase|rtrim)\b|[0-9A-Z_a-z]*?_))|(?:likel(?:ihood|y)|unlikely)[\s\v]*\()|r(?:egexp|like)[\s\v]+binary|not[\s\v]+between[\s\v]+(?:0[\s\v]+and|(?:'[^']*'|\"[^\"]*\")[\s\v]+and[\s\v]+(?:'[^']*'|\"[^\"]*\"))|is[\s\v]+null|like[\s\v]+(?:null|[0-9A-Z_a-z]+[\s\v]+escape\b)|(?:^|[^0-9A-Z_a-z])in[\s\v\+]*\([\s\v\"0-9]+[^\(-\)]*\)|[!<->]{1,2}[\s\v]*all\b" \
     "id:942120,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942120.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942120.yaml
@@ -656,3 +656,19 @@ tests:
             version: HTTP/1.1
           output:
             no_log_contains: id "942120"
+  - test_title: 942120-39
+    desc: "Detect path-based SQLi attempt"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            port: 80
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: */*
+            method: POST
+            uri: "/catalogue/rest/products/2499999||this.product/reviews"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942120"

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942120.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942120.yaml
@@ -666,7 +666,7 @@ tests:
             headers:
               Host: localhost
               User-Agent: OWASP ModSecurity Core Rule Set
-              Accept: */*
+              Accept: "*/*"
             method: POST
             uri: "/catalogue/rest/products/2499999||this.product/reviews"
             version: HTTP/1.0


### PR DESCRIPTION
PR adds `REQUEST_FILENAME` to rule 942120 at PL 2: _SQL Injection Attack: SQL Operator Detected_. A new test is also added.

This change allows us to detect path-based SQLi attempts like
`localhost/rest/products/2499999||this.product/reviews`
by matching against SQL operators in paths.

This PR should fully resolve bug bounty issue ULYKOFYK.

Associated issue: #2977 