### PR TITLE
fix: Rework restricted headers

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -565,7 +565,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #
 # Uncomment this rule to change the default.
 #SecAction \
-# "id:900260,\
+# "id:900255,\
 #  phase:1,\
 #  nolog,\
 #  pass,\

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -513,7 +513,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # should be lowercase and enclosed by /slashes/ as delimiters.
 #
 # [ Basic ]
-# Includes deprecated headers and headers with known security risks: always
+# Includes deprecated headers and headers with known security risks. Always
 # forbidden.
 # Default: /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/
 #
@@ -548,11 +548,11 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  nolog,\
 #  pass,\
 #  t:none,\
-#  setvar:'tx.restricted_headers_basic=/accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/'"
+#  setvar:'tx.restricted_headers_basic=/content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/'"
 #
 # [ Extended ]
 # Includes deprecated headers that are still in use (so false positives are
-# possible) and headers with possible security risks: forbidden at a higher
+# possible) and headers with possible security risks. Forbidden at a higher
 # paranoia level.
 # Default: /accept-charset/
 #

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -513,7 +513,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # should be lowercase and enclosed by /slashes/ as delimiters.
 #
 # [ Basic ]
-# Deprecated headers and/or headers with known security risks: always forbidden.
+# Includes deprecated headers and headers with known security risks: always
+# forbidden.
 # Default: /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/
 #
 # /content-encoding/
@@ -550,8 +551,9 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  setvar:'tx.restricted_headers=/accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/'"
 #
 # [ Extended ]
-# Deprecated headers still in use (so false positives are possible), possible
-# security risks: forbidden at a higher paranoia level.
+# Includes deprecated headers that are still in use (so false positives are
+# possible) and headers with possible security risks: forbidden at a higher
+# paranoia level.
 # Default: /accept-charset/
 #
 # /accept-charset/

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -548,7 +548,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  nolog,\
 #  pass,\
 #  t:none,\
-#  setvar:'tx.restricted_headers=/accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/'"
+#  setvar:'tx.restricted_headers_basic=/accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/'"
 #
 # [ Extended ]
 # Includes deprecated headers that are still in use (so false positives are
@@ -572,7 +572,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  nolog,\
 #  pass,\
 #  t:none,\
-#  setvar:'tx.restricted_headers=/accept-charset/'"
+#  setvar:'tx.restricted_headers_extended=/accept-charset/'"
 
 # Content-Types charsets that a client is allowed to send in a request.
 # The content-types are enclosed by |pipes| as delimiters to guarantee exact matches.

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -507,26 +507,38 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  t:none,\
 #  setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .rdb/ .resources/ .resx/ .sql/ .swp/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'"
 
-# Forbidden request headers.
-# Header names should be lowercase, enclosed by /slashes/ as delimiters.
-# Default: /accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/
+# Restricted request headers.
+# The HTTP request headers that CRS restricts are split into two categories:
+# basic (always forbidden) and extended (may be forbidden). All header names
+# should be lowercase and enclosed by /slashes/ as delimiters.
 #
-# Note: Accept-Charset is a deprecated header that should not be used by clients and
-# ignored by servers. It can be used for a response WAF bypass, by asking for a charset
-# that the WAF cannot decode.
-# Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Charset
+# [ Basic ]
+# Deprecated headers and/or headers with known security risks: always forbidden.
+# Default: /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/
 #
-# Note: Content-Encoding is used to list any encodings that have been applied to the
-# original payload. It is only used for compression, which isn't supported by CRS by
-# default since it blocks newlines and null bytes inside the request body. Most
-# compression algorithms require at least null bytes per RFC. Blocking it shouldn't
-# break anything and increases security since ModSecurity is incapable of properly
-# scanning compressed request bodies.
+# /content-encoding/
+#   Used to list any encodings that have been applied to the original payload.
+#   Only used for compression, which isn't supported by CRS by default since CRS
+#   blocks newlines and null bytes inside the request body. Most compression
+#   algorithms require at least null bytes per RFC. Blocking Content-Encoding
+#   shouldn't break anything and increases security since WAF engines, including
+#   ModSecurity, are typically incapable of properly scanning compressed request
+#   bodies.
 #
-# Note: Blocking Proxy header prevents 'httpoxy' vulnerability: https://httpoxy.org
+# /proxy/
+#   Blocking this prevents the 'httpoxy' vulnerability: https://httpoxy.org
 #
