### PR TITLE
fix(ci): updating to actions/upload-artifact@v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
             # we want to get the audit log, so change permissions (file is only for root on docker)
             sudo chmod 644 tests/logs/${{ matrix.modsec_version }}/modsec_audit.log
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: waf-logs


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Should solve this:

"regression (modsec2-apache)
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/."