### PR TITLE
fix(config): format crs-setup.conf.example

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -175,12 +175,12 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # Uncomment this rule to change the default:
 #
 #SecAction \
-#  "id:900000,\
-#   phase:1,\
-#   nolog,\
-#   pass,\
-#   t:none,\
-#   setvar:tx.blocking_paranoia_level=1"
+#    "id:900000,\
+#    phase:1,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    setvar:tx.blocking_paranoia_level=1"
 
 
 # It is possible to execute rules from a higher paranoia level but not include
@@ -201,12 +201,12 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # tx.blocking_paranoia_level to said level.
 #
 #SecAction \
-#  "id:900001,\
-#   phase:1,\
-#   nolog,\
-#   pass,\
-#   t:none,\
-#   setvar:tx.detection_paranoia_level=1"
+#    "id:900001,\
+#    phase:1,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    setvar:tx.detection_paranoia_level=1"
 
 
 #
@@ -225,12 +225,12 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # Uncomment this rule to change the default:
 #
 #SecAction \
-#  "id:900010,\
-#   phase:1,\
-#   nolog,\
-#   pass,\
-#   t:none,\
-#   setvar:tx.enforce_bodyproc_urlencoded=1"
+#    "id:900010,\
+#    phase:1,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    setvar:tx.enforce_bodyproc_urlencoded=1"
 
 
 #
@@ -258,15 +258,15 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # that all configuration variables are set before the CRS rules are processed.)
 #
 #SecAction \
-# "id:900100,\
-#  phase:1,\
-#  nolog,\
-#  pass,\
-#  t:none,\
-#  setvar:tx.critical_anomaly_score=5,\
-#  setvar:tx.error_anomaly_score=4,\
-#  setvar:tx.warning_anomaly_score=3,\
-#  setvar:tx.notice_anomaly_score=2"
+#    "id:900100,\
+#    phase:1,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    setvar:tx.critical_anomaly_score=5,\
+#    setvar:tx.error_anomaly_score=4,\
+#    setvar:tx.warning_anomaly_score=3,\
+#    setvar:tx.notice_anomaly_score=2"
 
 
 #
@@ -310,13 +310,13 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # Uncomment this rule to change the defaults:
 #
 #SecAction \
-# "id:900110,\
-#  phase:1,\
-#  nolog,\
-#  pass,\
-#  t:none,\
-#  setvar:tx.inbound_anomaly_score_threshold=5,\
-#  setvar:tx.outbound_anomaly_score_threshold=4"
+#    "id:900110,\
+#    phase:1,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    setvar:tx.inbound_anomaly_score_threshold=5,\
+#    setvar:tx.outbound_anomaly_score_threshold=4"
 
 
 #
@@ -369,12 +369,12 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # the request/access log. This applies to Nginx, for example.
 #
 #SecAction \
-# "id:900115,\
-#  phase:1,\
-#  nolog,\
-#  pass,\
-#  t:none,\
-#  setvar:tx.reporting_level=4"
+#    "id:900115,\
+#    phase:1,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    setvar:tx.reporting_level=4"
 
 
 #
@@ -399,12 +399,12 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # disabled early blocking again at some point in the future, then new alerts
 # from phase 2 might pop up.
 #SecAction \
-#  "id:900120,\
-#  phase:1,\
-#  nolog,\
-#  pass,\
-#  t:none,\
-#  setvar:tx.early_blocking=1"
+#    "id:900120,\
+#    phase:1,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    setvar:tx.early_blocking=1"
 
 
 #
@@ -425,12 +425,12 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #          MERGE MKACTIVITY MKCOL MOVE PROPFIND PROPPATCH PUT UNLOCK
 # Uncomment this rule to change the default.
 #SecAction \
-# "id:900200,\
-#  phase:1,\
-#  nolog,\
-#  pass,\
-#  t:none,\
-#  setvar:'tx.allowed_methods=GET HEAD POST OPTIONS'"
+#    "id:900200,\
+#    phase:1,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    setvar:'tx.allowed_methods=GET HEAD POST OPTIONS'"
 
 # Content-Types that a client is allowed to send in a request.
 # Default: |application/x-www-form-urlencoded| |multipart/form-data| |multipart/related|
