### PR TITLE
feat: add configuration file for toolchain

### DIFF
--- a/regex-assembly/toolchain.yaml
+++ b/regex-assembly/toolchain.yaml
@@ -1,0 +1,44 @@
+# # # # # # # # # # # # # # # # # # # #
+# configuration file for crs-toolchain
+# # # # # # # # # # # # # # # # # # # #
+patterns:
+  # The Unix evasion patterns, were extended per decision in https://github.com/coreruleset/coreruleset/issues/2632.
+  anti_evasion:
+    # - [\x5c'\"\[]: common evasion tokens and path expansion, e.g. `/bin/[c]''a""\t`
+    # - \|\||&&)\s*: hiding of empty variables through logial operators, e.g., `nc&&$u -p 777`
+    # - \$[a-z0-9_@?!#{*-]*: empty variable evasion, e.g. `n\$uc -p 777`
+    unix: |
+      [\x5c'\"\[]*(?:(?:(?:\|\||&&)\s*)?\$[a-z0-9_@?!#{*-]*)?\x5c?
+    windows: |
+      [\"\^]*
+  anti_evasion_suffix:
+    # - <>: redirection, e.g., `cat<foo`
+    # - ,: brace expansion, e.g., `""{nc,-p,777}`
+    unix: |
+      [\s<>,].*
+    # "more foo", "more,foo", "more;foo", "more.com", "more/e",
+    # "more<foo", "more>foo"
+    windows: |
+      [\s,;./<>].*
+  # Same as above but does not allow any white space as the next token.
+  # This is useful for words like `python3`, where `python@` would
+  # create too many false positives because it would match `python `.
+  anti_evasion_no_space_suffix:
+    # This will match:
+    #
+    # python<<<foo
+    # python2 foo
+    #
+    # It will _not_ match:
+    # python foo
+    unix: |
+      (?:[<>,]|(?:[\w\d._-][\x5c'\"\[]*(?:(?:(?:\|\||&&)\s*)?\$[a-z0-9_@?!#{*-]*)?\x5c?)+[\s<>,]).*
+    # This will match:
+    #
+    # python,foo
+    # python2 foo
+    #
+    # It will _not_ match:
+    # python foo
+    windows: |
+      (?:[,;./<>]|(?:[\w\d._-][\"\^]*)+[\s,;./<>]).*


### PR DESCRIPTION
The toolchain configuration file stores configuration that must be part of the CRS repository. For now, this information is limited to the anti-evasion patterns used by the cmdline processor of the toolchain.

See https://github.com/coreruleset/crs-toolchain/pull/70