-# Note: Blocking the x-http-method-override,x-http-method and x-method-override headers
-# prevents attacks as described here: https://www.sidechannel.blog/en/http-method-override-what-it-is-and-how-a-pentester-can-use-it
+# /lock-token/
+#
+# /content-range/
+#
+# /if/
+#
+# /x-http-method-override/
+# /x-http-method/
+# /x-method-override/
+#   Blocking these headers prevents method override attacks, as described here:
+#   https://www.sidechannel.blog/en/http-method-override-what-it-is-and-how-a-pentester-can-use-it
 #
 # Uncomment this rule to change the default.
 #SecAction \
@@ -536,6 +548,29 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #  pass,\
 #  t:none,\
 #  setvar:'tx.restricted_headers=/accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/'"
+#
+# [ Extended ]
+# Deprecated headers still in use (so false positives are possible), possible
+# security risks: forbidden at a higher paranoia level.
+# Default: /accept-charset/
+#
+# /accept-charset/
+#   Deprecated header that should not be used by clients and should be ignored
+#   by servers. Can be used for a response WAF bypass by asking for a charset
+#   that the WAF cannot decode. Considered to be a good indicator of suspicious
+#   behavior but produces too many false positives to be forbidden by default.
+#   References:
+#   https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Charset
+#   https://github.com/coreruleset/coreruleset/issues/3140
+#
+# Uncomment this rule to change the default.
+#SecAction \
+# "id:900260,\
+#  phase:1,\
+#  nolog,\
+#  pass,\
+#  t:none,\
+#  setvar:'tx.restricted_headers=/accept-charset/'"
 
 # Content-Types charsets that a client is allowed to send in a request.
 # The content-types are enclosed by |pipes| as delimiters to guarantee exact matches.

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -212,14 +212,23 @@ SecRule &TX:restricted_extensions "@eq 0" \
     ver:'OWASP_CRS/4.0.0-rc1',\
     setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .rdb/ .resources/ .resx/ .sql/ .swp/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'"
 
-# Default HTTP policy: restricted_headers (rule 900250 in crs-setup.conf)
-SecRule &TX:restricted_headers "@eq 0" \
+# Default HTTP policy: restricted_headers_basic (rule 900250 in crs-setup.conf)
+SecRule &TX:restricted_headers_basic "@eq 0" \
     "id:901165,\
     phase:1,\
     pass,\
     nolog,\
     ver:'OWASP_CRS/4.0.0-rc1',\
-    setvar:'tx.restricted_headers=/accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/'"
+    setvar:'tx.restricted_headers_basic=/content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/'"
+
+# Default HTTP policy: restricted_headers_extended (rule 900255 in crs-setup.conf)
+SecRule &TX:restricted_headers_extended "@eq 0" \
+    "id:901171,\
+    phase:1,\
+    pass,\
+    nolog,\
+    ver:'OWASP_CRS/4.0.0-rc1',\
+    setvar:'tx.restricted_headers_extended=/accept-charset/'"
 
 # Default enforcing of body processor URLENCODED (rule 900010 in crs-setup.conf)
 SecRule &TX:enforce_bodyproc_urlencoded "@eq 0" \

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1114,9 +1114,9 @@ SecRule REQUEST_FILENAME "@rx \.[^.~]+~(?:/.*|)$" \
 #
 # -=[ Rule Logic ]=-
 # The use of certain headers is restricted. They are listed in two variables:
-# - TX.restricted_headers_basic: known security risks, always forbidden (rule
+# - TX.restricted_headers_basic: Known security risks, always forbidden (rule
 #                                920450)
-# - TX.restricted_headers_extended: possible false positives, possible security 
+# - TX.restricted_headers_extended: Possible false positives, possible security 
 #                                   risks, may be forbidden (rule 920451)
 #
 # The headers are transformed into lowercase before the match. In order to make

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1126,8 +1126,8 @@ SecRule REQUEST_FILENAME "@rx \.[^.~]+~(?:/.*|)$" \
 # /content-range/ header, for example.
 #
 # This is a chained rule, where the first rule fills a set of variables of the
-# form TX.header_name_<HEADER_NAME>. The second rule is then executed for all
-# variables of the form TX.header_name_<HEADER_NAME>.
+# form TX.header_name_<RULE_ID>_<HEADER_NAME>. The second rule is then executed for all
+# variables of the form TX.header_name_<RULE_ID>_<HEADER_NAME>.
 #
 # As a consequence of the construction of the rule, the alert message and the
 # alert data will not display the original header name Content-Range, but
@@ -1161,9 +1161,9 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
     tag:'PCI/12.1',\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    setvar:'tx.header_name_%{tx.0}=/%{tx.0}/',\
+    setvar:'tx.header_name_920450_%{tx.0}=/%{tx.0}/',\
     chain"
-    SecRule TX:/^header_name_/ "@within %{tx.restricted_headers_basic}" \
+    SecRule TX:/^header_name_920450_/ "@within %{tx.restricted_headers_basic}" \
         "setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #
