### PR TITLE
added php Fileinfo functions

### DIFF
--- a/rules/php-function-names-933151.data
+++ b/rules/php-function-names-933151.data
@@ -193,6 +193,8 @@ filter_list
 filter_var
 filter_var_array
 finfo_close
+finfo_file
+finfo_set_flags
 fnmatch
 foreach
 forward_static_call


### PR DESCRIPTION
The PHP Fileinfo extension is enabled by default. Added `finfo_file` and `finfo_set_flags` PHP Fileinfo extensions.

- [finfo_file](https://www.php.net/manual/en/function.finfo-file.php) - Returns information about a file
- [finfo_set_flags](https://www.php.net/manual/en/function.finfo-set-flags.php) - Sets libmagic configuration options