### PR TITLE
fix: php-errors FP

### DIFF
--- a/rules/php-errors-pl2.data
+++ b/rules/php-errors-pl2.data
@@ -2,3 +2,4 @@
 
 Invalid date
 The function
+Static function

--- a/rules/php-errors-pl2.data
+++ b/rules/php-errors-pl2.data
@@ -1,5 +1,5 @@
 # For more information, see comments at the beginning of the php-errors.data file.
 
 Invalid date
-The function
 Static function
+The function

--- a/rules/php-errors.data
+++ b/rules/php-errors.data
@@ -1913,7 +1913,6 @@ Session callback must have a return value of type bool,
 # Size:
 SoapHeader::__construct(): "
 SoapServer::addFunction(): Function "
-Static function
 Struct/union can't contain an instance of itself at line
 Stuck count for pid
 Stuck count for thread id


### PR DESCRIPTION
`[Sat Mar 11 15:45:19.636843 2023] [:error] [pid 292128] [client 103.80.153.172:51798] [client 103.80.153.172]`
`ModSecurity: Warning. Matched phrase "Static function" at RESPONSE_BODY. [file "/etc/modsecurity/`
`coreruleset/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf"] [line "44"] [id "953100"] [msg "PHP Information Leakage"]` `[data "Matched Data: Static function found within RESPONSE_BODY"] [severity "ERROR"] [ver`
`"OWASP_CRS/4.0.0-rc1"] [tag "application-multi"] [tag "language-php"] [tag "platform-multi"] `
`[tag "attack-disclosure"] [tag "paranoia-level/1"] [tag "OWASP_CRS"] [tag "capec/1000/118/116"]`
`[tag "PCI/6.5.6"] [hostname "blog.jitendrapatro.me"] [uri "/wp-admin/post.php"] [unique_id`
`ZAxUt5um5UuN8ldYD8BbMwAAAAE"], referer: https://blog.jitendrapatro.me/wp-admin/edit.php`





@azurit We need to come up with a better solution for this. I write a lot of technical articles in my blog some of which deal with programming and I've to write "code" as example in them. Now, I can't edit the blog post in my wp-admin backend.