@@ -1485,9 +1485,9 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
     tag:'PCI/12.1',\
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
-    setvar:'tx.header_name_%{tx.0}=/%{tx.0}/',\
+    setvar:'tx.header_name_920451_%{tx.0}=/%{tx.0}/',\
     chain"
-    SecRule TX:/^header_name_/ "@within %{tx.restricted_headers_extended}" \
+    SecRule TX:/^header_name_920451_/ "@within %{tx.restricted_headers_extended}" \
         "setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1126,8 +1126,8 @@ SecRule REQUEST_FILENAME "@rx \.[^.~]+~(?:/.*|)$" \
 # /content-range/ header, for example.
 #
 # This is a chained rule, where the first rule fills a set of variables of the
-# form TX.header_name_<RULE_ID>_<HEADER_NAME>. The second rule is then executed for all
-# variables of the form TX.header_name_<RULE_ID>_<HEADER_NAME>.
+# form TX.header_name_<RULE_ID>_<HEADER_NAME>. The second rule is then executed
+# for all variables of the form TX.header_name_<RULE_ID>_<HEADER_NAME>.
 #
 # As a consequence of the construction of the rule, the alert message and the
 # alert data will not display the original header name Content-Range, but

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -681,7 +681,7 @@ SecRule REQUEST_HEADERS:User-Agent "@rx ^$" \
 #
 # Missing Content-Type Header with Request Body
 #
-# -=[ Rule Logic]=-
+# -=[ Rule Logic ]=-
 # This rule will first check to see if the value of the Content-Length header is
 # non-equal to 0. The chained rule is then checking the existence of the
 # Content-Type header. The RFCs do not state there must be a
@@ -1113,14 +1113,17 @@ SecRule REQUEST_FILENAME "@rx \.[^.~]+~(?:/.*|)$" \
 # Restricted HTTP headers
 #
 # -=[ Rule Logic ]=-
-# The use of certain headers is restricted. They are listed in the variable
-# TX.restricted_headers.
+# The use of certain headers is restricted. They are listed in two variables:
+# - TX.restricted_headers_basic: known security risks, always forbidden (rule
+#                                920450)
+# - TX.restricted_headers_extended: possible false positives, possible security 
+#                                   risks, may be forbidden (rule 920451)
 #
-# The headers are transformed into lowercase before the match.  In order to
-# make sure that only complete header names are matching, the names in
-# TX.restricted_headers are wrapped in slashes. This guarantees that the
-# header Range (-> /range/) is not matching the restricted header
-# /content-range/ for example.
+# The headers are transformed into lowercase before the match. In order to make
+# sure that only complete header names match, the names in the
+# TX.restricted_headers_* variables are wrapped in slashes. This guarantees that
+# the Range header (which becomes /range/) will not match the restricted
+# /content-range/ header, for example.
 #
 # This is a chained rule, where the first rule fills a set of variables of the
 # form TX.header_name_<HEADER_NAME>. The second rule is then executed for all
@@ -1130,9 +1133,15 @@ SecRule REQUEST_FILENAME "@rx \.[^.~]+~(?:/.*|)$" \
 # alert data will not display the original header name Content-Range, but
 # /content-range/ instead.
 #
+# This rule has a stricter sibling, 920451, which matches against the variable
+# TX.restricted_headers_extended. It handles deprecated headers that are still
+# in use (so false positives are possible, hence unsuitable for blocking in a
+# default paranoia level 1 installation) and headers with possible security
+# risks.
 #
 # -=[ References ]=-
 # https://access.redhat.com/security/vulnerabilities/httpoxy (Header Proxy)
+# https://www.sidechannel.blog/en/http-method-override-what-it-is-and-how-a-pentester-can-use-it
 #
 SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
     "id:920450,\
@@ -1154,8 +1163,9 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
     severity:'CRITICAL',\
     setvar:'tx.header_name_%{tx.0}=/%{tx.0}/',\
     chain"
-    SecRule TX:/^header_name_/ "@within %{tx.restricted_headers}" \
+    SecRule TX:/^header_name_/ "@within %{tx.restricted_headers_basic}" \
         "setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
 #
 # Rule against CVE-2022-21907
 # This rule blocks Accept-Encoding headers longer than 50 characters.
@@ -1452,6 +1462,33 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
     SecRule &REQUEST_HEADERS:Content-Type "@eq 0" \
         "t:none,\
         setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+