@@ -451,25 +451,25 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #
 # To prevent blocking request with not allowed content-type by default, you can create an exclusion
 # rule that removes rule 920420. For example:
-# SecRule REQUEST_HEADERS:Content-Type "@rx ^text/plain" \
-#  "id:1234,\
-#  phase:1,\
-#  nolog,\
-#  pass,\
-#  t:none,\
-#  ctl:ruleRemoveById=920420,\
-#  chain"
-#  SecRule REQUEST_URI "@rx ^/foo/bar" "t:none"
+#SecRule REQUEST_HEADERS:Content-Type "@rx ^text/plain" \
+#    "id:1234,\
+#    phase:1,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    ctl:ruleRemoveById=920420,\
+#    chain"
+#    SecRule REQUEST_URI "@rx ^/foo/bar" "t:none"
 #
 # Uncomment this rule to change the default.
 #
 #SecAction \
-# "id:900220,\
-#  phase:1,\
-#  nolog,\
-#  pass,\
-#  t:none,\
-#  setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |multipart/related| |text/xml| |application/xml| |application/soap+xml| |application/json| |application/cloudevents+json| |application/cloudevents-batch+json|'"
+#    "id:900220,\
+#    phase:1,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |multipart/related| |text/xml| |application/xml| |application/soap+xml| |application/json| |application/cloudevents+json| |application/cloudevents-batch+json|'"
 
 # Allowed HTTP versions.
 # Default: HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0
@@ -478,12 +478,12 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # we include both version strings by default.
 # Uncomment this rule to change the default.
 #SecAction \
-# "id:900230,\
-#  phase:1,\
-#  nolog,\
-#  pass,\
-#  t:none,\
-#  setvar:'tx.allowed_http_versions=HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0'"
+#    "id:900230,\
+#    phase:1,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    setvar:'tx.allowed_http_versions=HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0'"
 
 # Forbidden file extensions.
 # Guards against unintended exposure of development/configuration files.
@@ -500,12 +500,12 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #
 # Uncomment this rule to change the default.
 #SecAction \
-# "id:900240,\
-#  phase:1,\
-#  nolog,\
-#  pass,\
-#  t:none,\
-#  setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .rdb/ .resources/ .resx/ .sql/ .swp/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'"
+#    "id:900240,\
+#    phase:1,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .rdb/ .resources/ .resx/ .sql/ .swp/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'"
 
 # Forbidden request headers.
 # Header names should be lowercase, enclosed by /slashes/ as delimiters.
@@ -530,24 +530,24 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #
 # Uncomment this rule to change the default.
 #SecAction \
-# "id:900250,\
-#  phase:1,\
-#  nolog,\
-#  pass,\
-#  t:none,\
-#  setvar:'tx.restricted_headers=/accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/'"
+#    "id:900250,\
+#    phase:1,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    setvar:'tx.restricted_headers=/accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/'"
 
 # Content-Types charsets that a client is allowed to send in a request.
 # The content-types are enclosed by |pipes| as delimiters to guarantee exact matches.
 # Default: |utf-8| |iso-8859-1| |iso-8859-15| |windows-1252|
 # Uncomment this rule to change the default.
 #SecAction \
-# "id:900280,\
-#  phase:1,\
-#  nolog,\
-#  pass,\
-#  t:none,\
-#  setvar:'tx.allowed_request_content_type_charset=|utf-8| |iso-8859-1| |iso-8859-15| |windows-1252|'"
+#    "id:900280,\
+#    phase:1,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    setvar:'tx.allowed_request_content_type_charset=|utf-8| |iso-8859-1| |iso-8859-15| |windows-1252|'"
 
 #
 # -- [[ HTTP Argument/Upload Limits ]] -----------------------------------------
@@ -564,72 +564,72 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # Example: 255
 # Uncomment this rule to set a limit.
 #SecAction \
