### PR TITLE
fix: Remove .DS_Store files from restricted-files.data

### DIFF
--- a/rules/restricted-files.data
+++ b/rules/restricted-files.data
@@ -126,8 +126,6 @@ wp-config.txt
 /packages.json
 # dotenv
 /.env
-# OSX
-/.DS_Store
 # WS FTP
 /.ws_ftp.ini
 # common, old network config file


### PR DESCRIPTION
.DS_Store files just contain positioning data for files in MacOS Finder, and so they are not considered sensitive.
https://metacpan.org/dist/Mac-Finder-DSStore/view/DSStoreFormat.pod

Maybe blocking .DS_Store files would catch [CVE-2007-5850](https://nvd.nist.gov/vuln/detail/CVE-2007-5850), but given there's a .DS_Store file in every directory, lay-people are likely to hit a lot of false-positives.

Thoughts?