### PR TITLE
chore: adds 426 and 505 status codes for HTTP/0.9 tests 

### DIFF
--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920280.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920280.yaml
@@ -43,4 +43,4 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
           output:
             # Technically valid but Apache doesn't allow 0.9 anymore
-            status: [400]
+            status: [400, 426, 505]

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920430.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920430.yaml
@@ -43,7 +43,7 @@ tests:
               Host: "localhost"
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
           output:
-            status: [403, 400]
+            status: [403, 400, 426, 505]
   - test_title: 920430-4
     stages:
       - stage:
@@ -138,7 +138,7 @@ tests:
             uri: /
             version: HTTP/0.8
           output:
-            status: [403, 400]
+            status: [403, 400, 426, 505]
   - test_title: 920430-10
     desc: HTTP protocol version is not allowed by policy (920430) from old modsec regressions
     stages:


### PR DESCRIPTION
`920280-3`, `920430-3` and `920430-9`  tests are performing requests with http version <= `HTTP/0.9`. Depending on the server, I'm experiencing different behaviours (and status codes returned).
This PR proposes to add status codes  `505` (`HTTP Version Not Supported`) and `426` (`Upgrade Required`) as accepted statuses for these tests in order to make them compatible also with, respectively, Go/http and Envoy proxy.
Thanks!