### PR TITLE
fix: add headers to pl2 rules 942200, 942370

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -823,7 +823,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 942200
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i),.*?[\"'\)0-9`-f][\"'`](?:[\"'`].*?[\"'`]|(?:\r?\n)?\z|[^\"'`]+)|[^0-9A-Z_a-z]select.+[^0-9A-Z_a-z]*?from|(?:alter|(?:(?:cre|trunc|upd)at|renam)e|d(?:e(?:lete|sc)|rop)|(?:inser|selec)t|load)[\s\v]*?\([\s\v]*?space[\s\v]*?\(" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@rx (?i),.*?[\"'\)0-9`-f][\"'`](?:[\"'`].*?[\"'`]|(?:\r?\n)?\z|[^\"'`]+)|[^0-9A-Z_a-z]select.+[^0-9A-Z_a-z]*?from|(?:alter|(?:(?:cre|trunc|upd)at|renam)e|d(?:e(?:lete|sc)|rop)|(?:inser|selec)t|load)[\s\v]*?\([\s\v]*?space[\s\v]*?\(" \
     "id:942200,\
     phase:2,\
     block,\
@@ -1080,7 +1080,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 942370
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\"'`](?:[\s\v]*?(?:(?:\*.+(?:x?or|div|like|between|(?:an|i)d)[^0-9A-Z_a-z]*?[\"'`]|(?:x?or|div|like|between|and)[\s\v][^0-9]+[\-0-9A-Z_a-z]+.*?)[0-9]|[^\s\v0-9\?A-Z_a-z]+[\s\v]*?[^\s\v0-9A-Z_a-z]+[\s\v]*?[\"'`]|[^\s\v0-9A-Z_a-z]+[\s\v]*?[^A-Z_a-z].*?(?:#|--))|.*?\*[\s\v]*?[0-9])|\^[\"'`]|[%\(-\+\-<>][\-0-9A-Z_a-z]+[^\s\v0-9A-Z_a-z]+[\"'`][^,]" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:Referer|REQUEST_HEADERS:User-Agent|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\"'`](?:[\s\v]*?(?:(?:\*.+(?:x?or|div|like|between|(?:an|i)d)[^0-9A-Z_a-z]*?[\"'`]|(?:x?or|div|like|between|and)[\s\v][^0-9]+[\-0-9A-Z_a-z]+.*?)[0-9]|[^\s\v0-9\?A-Z_a-z]+[\s\v]*?[^\s\v0-9A-Z_a-z]+[\s\v]*?[\"'`]|[^\s\v0-9A-Z_a-z]+[\s\v]*?[^A-Z_a-z].*?(?:#|--))|.*?\*[\s\v]*?[0-9])|\^[\"'`]|[%\(-\+\-<>][\-0-9A-Z_a-z]+[^\s\v0-9A-Z_a-z]+[\"'`][^,]" \
     "id:942370,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942200.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942200.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "Christian S.J. Peron"
+  author: "Christian S.J. Peron, Franziska Bühler"
   description: None
   enabled: true
   name: 942200.yaml
@@ -18,6 +18,21 @@ tests:
             method: POST
             port: 80
             data: ",varname%22=somedata"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942200"
+  - test_title: 942200-2
+    desc: "comment-/space-obfuscated injections and backtick termination in request headers"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: "encode(lo_get(16400),'base64')::int"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
             version: HTTP/1.0
           output:
             log_contains: id "942200"

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942370.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942370.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "Christian S.J. Peron, Max Leske"
+  author: "Christian S.J. Peron, Max Leske, Franziska Bühler"
   description: |
     classic SQL injection probings 2/3
 
@@ -170,6 +170,35 @@ tests:
             method: POST
             port: 80
             data: "var=>foo##'."
+            version: HTTP/1.0
+          output:
+            log_contains: id "942370"
+  - test_title: 942370-10
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: 1"and json_search (json_array(password),0b11000010110110001101100,"t_______________")#
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            version: HTTP/1.0
+          output:
+            log_contains: id "942370"
+  - test_title: 942370-11
+    desc: encode(lo_get(16400),'base64')::int
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: encode(lo_get(16400),'base64')::int
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
             version: HTTP/1.0
           output:
             log_contains: id "942370"


### PR DESCRIPTION
This PR adds request headers referer and user-agent to two PL2 rules:
* 942200
* 942370
* 
This PR also adds tests with PoC commands from Shivam Bathla.
For more info see: https://github.com/coreruleset/coreruleset/issues/2924