### PR TITLE
fix: PHP errors data file

### DIFF
--- a/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -101,6 +101,31 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:953014,phase:4,pass,nolog,skipAf
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
+#
+# -=[ PHP Error Message Leakage ]=-
+#
+# This is a stricter sibling of rule 953100.
+# This stricter sibling checks for additional error messages which has a higher chance to appear in common language.
+#
+SecRule RESPONSE_BODY "@pmFromFile php-errors-pl2.data" \
+    "id:953101,\
+    phase:4,\
+    block,\
+    capture,\
+    t:none,\
+    msg:'PHP Information Leakage',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
+    tag:'application-multi',\
+    tag:'language-php',\
+    tag:'platform-multi',\
+    tag:'attack-disclosure',\
+    tag:'paranoia-level/2',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/118/116',\
+    tag:'PCI/6.5.6',\
+    ver:'OWASP_CRS/4.0.0-rc1',\
+    severity:'ERROR',\
+    setvar:'tx.outbound_anomaly_score_pl2=+%{tx.error_anomaly_score}'"
 
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:953015,phase:3,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"

--- a/rules/php-errors-pl2.data
+++ b/rules/php-errors-pl2.data
@@ -1,0 +1,4 @@
+# For more information, see comments at the beginning of the php-errors.data file.
+
+Invalid date
+The function

--- a/rules/php-errors.data
+++ b/rules/php-errors.data
@@ -407,7 +407,6 @@ Invalid boundary in multipart/form-data POST data
 Invalid browscap ini file:
 Invalid characters passed for attempted conversion, these have been ignored
 Invalid column index
-Invalid date
 Invalid document encoding
 Invalid finfo object
 Invalid number of threads
@@ -1307,13 +1306,13 @@ zlib window size (logarithm) (
 #   into (
 # ($end)
 # (after
- (breaking at opline
- (inclusive)
- (path:
- (tried to allocate
- - dynamic modules are not supported
- Chunks Wide
- Chunks vertically
+(breaking at opline
+(inclusive)
+(path:
+(tried to allocate
+- dynamic modules are not supported
+Chunks Wide
+Chunks vertically
 # \n
 # already defined
 # and
@@ -1321,119 +1320,119 @@ zlib window size (logarithm) (
 # and property
 # argument
 # arguments are required,
- arguments for the fetch mode provided,
+arguments for the fetch mode provided,
 # as array
- as execution context, not a valid file or symlink
+as execution context, not a valid file or symlink
 # as non static
 # at continuation
 # at line
 # bytes
- bytes (Current memory usage is
- bytes exhausted (tried to allocate
- bytes exhausted at
+bytes (Current memory usage is
+bytes exhausted (tried to allocate
+bytes exhausted at
 # bytes passed
- bytes were written, expected to write
+bytes were written, expected to write
 # bytes)
- bytes) (tried to allocate
+bytes) (tried to allocate
 # bytes) at
 # bytes,
- bytes. Uncompressing into buffer of
- cannot be instantiated
- cannot be of type array
- cannot be passed by reference
- cannot contain non abstract method
+bytes. Uncompressing into buffer of
+cannot be instantiated
+cannot be of type array
+cannot be passed by reference
+cannot contain non abstract method
 # characters to "
- chunk index entries
+chunk index entries
 # colours
- command is disallowed during hard interrupt
+command is disallowed during hard interrupt
 # constant
- contains a null byte
+contains a null byte
 # could not be converted to
- could not be converted to bool
- could not be converted to string
+could not be converted to bool
+could not be converted to string
 # could not be found
- could not compile file
- did not create an Iterator
- died before SIGKILL was sent
- does not have a constructor, cannot pass arguments
- does not match enum backing type
- does not support method calls
- doesn't exist in class
+could not compile file
+did not create an Iterator
+died before SIGKILL was sent
+does not have a constructor, cannot pass arguments
+does not match enum backing type
+does not support method calls
+doesn't exist in class
 # done.
 # elements
 # elements,
 # exists
 # expected
- file is closed
+file is closed
 # for cases
 # for initialization
 # for parameter
- for stream_metadata
+for stream_metadata
 # from
 # from uncompress
 # given
 # given, called in
 # has no effect
- has no unserializer
+has no unserializer
 # held by property
- implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary)
+implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary)
 # in
 # in table for
- instance wasn't initialized properly
+instance wasn't initialized properly
 # is deprecated
- is greater than \\377
- is inapplicable to this socket type
+is greater than \\377
+is inapplicable to this socket type
 # is installed
- is nor an array nor an object
+is nor an array nor an object
 # is not a string
- is not a user defined function, no oplines exist
- is not a user defined method, no oplines exist
- is not a valid backing value for enum "
- is not a valid phar archive
+is not a user defined function, no oplines exist
+is not a user defined method, no oplines exist
+is not a valid backing value for enum "
+is not a valid phar archive
 # is not allowed
 # is not callable
- is not compatible with property
+is not compatible with property
 # is undefined
 # items,
 # magic
 # method
 # module failed
- must be a field name from this result set
- must be greater than or equal to 0
- must be less than the number of fields for this result set
- must be passed by reference, value given
+must be a field name from this result set
+must be greater than or equal to 0
+must be less than the number of fields for this result set
+must be passed by reference, value given
 # must be public
- must not be accessed before initialization
+must not be accessed before initialization
 # not found
- object is already closed
- object is not fully initialized
- object_id:
- of C function '
+object is already closed
+object is not fully initialized
+object_id:
+of C function '
 # of type
 # offset
 # on line
 # on string
- oplines in file
- oplines in function
- oplines in method
- option must have an array value
+oplines in file
+oplines in function
+oplines in method
+option must have an array value
 # or null,
- overwrites previous argument
- packet. PID=
+overwrites previous argument
+packet. PID=
 # parameter
 # passed and
 # passed in
 # past its maximal value
 # past its minimal value
 # points
- points in array with only
+points in array with only
 # present
 # property
 # provided
- readonly property
+readonly property
 # received
- requires PDO API version
- requires Zend Engine API version
+requires PDO API version
+requires Zend Engine API version
 # resource
 # resource supplied
 # returned
@@ -1441,13 +1440,13 @@ zlib window size (logarithm) (
 # supports only version
 # to
 # to property
- to reference held by property
+to reference held by property
 # to write index
- used as array
- was built with configuration
- when argument #1 ($search) is
+used as array
+was built with configuration
+when argument #1 ($search) is
 # when declared
- with an empty name
+with an empty name
 ' (include_path='
 ' (info)\n
 ' (mem)\n
@@ -1923,7 +1922,6 @@ The arguments array must contain
 The class requested (
 # The command "
 The expanded parameter requires SQLite3 >= 3.14 and
-The function
 The function requested (
 The magic method
 # The method


### PR DESCRIPTION
Some of the patterns in `php-errors.data` are too common to be in PL1 so i'm moving them into PL2. I also removed a whitespace from the beginning of few patters as it's trimmer by modsec anyway.