### PR TITLE
fix(feat): strip comments during the parsing of crs-setup.conf.example

### DIFF
--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -690,7 +690,7 @@ if __name__ == "__main__":
         try:
             with open(f, 'r') as inputfile:
                 data = inputfile.read()
-                # modify the content of the file, it it is the "crs-setup.conf.example"
+                # modify the content of the file, if it is the "crs-setup.conf.example"
                 if f.startswith("crs-setup.conf.example"):
                     data = remove_comments(data)
         except:

--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -608,7 +608,7 @@ def remove_comments(data):
 
     """
     _data = []  # new structure by lines
-    lines = [l.strip("\n") for l in data.split("\n")] # split the old content
+    lines = data.split("\n")
     marks = re.compile("^#(| *)(SecRule|SecAction)", re.I) # regex what catches the rules
     state = 0   # hold the state of the parser
     for l in lines:

--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -619,7 +619,7 @@ def remove_comments(data):
         if state == 1 and l.strip() in ["", "#"]:
             state = 0
 
-        # if marker has set, remove the comment
+        # if marker is set, remove the comment
         if state == 1:
             _data.append(re.sub("^#", "", l))
         else:

--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -569,7 +569,7 @@ class Check(object):
                     severity  = None     # severity
                     has_nolog = False    # rule has nolog action
 
-def removecomments(data):
+def remove_comments(data):
     """
     In some special cases, remove the comments from the beginning of the lines.
 
@@ -692,7 +692,7 @@ if __name__ == "__main__":
                 data = inputfile.read()
                 # modify the content of the file, it it is the "crs-setup.conf.example"
                 if f.startswith("crs-setup.conf.example"):
-                    data = removecomments(data)
+                    data = remove_comments(data)
         except:
             errmsg("Can't open file: %s" % f)
             sys.exit(1)
@@ -758,7 +758,7 @@ if __name__ == "__main__":
             with open(f, 'r') as fp:
                 fromlines = fp.readlines()
                 if f.startswith("crs-setup.conf.example"):
-                    fromlines = removecomments("".join(fromlines)).split("\n")
+                    fromlines = remove_comments("".join(fromlines)).split("\n")
                     fromlines = [l + "\n" for l in fromlines]
         except:
             errmsg("  Can't open file for indent check: %s" % (f))

--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -570,6 +570,43 @@ class Check(object):
                     has_nolog = False    # rule has nolog action
 
 def removecomments(data):
+    """
+    In some special cases, remove the comments from the beginning of the lines.
+
+    A special case starts when the line has a "SecRule" or "SecAction" token at
+    the beginning and ends when the line - with or without a comment - is empty.
+
+    Eg.:
+    175	# Uncomment this rule to change the default:
+    176	#
+    177	#SecAction \
+    178	#    "id:900000,\
+    179	#    phase:1,\
+    180	#    pass,\
+    181	#    t:none,\
+    182	#    nolog,\
+    183	#    setvar:tx.blocking_paranoia_level=1"
+    184
+    185
+    186	# It is possible to execute rules from a higher paranoia level but not include
+
+    In this case, the comments from the beginning of lines 177 and 183 are deleted and
+    evaluated as follows:
+
+    175	# Uncomment this rule to change the default:
+    176	#
+    177	SecAction \
+    178	    "id:900000,\
+    179	    phase:1,\
+    180	    pass,\
+    181	    t:none,\
+    182	    nolog,\
+    183	    setvar:tx.blocking_paranoia_level=1"
+    184
+    185
+    186	# It is possible to execute rules from a higher paranoia level but not include
+
+    """
     _data = []  # new structure by lines
     lines = [l.strip("\n") for l in data.split("\n")] # split the old content
     marks = re.compile("^#(| *)(SecRule|SecAction)", re.I) # regex what catches the rules


### PR DESCRIPTION
This PR modifies the `rules-check.py` script that during the parsing of the `crs-setup.conf.example` it removes the comments before `SecRule` and `SecAction` directives. This means it emulates that rules are valid part of CRS, and - for eg. - therefore it does not need to initialize the TX variables.

The next PR will contain the modification which removes the rules [901167](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/rules/REQUEST-901-INITIALIZATION.conf#L223-L231) and [901169](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/rules/REQUEST-901-INITIALIZATION.conf#L233-L240) from [REQUEST-901-INITIALIZATION.conf](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/rules/REQUEST-901-INITIALIZATION.conf), therefore the `tx.enforce_bodyproc_urlencoded` and `tx.crs_validate_utf8_encoding` variables are no longer initialized.