+
+#
+# PL2: This is a stricter sibling of 920450.
+#
+SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
+    "id:920451,\
+    phase:1,\
+    block,\
+    capture,\
+    t:none,t:lowercase,\
+    msg:'HTTP header is restricted by policy (%{MATCHED_VAR})',\
+    logdata:'Restricted header detected: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    tag:'paranoia-level/2',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/210/272',\
+    tag:'PCI/12.1',\
+    ver:'OWASP_CRS/4.0.0-rc1',\
+    severity:'CRITICAL',\
+    setvar:'tx.header_name_%{tx.0}=/%{tx.0}/',\
+    chain"
+    SecRule TX:/^header_name_/ "@within %{tx.restricted_headers_extended}" \
+        "setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:920015,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920450.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920450.yaml
@@ -109,20 +109,6 @@ tests:
               User-Agent: "OWASP CRS test agent"
               Host: "localhost"
               Accept: text/html
-              Accept-Charset: UTF-8
-          output:
-            log_contains: "id \"920450\""
-  - test_title: 920450-8
-    stages:
-      - stage:
-          input:
-            dest_addr: "127.0.0.1"
-            port: 80
-            uri: "/"
-            headers:
-              User-Agent: "OWASP CRS test agent"
-              Host: "localhost"
-              Accept: text/html
               Content-Encoding: deflate
           output:
             log_contains: "id \"920450\""

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920451.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920451.yaml
@@ -9,29 +9,29 @@ tests:
     desc: "Send an Accept-Charset header, which should be blocked"
     stages:
       - stage:
-        input:
-          dest_addr: "127.0.0.1"
-          port: 80
-          uri: "/"
-          headers:
-            User-Agent: "OWASP CRS test agent"
-            Host: localhost
-            Accept: text/html
-            Accept-Charset: UTF-8
-        output:
-          log_contains: id "920450"
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            uri: "/"
+            headers:
+              User-Agent: "OWASP CRS test agent"
+              Host: localhost
+              Accept: text/html
+              Accept-Charset: UTF-8
+          output:
+            log_contains: id "920450"
   - test_title: 920451-2
     desc: "Send a Content-Range header, which should be blocked but by this rule's sibling rule, not by this rule"
     stages:
       - stage:
-        input:
-          dest_addr: "127.0.0.1"
-          port: 80
-          uri: "/"
-          headers:
-            User-Agent: "OWASP CRS test agent"
-            Host: localhost
-            Accept: text/html
-            Content-Range: bytes 4096-8192/8192
-        output:
-          no_log_contains: id "920450"
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            uri: "/"
+            headers:
+              User-Agent: "OWASP CRS test agent"
+              Host: localhost
+              Accept: text/html
+              Content-Range: bytes 4096-8192/8192
+          output:
+            no_log_contains: id "920450"

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920451.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920451.yaml
@@ -19,7 +19,7 @@ tests:
               Accept: text/html
               Accept-Charset: UTF-8
           output:
-            log_contains: id "920450"
+            log_contains: id "920451"
   - test_title: 920451-2
     desc: "Send a Content-Range header, which should be blocked but by this rule's sibling rule, not by this rule"
     stages:
@@ -34,4 +34,4 @@ tests:
               Accept: text/html
               Content-Range: bytes 4096-8192/8192
           output:
-            no_log_contains: id "920450"
+            no_log_contains: id "920451"

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920451.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920451.yaml
@@ -1,0 +1,37 @@
+---
+meta:
+  author: "Andrew Howe"
+  enabled: true
+  name: "920451.yaml"
+  description: "Tests to trigger and not trigger rule 920451"
+tests:
+  - test_title: 920451-1
+    desc: "Send an Accept-Charset header, which should be blocked"
+    stages:
+      - stage:
+        input:
+          dest_addr: "127.0.0.1"
+          port: 80
+          uri: "/"
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: localhost
+            Accept: text/html
+            Accept-Charset: UTF-8
+        output:
+          log_contains: id "920450"
+  - test_title: 920451-2
+    desc: "Send a Content-Range header, which should be blocked but by this rule's sibling rule, not by this rule"
+    stages:
+      - stage:
+        input:
+          dest_addr: "127.0.0.1"
+          port: 80
+          uri: "/"
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: localhost
+            Accept: text/html
+            Content-Range: bytes 4096-8192/8192
+        output:
+          no_log_contains: id "920450"


### PR DESCRIPTION
PR reworks the "restricted headers" mechanism so that there are two different lists (and sets of rules)

- Basic
- Extended

This allows for difficult headers like "Accept-Charest" to be handled: block at a higher PL, but not by default / at PL 1 due to a handful of potential false positives.

*PR relates to issue #3148*

## TODO

- [x] Add and rework detection rules in `REQUEST-920-PROTOCOL-ENFORCEMENT.conf`
- [x] Rework existing tests (Accept-Charset tests to be moved to test against new rule)
- [x] Add new tests, if appropriate