### PR TITLE
fix: apply non-draft state to nightly release forcefully

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,6 +30,8 @@ jobs:
           commit: v4.0/dev
           allowUpdates: true
           prerelease: true
+          draft: false
+          omitDraftDuringUpdate: false
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |
             Nightly releases are snapshots of the development activity on the Core Rule Set project that may include new features and bug fixes scheduled for upcoming releases. These releases are made available to make it easier for users to test their existing configurations against the Core Rule Set code base for potential issues or to experiment with new features, with a chance to provide feedback on ways to improve the changes before being released.


### PR DESCRIPTION
The issue we are having with the nightly release being marked as draft is something that has happened to others: https://github.com/ncipollo/release-action/issues/317.

This PR tries to fix the issue by forcing the `draft` parameter to be always applied when the release is being updated.

Docs: https://github.com/marketplace/actions/create-release