-# "id:900300,\
-#  phase:1,\
-#  nolog,\
-#  pass,\
-#  t:none,\
-#  setvar:tx.max_num_args=255"
+#    "id:900300,\
+#    phase:1,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    setvar:tx.max_num_args=255"
 
 # Block request if the length of any argument name is too high
 # Default: unlimited
 # Example: 100
 # Uncomment this rule to set a limit.
 #SecAction \
-# "id:900310,\
-#  phase:1,\
-#  nolog,\
-#  pass,\
-#  t:none,\
-#  setvar:tx.arg_name_length=100"
+#    "id:900310,\
+#    phase:1,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    setvar:tx.arg_name_length=100"
 
 # Block request if the length of any argument value is too high
 # Default: unlimited
 # Example: 400
 # Uncomment this rule to set a limit.
 #SecAction \
-# "id:900320,\
-#  phase:1,\
-#  nolog,\
-#  pass,\
-#  t:none,\
-#  setvar:tx.arg_length=400"
+#    "id:900320,\
+#    phase:1,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    setvar:tx.arg_length=400"
 
 # Block request if the total length of all combined arguments is too high
 # Default: unlimited
 # Example: 64000
 # Uncomment this rule to set a limit.
 #SecAction \
-# "id:900330,\
-#  phase:1,\
-#  nolog,\
-#  pass,\
-#  t:none,\
-#  setvar:tx.total_arg_length=64000"
+#    "id:900330,\
+#    phase:1,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    setvar:tx.total_arg_length=64000"
 
 # Block request if the file size of any individual uploaded file is too high
 # Default: unlimited
 # Example: 1048576
 # Uncomment this rule to set a limit.
 #SecAction \
-# "id:900340,\
-#  phase:1,\
-#  nolog,\
-#  pass,\
-#  t:none,\
-#  setvar:tx.max_file_size=1048576"
+#    "id:900340,\
+#    phase:1,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    setvar:tx.max_file_size=1048576"
 
 # Block request if the total size of all combined uploaded files is too high
 # Default: unlimited
 # Example: 1048576
 # Uncomment this rule to set a limit.
 #SecAction \
-# "id:900350,\
-#  phase:1,\
-#  nolog,\
-#  pass,\
-#  t:none,\
-#  setvar:tx.combined_file_sizes=1048576"
+#    "id:900350,\
+#    phase:1,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    setvar:tx.combined_file_sizes=1048576"
 
 
 #
@@ -654,7 +654,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # following directive somewhere after the inclusion of the CRS
 # (E.g., RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf).
 #
-# SecRuleUpdateActionById 901450 "nolog"
+#SecRuleUpdateActionById 901450 "nolog"
 #
 # ATTENTION: If this TX.sampling_percentage is below 100, then some of the
 # requests will bypass the Core Rules completely and you lose the ability to
@@ -662,11 +662,12 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #
 # Uncomment this rule to enable this feature:
 #
-#SecAction "id:900400,\
-#  phase:1,\
-#  pass,\
-#  nolog,\
-#  setvar:tx.sampling_percentage=100"
+#SecAction \
+#    "id:900400,\
+#    phase:1,\
+#    pass,\
+#    nolog,\
+#    setvar:tx.sampling_percentage=100"
 
 
 
@@ -680,12 +681,12 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # Uncomment this rule to use this feature:
 #
 #SecAction \
-# "id:900950,\
-#  phase:1,\
-#  nolog,\
-#  pass,\
-#  t:none,\
-#  setvar:tx.crs_validate_utf8_encoding=1"
+#    "id:900950,\
+#    phase:1,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    setvar:tx.crs_validate_utf8_encoding=1"
 
 
 #


### PR DESCRIPTION
This PR formats `crs-setup.conf.example` file:
* puts the actions in the correct order
* set the correct indentations

This is necessary if we want to process the `crs-setup.conf.example` with all commented `SecRule`'s and `SecAction`'s to fix #3141 without adding an extra rule.

If we don't want to allow these modifications (in this PR), the other possible solution is that we ignore checking of indentations and order of actions in that file.

I prefer this solution (I mean the first one).

The next PR will contain that `rules-check.py` script process `crs-setup.conf.example` without comments in case of `SecRule` and `SecAction` lines (and next ones).