### PR TITLE
fix: add headers to pl2 rule 942521

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1473,7 +1473,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 942521
 #
-SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i)^(?:[^']*?(?:'[^']*?'[^']*?)*?'|[^\"]*?(?:\"[^\"]*?\"[^\"]*?)*?\"|[^`]*?(?:`[^`]*?`[^`]*?)*?`)[\s\v]*([0-9A-Z_a-z]+)\b" \
+SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@rx (?i)^(?:[^']*?(?:'[^']*?'[^']*?)*?'|[^\"]*?(?:\"[^\"]*?\"[^\"]*?)*?\"|[^`]*?(?:`[^`]*?`[^`]*?)*?`)[\s\v]*([0-9A-Z_a-z]+)\b" \
     "id:942521,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942521.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942521.yaml
@@ -378,7 +378,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: 1'and json_search (json_array(password),0b11000010110110001101100,'t_______________')#"
+              User-Agent: "1'and json_search (json_array(password),0b11000010110110001101100,'t_______________')#"
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             method: GET
             port: 80

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942521.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942521.yaml
@@ -333,7 +333,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: "1' and starts_with(password,\$\$t\$\$) and 'true"
+              User-Agent: "1' and starts_with(password) and 'true"
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             method: GET
             port: 80

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942521.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942521.yaml
@@ -325,3 +325,63 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "942521"
+  - test_title: 942521-21
+    desc: "Detects odd number of quotes in request headers"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: "1' and starts_with(password,\$\$t\$\$) and 'true"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            version: HTTP/1.0
+          output:
+            log_contains: id "942521"
+  - test_title: 942521-22
+    desc: "Detects odd number of quotes in request headers"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: "1' and lo_import('/etc' || '/pass' || 'wd')::int::bool and 'true"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            version: HTTP/1.0
+          output:
+            log_contains: id "942521"
+  - test_title: 942521-23
+    desc: "Detects odd number of quotes in request headers"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: "1' and lo_get(16400)::text::bool and 'true"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            version: HTTP/1.0
+          output:
+            log_contains: id "942521"
+  - test_title: 942521-24
+    desc: "Detects odd number of quotes in request headers"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: 1'and json_search (json_array(password),0b11000010110110001101100,'t_______________')#"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            version: HTTP/1.0
+          output:
+            log_contains: id "942521"


### PR DESCRIPTION
This PR adds 2 request headers to rule 942521: user-agent and referer.
This PR also adds PoC provided by Shivam Bathla as new regression tests.

For more info see: https://github.com/coreruleset/coreruleset/issues/2924