### PR TITLE
fix(style): Format malformed rules

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -478,7 +478,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    nolog,\
 #    ctl:ruleRemoveById=920420,\
 #    chain"
-#    SecRule REQUEST_URI "@rx ^/foo/bar" "t:none"
+#    SecRule REQUEST_URI "@rx ^/foo/bar" \
+#        "t:none"
 #
 # Uncomment this rule to change the default.
 #

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -941,7 +941,8 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     setvar:'tx.932200_matched_var_name=%{matched_var_name}',\
     chain"
     SecRule MATCHED_VAR "@rx /" \
-        "t:none,t:urlDecodeUni,chain"
+        "t:none,t:urlDecodeUni,\
+        chain"
         SecRule MATCHED_VAR "@rx \s" \
             "t:none,t:urlDecodeUni,\
             setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -940,8 +940,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     severity:'CRITICAL',\
     setvar:'tx.932200_matched_var_name=%{matched_var_name}',\
     chain"
-    SecRule MATCHED_VAR "@rx /" "t:none,t:urlDecodeUni,chain"
-        SecRule MATCHED_VAR "@rx \s" "t:none,t:urlDecodeUni,\
+    SecRule MATCHED_VAR "@rx /" \
+        "t:none,t:urlDecodeUni,chain"
+        SecRule MATCHED_VAR "@rx \s" \
+            "t:none,t:urlDecodeUni,\
             setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
             setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1359,7 +1359,8 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     chain"
-    SecRule MATCHED_VARS "!@rx ^ey[A-Z-a-z0-9-_]+[.]ey[A-Z-a-z0-9-_]+[.][A-Z-a-z0-9-_]+$" "t:none,\
+    SecRule MATCHED_VARS "!@rx ^ey[A-Z-a-z0-9-_]+[.]ey[A-Z-a-z0-9-_]+[.][A-Z-a-z0-9-_]+$" \
+        "t:none,\
         setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
         setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 

--- a/rules/REQUEST-949-BLOCKING-EVALUATION.conf
+++ b/rules/REQUEST-949-BLOCKING-EVALUATION.conf
@@ -79,13 +79,15 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
 
 # at start of phase 2, we reset the aggregate scores to 0 to prevent duplicate counting of per-PL scores
 # this is necessary because the per-PL scores are counted across phases
-SecAction "id:949059,\
+SecAction \
+    "id:949059,\
     phase:2,\
     pass,\
     t:none,\
     nolog,\
     setvar:'tx.blocking_inbound_anomaly_score=0'"
-SecAction "id:949159,\
+SecAction \
+    "id:949159,\
     phase:2,\
     pass,\
     t:none,\

--- a/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
+++ b/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
@@ -90,13 +90,15 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
 
 # at start of phase 4, we reset the aggregate scores to 0 to prevent duplicate counting of per-PL scores
 # this is necessary because the per-PL scores are counted across phases
-SecAction "id:959059,\
+SecAction \
+    "id:959059,\
     phase:4,\
     pass,\
     t:none,\
     nolog,\
     setvar:'tx.blocking_outbound_anomaly_score=0'"
-SecAction "id:959159,\
+SecAction \
+    "id:959159,\
     phase:4,\
     pass,\
     t:none,\


### PR DESCRIPTION
This patch just aligns some malformed rules.

Question: what about  [these](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/rules/RESPONSE-980-CORRELATION.conf#L43-L69) rules? These are also malformed, and differs from our [policy](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/CONTRIBUTING.md#general-formatting-guidelines-for-rules-contributions).