### PR TITLE
Move Base64Decode to the start of the transform 

### DIFF
--- a/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
+++ b/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
@@ -54,7 +54,7 @@ SecRule REQUEST_FILENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIE
     phase:2,\
     block,\
     capture,\
-    t:none,t:urlDecodeUni,t:jsDecode,t:removeWhitespace,t:base64Decode,\
+    t:none,t:base64Decode,t:urlDecodeUni,t:jsDecode,t:removeWhitespace,\
     msg:'Node.js Injection Attack 1/2',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
@@ -77,7 +77,7 @@ SecRule REQUEST_FILENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIE
     phase:2,\
     block,\
     capture,\
-    t:none,t:urlDecodeUni,t:base64Decode,\
+    t:none,t:base64Decode,t:urlDecodeUni,\
     msg:'Node.js Injection Attack 2/2',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
@@ -147,7 +147,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     phase:2,\
     block,\
     capture,\
-    t:none,t:urlDecodeUni,t:base64Decode,\
+    t:none,t:base64Decode,t:urlDecodeUni,\
     msg:'JavaScript Prototype Pollution',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
@@ -210,7 +210,7 @@ SecRule REQUEST_FILENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIE
     phase:2,\
     block,\
     capture,\
-    t:none,t:urlDecodeUni,t:base64Decode,t:replaceComments,\
+    t:none,t:base64Decode,t:urlDecodeUni,t:replaceComments,\
     msg:'Node.js DoS attack',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
@@ -318,7 +318,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     phase:2,\
     block,\
     capture,\
-    t:none,t:urlDecodeUni,t:base64Decode,\
+    t:none,t:base64Decode,t:urlDecodeUni,\
     msg:'JavaScript Prototype Pollution',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\


### PR DESCRIPTION
Moves base64Decode to the start of the transformation pipeline in  REQUEST-934-APPLICATION-ATTACK-GENERIC.conf

Issue described in: https://github.com/coreruleset/coreruleset/issues/3182