### PR TITLE
chore: adds Matteo Pace to list of Developers

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,7 @@
 - [Karel Knibbe](https://github.com/karelorigin)
 - [Max Leske](https://github.com/theseion)
 - [Andrea Menin](https://github.com/theMiddleBlue)
+- [Matteo Pace](https://github.com/M4tteoP)
 - [Chaim Sanders](https://github.com/csanders-git)
 - [Federico G. Schwindt](https://github.com/fgsch)
 - [Manuel Leos Rivas](https://github.com/spartantri)


### PR DESCRIPTION
Follows https://github.com/coreruleset/coreruleset/issues/3204 invitation to join the project as a developer. So glad to accept the invitation and open this PR. 