### PR TITLE
chore (3230): Review doc hyperlinks

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_false-positive.md
+++ b/.github/ISSUE_TEMPLATE/01_false-positive.md
@@ -13,7 +13,7 @@ our project:
 
 * https://security.stackexchange.com/questions/tagged/owasp-crs
 * https://twitter.com/coreruleset
-* https://groups.google.com/a/owasp.org/forum/#!forum/modsecurity-core-rule-set-project
+* https://groups.google.com/a/owasp.org/g/modsecurity-core-rule-set-project
 * https://owasp.org/slack/invite (-> Channel #coreruleset)
 -->
 

--- a/.github/ISSUE_TEMPLATE/02_false-negative.md
+++ b/.github/ISSUE_TEMPLATE/02_false-negative.md
@@ -13,7 +13,7 @@ our project:
 
 * https://security.stackexchange.com/questions/tagged/owasp-crs
 * https://twitter.com/coreruleset
-* https://groups.google.com/a/owasp.org/forum/#!forum/modsecurity-core-rule-set-project
+* https://groups.google.com/a/owasp.org/g/modsecurity-core-rule-set-project
 * https://owasp.org/slack/invite (-> Channel #coreruleset)
 -->
 

--- a/.github/ISSUE_TEMPLATE/04_feature.md
+++ b/.github/ISSUE_TEMPLATE/04_feature.md
@@ -10,7 +10,7 @@ For help and support please go here:
 - https://security.stackexchange.com/questions/tagged/owasp-crs
 
 Ask general usage questions and participate in discussions on the CRS:
-- https://groups.google.com/a/owasp.org/forum/#!forum/modsecurity-core-rule-set-project
+- https://groups.google.com/a/owasp.org/g/modsecurity-core-rule-set-project
 -->
 ### Motivation
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url:  https://security.stackexchange.com/questions/tagged/owasp-crs
     about: For help and support please go here.
   - name: OWASP Core Rule Set mailing list
-    url:  https://groups.google.com/a/owasp.org/forum/#!forum/modsecurity-core-rule-set-project
+    url:  https://groups.google.com/a/owasp.org/g/modsecurity-core-rule-set-project
     about: Ask general usage questions and participate in discussions on the CRS.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ## Report Bugs/Issues to GitHub Issues Tracker or the mailinglist
 * https://github.com/coreruleset/coreruleset/issues
   or the CRS Google Group at
-* https://groups.google.com/a/owasp.org/forum/#!forum/modsecurity-core-rule-set-project
+* https://groups.google.com/a/owasp.org/g/modsecurity-core-rule-set-project
 
 ## Version 4.0.0 - 2022-06-??
 
@@ -974,7 +974,7 @@ Improvements:
 * Added new Application Defect checks (55 app defect file) from Watcher tool (Check Charset)
   http://websecuritytool.codeplex.com/wikipage?title=Checks#charset
 * Added new AppSensor rules to experimental_dir
-  https://www.owasp.org/index.php/AppSensor_DetectionPoints
+  https://owasp.org/www-project-appsensor/
 * Added new Generic Malicious JS checks in outbound content
 * Added experimental IP Forensic rules to gather Client hostname/whois info
   http://blog.spiderlabs.com/2010/11/detecting-malice-with-modsecurity-ip-forensics.html

--- a/KNOWN_BUGS.md
+++ b/KNOWN_BUGS.md
@@ -4,7 +4,7 @@
 
 * https://github.com/coreruleset/coreruleset/issues
 or the CRS Google Group at
-* https://groups.google.com/a/owasp.org/forum/#!forum/modsecurity-core-rule-set-project
+* https://groups.google.com/a/owasp.org/g/modsecurity-core-rule-set-project
 
 * There are still false positives for standard web applications in
   the default install (paranoia level 1). Please report these when

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We strive to make the OWASP ModSecurity CRS accessible to a wide audience of beg
 
 [Create an issue on GitHub](https://github.com/coreruleset/coreruleset/issues) to report a false positive or false negative (evasion). Please include your installed version and the relevant portions of your ModSecurity audit log. We will try and address your issue and potentially ask for additional information to reproduce your problem. Please also note that stale issues will be flagged and closed after 120 days. You can search for stale issues with the following [search query](https://github.com/coreruleset/coreruleset/issues?q=label%3A%22Stale+issue%22).
 
-[Sign up for our Google Group](https://groups.google.com/a/owasp.org/forum/#!forum/modsecurity-core-rule-set-project) to ask general usage questions and participate in discussions on the CRS. Also [here](https://lists.owasp.org/pipermail/owasp-modsecurity-core-rule-set/index) you can find the archives for the previous mailing list.
+[Sign up for our Google Group](https://groups.google.com/a/owasp.org/g/modsecurity-core-rule-set-project) to ask general usage questions and participate in discussions on the CRS. Also [here](https://lists.owasp.org/pipermail/owasp-modsecurity-core-rule-set/index) you can find the archives for the previous mailing list.
 
 [Join the #coreruleset channel on OWASP Slack](https://owasp.slack.com/) to chat about the CRS. ([Click here](https://owasp.org/slack/invite) to get an invitation if you are not yet registered on the OWASP slack. It's open to non-members too.)
 

--- a/regex-assembly/932370.ra
+++ b/regex-assembly/932370.ra
@@ -4,7 +4,7 @@
 ##! Word list for rule 932370 (RCE Windows command injection part 1/2)
 ##!
 ##! The list comes from the project LOLBAS. You can get it using the following one-liner:
-##! `curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/LOLBAS-Project/LOLBAS/git/trees/master\?recursive\=1 | jq -r '.tree[].path ' | grep ^yml/ | cut -f3 -d/ | cut -f1 -d. | tr 'A-Z' 'a-z' | sort | uniq`
+##! `curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/LOLBAS-Project/LOLBAS/git/trees/master | jq -r '.tree[].path ' | grep ^yml/ | cut -f3 -d/ | cut -f1 -d. | tr 'A-Z' 'a-z' | sort | uniq`
 ##! To prevent some FP for a command, you can require command parameters
 ##! after a command. Only do this if the command regularly causes FP and if
 ##! allowing the bare command (without parameters) is not too dangerous.

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -24,7 +24,7 @@
 #
 # - Producer: ModSecurity for Apache/2.9.1 (http://www.modsecurity.org/); OWASP_CRS/3.1.0.
 #
-# Ref: https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual#wiki-SecComponentSignature
+# Ref: https://github.com/SpiderLabs/ModSecurity/wiki/#SecComponentSignature
 #
 SecComponentSignature "OWASP_CRS/4.0.0-rc1"
 

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -94,7 +94,6 @@ SecRule REQUEST_LINE "!@rx (?i)^(?:get /[^#\?]*(?:\?[^\s\v#]*)?(?:#[^\s\v]*)?|(?
 #    Disallow ['\";=]
 #
 # -=[ References ]=-
-# https://www.owasp.org/index.php/ModSecurity_CRS_RuleID-96000
 # http://www.ietf.org/rfc/rfc2183.txt
 #
 # This rule used to use negative look-behind.

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -14,7 +14,7 @@
 #
 # The purpose of this rules file is to enforce HTTP RFC requirements that state how
 # the client is supposed to interact with the server.
-# https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html
+# https://www.rfc-editor.org/rfc/rfc9110.html
 
 
 
@@ -47,7 +47,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:920012,phase:2,pass,nolog,skipAf
 #   crs-toolchain regex update 920100
 #
 # -=[ References ]=-
-# https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.2.1
+# https://www.rfc-editor.org/rfc/rfc9110.html
 # http://capec.mitre.org/data/definitions/272.html
 #
 SecRule REQUEST_LINE "!@rx (?i)^(?:get /[^#\?]*(?:\?[^\s\v#]*)?(?:#[^\s\v]*)?|(?:connect (?:(?:[0-9]{1,3}\.){3}[0-9]{1,3}\.?(?::[0-9]+)?|[\--9A-Z_a-z]+:[0-9]+)|options \*|[a-z]{3,10}[\s\v]+(?:[0-9A-Z_a-z]{3,7}?://[\--9A-Z_a-z]*(?::[0-9]+)?)?/[^#\?]*(?:\?[^\s\v#]*)?(?:#[^\s\v]*)?)[\s\v]+[\.-9A-Z_a-z]+)$" \
@@ -132,7 +132,7 @@ SecRule FILES|FILES_NAMES "!@rx (?i)^(?:&(?:(?:[acegiln-or-suz]acut|[aeiou]grav|
 # is NOT all digits, then it will match.
 #
 # -=[ References ]=-
-# https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13
+# https://www.rfc-editor.org/rfc/rfc9110.html
 #
 SecRule REQUEST_HEADERS:Content-Length "!@rx ^\d+$" \
     "id:920160,\
@@ -166,7 +166,7 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^\d+$" \
 # empty, then it will match.
 #
 # -=[ References ]=-
-# https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.3
+https://www.rfc-editor.org/rfc/rfc9110.html
 #
 SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
     "id:920170,\
@@ -293,7 +293,7 @@ SecRule &REQUEST_HEADERS:Transfer-Encoding "!@eq 0" \
 # when the first value is greater than the second.
 #
 # -=[ References ]=-
-# https://tools.ietf.org/html/rfc7233
+# https://datatracker.ietf.org/doc/html/rfc7233
 # https://seclists.org/fulldisclosure/2011/Aug/175
 #
 SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx (\d+)-(\d+)" \
@@ -327,8 +327,7 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx (\d+)-(\d+)" \
 # keep-alive and close options.
 #
 # -=[ References ]=-
-# http://www.bad-behavior.ioerror.us/about/
-# https://tools.ietf.org/html/rfc7233
+# https://datatracker.ietf.org/doc/html/rfc7233
 #
 SecRule REQUEST_HEADERS:Connection "@rx \b(?:keep-alive|close),\s?(?:keep-alive|close)\b" \
     "id:920210,\
@@ -1159,7 +1158,7 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
 # Rule against CVE-2022-21907
 # This rule blocks Accept-Encoding headers longer than 50 characters.
 # The length of 50 is a heuristic based on the length of values from
-# the RFC (https://datatracker.ietf.org/doc/draft-ietf-httpbis-semantics/)
+# the RFC (https://datatracker.ietf.org/doc/rfc9110/)
 # and the respective values assigned by IANA
 # (https://www.iana.org/assignments/http-parameters/http-parameters.xml#content-coding).
 #
@@ -1531,7 +1530,7 @@ SecRule &REQUEST_HEADERS:Accept "@eq 0" \
 # Note that this only works in combination with a User-Agent prefix.
 #
 # This rule is based on a blog post by Soroush Dalili at
-# https://soroush.secproject.com/blog/2019/05/x-up-devcap-post-charset-header-in-aspnet-to-bypass-wafs-again/
+# https://soroush.me/blog/2019/05/x-up-devcap-post-charset-header-in-aspnet-to-bypass-wafs-again/
 #
 SecRule &REQUEST_HEADERS:x-up-devcap-post-charset "@ge 1" \
     "id:920490,\
@@ -1714,7 +1713,7 @@ SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!RE
 # This is a stricter sibling of 920270.
 # The headers of this rule are Structured Header booleans, for which only `?0`,
 # and `?1` are inconspicuous.
-# Structured Header boolean: https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-19#section-3.3.6
+# Structured Header boolean: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-header-structure-19#section-3.3.6
 # Sec-Fetch-User: https://www.w3.org/TR/fetch-metadata/#http-headerdef-sec-fetch-user
 # Sec-CH-UA-Mobile: https://wicg.github.io/ua-client-hints/#sec-ch-ua-mobile
 #

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -191,7 +191,7 @@ SecRule ARGS_GET_NAMES|ARGS_GET "@rx [\n\r]+(?:\s|location|refresh|(?:set-)?cook
 # -=[ HTTP Splitting ]=-
 #
 # This rule detect \n or \r in the REQUEST FILENAME
-# Reference: https://www.owasp.org/index.php/Testing_for_HTTP_Splitting/Smuggling_(OTG-INPVAL-016)
+# Reference: https://wiki.owasp.org/index.php/Testing_for_HTTP_Splitting/Smuggling_(OTG-INPVAL-016)
 #
 SecRule REQUEST_FILENAME "@rx [\n\r]" \
     "id:921190,\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -223,7 +223,7 @@ SecRule REQUEST_FILENAME "@rx [\n\r]" \
 #
 # [ References ]
 # * https://www.blackhat.com/presentations/bh-europe-08/Alonso-Parada/Whitepaper/bh-eu-08-alonso-parada-WP.pdf
-# * https://blog.ripstech.com/2017/joomla-takeover-in-20-seconds-with-ldap-injection-cve-2017-14596/
+# * https://www.sonarsource.com/blog/joomla-takeover-in-20-seconds-with-ldap-injection-cve-2017-14596/
 # * https://github.com/SpiderLabs/owasp-modsecurity-crs/issues/276#issue-126581660
 
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx ^[^:\(\)\&\|\!\<\>\~]*\)\s*(?:\((?:[^,\(\)\=\&\|\!\<\>\~]+[><~]?=|\s*[&!|]\s*(?:\)|\()?\s*)|\)\s*\(\s*[\&\|\!]\s*|[&!|]\s*\([^\(\)\=\&\|\!\<\>\~]+[><~]?=[^:\(\)\&\|\!\<\>\~]*)" \

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -687,7 +687,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # Detects attempts to upload a file with a forbidden filename.
 #
 # Many application contain Unrestricted File Upload vulnerabilities.
-# https://www.owasp.org/index.php/Unrestricted_File_Upload
+# https://owasp.org/www-community/vulnerabilities/Unrestricted_File_Upload
 #
 # These might be abused to upload configuration files or other files
 # that affect the behavior of the web server, possibly causing remote

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -229,8 +229,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #
 # If you are not running Windows, it is safe to disable this rule.
 #
-# https://technet.microsoft.com/en-us/magazine/ff714569.aspx
-# https://msdn.microsoft.com/en-us/powershell/scripting/core-powershell/console/powershell.exe-command-line-help
+# https://learn.microsoft.com/en-us/previous-versions/technet-magazine/ff714569(v=msdn.10)
 #
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pmFromFile windows-powershell-commands.data" \
     "id:932120,\

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -24,7 +24,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:933012,phase:2,pass,nolog,skipAf
 # -=[ PHP Injection Attacks ]=-
 #
 # [ References ]
-# http://rips-scanner.sourceforge.net/
+# https://rips-scanner.sourceforge.net/
 # https://wiki.owasp.org/index.php/PHP_Top_5#P1:_Remote_Code_Executionh
 #
 
@@ -79,7 +79,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # .php file and have the code within it executed on the server.
 #
 # Also block files with just dot (.) characters after the extension:
-# https://community.rapid7.com/community/metasploit/blog/2013/08/15/time-to-patch-joomla
+# https://www.rapid7.com/blog/post/2013/08/15/time-to-patch-joomla/
 #
 # Some AJAX uploaders use the nonstandard request headers X-Filename,
 # X_Filename, or X-File-Name to transmit the file name to the server;
@@ -371,7 +371,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
 #    O:3:"Foo":0:{}
 #
 # Also detected are PHP objects with a custom unserializer:
-# http://www.phpinternalsbook.com/classes_objects/serialization.html
+# https://www.phpinternalsbook.com/php5/classes_objects/serialization.html
 # These have the following format:
 #
 #    C:11:"ArrayObject":37:{x:i:0;a:1:{s:1:"a";s:1:"b";};m:a:0:{}}

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -25,7 +25,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:933012,phase:2,pass,nolog,skipAf
 #
 # [ References ]
 # http://rips-scanner.sourceforge.net/
-# https://www.owasp.org/index.php/PHP_Top_5#P1:_Remote_Code_Executionh
+# https://wiki.owasp.org/index.php/PHP_Top_5#P1:_Remote_Code_Executionh
 #
 
 #
@@ -363,7 +363,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
 # unserialize() call, resulting in an arbitrary PHP object(s) injection into the
 # application scope.
 #
-# https://www.owasp.org/index.php/PHP_Object_Injection
+# https://owasp.org/www-community/vulnerabilities/PHP_Object_Injection
 #
 # In serialized form, PHP objects have the following format:
 #

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -519,7 +519,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 #
-# https://www.owasp.org/www-community/xss-filter-evasion-cheatsheet
+# https://cheatsheetseries.owasp.org/cheatsheets/XSS_Filter_Evasion_Cheat_Sheet.html
 # US-ASCII encoding bypass listed on XSS filter evasion
 # Reported by Mazin Ahmed
 #

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -238,7 +238,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
 
 #
 # [Deny List Keywords from Node-Validator]
-# https://raw.github.com/chriso/node-validator/master/validator.js
+# https://github.com/validatorjs/validator.js/
 # This rule has a stricter sibling 941181 (PL2) that covers the additional payload "-->"
 #
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@pm document.cookie document.domain document.write .parentnode .innerhtml window.location -moz-binding <!-- <![cdata[" \
@@ -826,7 +826,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
 
 #
 # [Deny List Keywords from Node-Validator]
-# https://raw.github.com/chriso/node-validator/master/validator.js
+# https://github.com/validatorjs/validator.js/
 # This rule is a stricter sibling of 941180 (PL1)
 #
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@contains -->" \
@@ -987,7 +987,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
 # Of course, pure client-side AngularJS commands can not be intercepted.
 # But once a command is sent to the server, the CRS will trigger.
 #
-# https://portswigger.net/blog/xss-without-html-client-side-template-injection-with-angularjs
+# https://portswigger.net/research/xss-without-html-client-side-template-injection-with-angularjs
 #
 # Example payload:
 # http://localhost/login?user=%20x%20%7B%7Bconstructor.constructor(%27alert(1)%27)()%7D%7D%20.%20ff

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -33,7 +33,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:942012,phase:2,pass,nolog,skipAf
 # http://ferruh.mavituna.com/sql-injection-cheatsheet-oku/
 #
 # SQLMap's Tamper Scripts (for evasions)
-# https://svn.sqlmap.org/sqlmap/trunk/sqlmap/tamper/
+# https://github.com/sqlmapproject/sqlmap
 #
 
 #
@@ -41,7 +41,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:942012,phase:2,pass,nolog,skipAf
 #
 # There is a stricter sibling of this rule at 942101. It covers REQUEST_BASENAME and REQUEST_FILENAME.
 #
-# Ref: https://libinjection.client9.com/
+# Ref: https://github.com/libinjection/libinjection
 #
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@detectSQLi" \
     "id:942100,\
@@ -132,7 +132,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #
 # -=[ PHPIDS - Converted SQLI Filters ]=-
 #
-# https://raw.github.com/PHPIDS/PHPIDS/master/lib/IDS/default_filter.xml
+# https://raw.githubusercontent.com/PHPIDS/PHPIDS/master/lib/IDS/default_filter.xml
 #
 # The rule 942160 prevents time-based blind SQL injection attempts
 # by prohibiting sleep() or benchmark(,) functions:
@@ -456,10 +456,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #
 # Sources for SQL ALTER statements:
 # MySQL: https://dev.mysql.com/doc/refman/5.7/en/sql-syntax-data-definition.html
-# Oracle/PLSQL: https://docs.oracle.com/apps/search/search.jsp?q=alter&size=60&category=database
+# Oracle/PLSQL: https://docs.oracle.com/search/?q=alter&size=60&category=database
 # PostgreQSL: https://www.postgresql.org/search/?u=%2Fdocs&q=alter
-# MSSQL: https://docs.microsoft.com/en-us/sql/t-sql/statements/statements
-# DB2: https://www.ibm.com/support/knowledgecenter/en/search/alter?scope=SSEPGG_9.5.0
+# MSSQL: https://learn.microsoft.com/en-us/sql/t-sql/statements/statements?view=sql-server-ver16
+# DB2: https://www.ibm.com/docs/en/search/alter?scope=SSEPGG_9.5.0
 #
 # Regular expression generated from regex-assembly/942360.ra.
 # To update the regular expression run the following shell script

--- a/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -366,7 +366,6 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
 
 # This rule is also triggered by the following exploit(s):
 # - https://www.rapid7.com/blog/post/2022/03/30/spring4shell-zero-day-vulnerability-in-spring-framework/
-# - https://www.ironcastle.net/possible-new-java-spring-framework-vulnerability-wed-mar-30th/
 #
 SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \
     "@rx (?:class\.module\.classLoader\.resources\.context\.parent\.pipeline|springframework\.context\.support\.FileSystemXmlApplicationContext)" \

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -23,7 +23,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:951012,phase:4,pass,nolog,skipAf
 #
 # -=[ SQL Error Leakages ]=-
 #
-# Ref: https://raw.github.com/sqlmapproject/sqlmap/master/xml/errors.xml
+# Ref: https://github.com/sqlmapproject/sqlmap
 # Ref: https://github.com/Arachni/arachni/tree/master/components/checks/active/sql_injection/regexps
 #
 SecRule RESPONSE_BODY "!@pmFromFile sql-errors.data" \

--- a/rules/crawlers-user-agents.data
+++ b/rules/crawlers-user-agents.data
@@ -18,7 +18,7 @@ blackwidow
 CensysInspect
 # scraping framework
 # http://go-colly.org/
-# User-Agent: colly - https://github.com/gocolly/colly/v2
+# User-Agent: colly - https://github.com/gocolly/colly
 colly -
 # scraping framework
 # https://github.com/yasserg/crawler4j
@@ -46,7 +46,7 @@ Mechanize
 MJ12bot
 # scraping framework
 # https://nutch.apache.org/
-# User-Agent: NutchCVS/VERSION (Nutch; http://lucene.apache.org/nutch/bot.html; nutch-agent@lucene.apache.org)
+# User-Agent: NutchCVS/VERSION (Nutch; https://nutch.apache.org/; nutch-agent@lucene.apache.org)
 NutchCVS/
 # news service
 Owlin bot
@@ -63,7 +63,7 @@ pymills-spider/
 # User-Agent: pyspider/VERSION (+http://pyspider.org/)
 pyspider/
 # SEO
-# https://moz.com/help/guides/moz-procedures/what-is-rogerbot
+# https://moz.com/help/moz-procedures/crawlers/rogerbot
 rogerbot
 # SEO
 # http://www.searchmetrics.com/searchmetricsbot/

--- a/rules/php-errors.data
+++ b/rules/php-errors.data
@@ -1,4 +1,4 @@
-# The contents of this list come from the [PHP source code](https://github.com:php/php-src).
+# The contents of this list come from the [PHP source code](https://github.com/php/php-src).
 #
 # There are different types of errors that might be thrown. An easy way to discover them is to
 # get any text that comes from the error handling functions: `zend_error`, `zend_throw_error`, `soap_error0`, etc.

--- a/rules/scanners-user-agents.data
+++ b/rules/scanners-user-agents.data
@@ -1,10 +1,10 @@
 # Vulnerability scanners, bruteforce password crackers and exploitation tools
 
 # password cracker
-# http://sectools.org/tool/hydra/
+# https://sectools.org/tool/hydra/
 (hydra)
 # vuln scanner
-# http://virtualblueness.net/nasl.html
+# (deprecated) http://virtualblueness.net/nasl.html
 .nasl
 # sql injection
 # https://sourceforge.net/projects/absinthe/
@@ -13,11 +13,11 @@ absinthe
 # dead? 2004
 advanced email extractor
 # vuln scanner
-# http://www.arachni-scanner.com/
+# https://ecsypno.com/pages/arachni-web-application-security-scanner-framework
 arachni/
 autogetcontent
 # nessus frontend
-# http://www.crossley-nilsen.com/Linux/Bilbo_-_Nessus_WEB/bilbo_-_nessus_web.html
+# (deprecated) http://www.crossley-nilsen.com/Linux/Bilbo_-_Nessus_WEB/bilbo_-_nessus_web.html
 # dead? 2003
 bilbo
 # Backup File Artifacts Checker
@@ -37,13 +37,13 @@ bsqlbf
 # https://portswigger.net/burp/documentation/collaborator
 burpcollaborator
 # vuln scanner
-# http://freecode.com/projects/cgichk dead? 2001
+# (deprecated) http://freecode.com/projects/cgichk
 cgichk
 # vuln scanner
 # https://sourceforge.net/projects/cisco-torch/
 cisco-torch
 # vuln scanner
-# https://github.com/stasinopoulos/commix
+# https://github.com/commixproject/commix
 commix
 # MS FrontPage vuln scanner?
 core-project/1.0
@@ -90,7 +90,7 @@ havij
 # https://github.com/projectdiscovery/httpx
 httpx - Open-source project
 # vuln scanner - path disclosure finder
-# http://seclists.org/fulldisclosure/2010/Sep/375
+# https://seclists.org/fulldisclosure/2010/Sep/375
 inspath
 internet ninja
 # vuln scanner
@@ -109,7 +109,7 @@ morfeus fucking scanner
 # https://github.com/dtrip/mysqloit
 mysqloit
 # vuln scanner
-# http://www.nstalker.com/
+# http://www.nstalker.com/alliance/
 n-stealth
 # vuln scanner
 # http://www.tenable.com/products/nessus-vulnerability-scanner
@@ -131,10 +131,10 @@ nsauditor
 # https://github.com/projectdiscovery/nuclei
 Nuclei
 # vuln scanner
-# http://www.openvas.org/
+# https://www.openvas.org/
 openvas
 # sql injection
-# http://www.vealtel.com/software/nosec/pangolin/
+# (deprecated) http://www.vealtel.com/software/nosec/pangolin/
 pangolin
 # web proxy & vuln scanner
 # https://sourceforge.net/projects/paros/
@@ -147,7 +147,7 @@ prog.customcrawler
 # https://twitter.com/bagder/status/1244982556958826496?s=20
 QQGameHall
 # vuln scanner
-# https://www.qualys.com/suite/web-application-scanning/
+# https://www.qualys.com/apps/web-app-scanning/
 qualys was
 s.t.a.l.k.e.r.
 security scan
@@ -161,12 +161,12 @@ sql power injector
 # http://sqlmap.org/
 sqlmap
 # sql injection
-# http://sqlninja.sourceforge.net/
+# https://sqlninja.sourceforge.net/
 sqlninja
 # vuln scanner
 # https://github.com/mazen160/struts-pwn
 struts-pwn
-# https://www.cyber.nj.gov/threat-profiles/trojan-variants/sysscan
+# https://www.cyber.nj.gov/threat-center/threat-profiles/trojan-variants/sysscan
 sysscan
 # LeakIX web scanner (User-Agent: TBI-WebScanner/0.0.1 (+https://leakix.net/))
 # https://leakix.net/
@@ -179,7 +179,7 @@ this is an exploit
 toata dragostea
 toata dragostea mea pentru diavola
 # SQL bot
-# http://tools.cisco.com/security/center/viewIpsSignature.x?signatureId=22142&signatureSubId=0
+# https://sec.cloudapps.cisco.com/security/center/resources/eol_ips
 uil2pn
 # badly scripted UAs (e.g. User-Agent: User-Agent: foo)
 user-agent:
@@ -198,10 +198,10 @@ w3af.org
 # http://www.robotstxt.org/db/webbandit.html
 webbandit
 # vuln scanner
-# http://www8.hp.com/us/en/software-solutions/webinspect-dynamic-analysis-dast/
+# (deprecated) http://www8.hp.com/us/en/software-solutions/webinspect-dynamic-analysis-dast/
 webinspect
 # site scanner
-# http://www.scrt.ch/en/attack/downloads/webshag
+# (deprecated) http://www.scrt.ch/en/attack/downloads/webshag
 webshag
 # vuln scanner
 # dead?
@@ -220,7 +220,7 @@ whcc/
 # exploit poc
 wordpress hash grabber
 # wordpress vuln scanner
-# https://wpscan.org/
+# https://wpscan.com/
 WPScan
 # exploit
 xmlrpc exploit

--- a/rules/scanners-user-agents.data
+++ b/rules/scanners-user-agents.data
@@ -55,7 +55,7 @@ datacha0s
 # https://detectify.com/
 Detectify
 # hidden page scanner
-# https://www.owasp.org/index.php/Category:OWASP_DirBuster_Project
+# (deprecated) https://www.owasp.org/index.php/Category:OWASP_DirBuster_Project
 dirbuster
 # vuln scanner
 # https://sourceforge.net/projects/dominohunter/

--- a/rules/scripting-user-agents.data
+++ b/rules/scripting-user-agents.data
@@ -6,7 +6,7 @@
 aiohttp/
 
 # http library
-# http://search.cpan.org/~opera/HTTP-DAV/DAV.pm
+# https://metacpan.org/release/OPERA/HTTP-DAV-0.44/view/DAV.pm
 dav.pm/v
 
 # http library
@@ -19,7 +19,7 @@ Go 1.1 package http
 Go-http-client/
 
 # http library
-# http://search.cpan.org/dist/libwww-perl/lib/LWP.pm
+# https://metacpan.org/dist/libwww-perl/view/lib/LWP.pm
 libwww-perl
 # generic
 mozilla/4.0 (compatible)
@@ -28,7 +28,7 @@ mozilla/5.0 sf/
 mozilla/5.0 sf//
 
 # http library
-# https://pypi.python.org/pypi/httplib2
+# https://pypi.org/project/httplib2/
 python-httplib2
 
 # http library

--- a/rules/ssrf.data
+++ b/rules/ssrf.data
@@ -37,7 +37,7 @@ http://[::]:
 http://169.254.170.2/v2
 
 ## Google Cloud
-#  https://cloud.google.com/compute/docs/metadata
+#  https://cloud.google.com/compute/docs/metadata/overview
 #  - Requires the header "Metadata-Flavor: Google" or "X-Google-Metadata-Request: True"
 
 http://169.254.169.254/computeMetadata/v1/

--- a/rules/web-shells-php.data
+++ b/rules/web-shells-php.data
@@ -13,7 +13,7 @@
 # Data comes from multiple places of which some doesn't work anymore. Few are
 # listed below:
 # - https://github.com/JohnTroony/php-webshells/tree/master/Collection
-# - https://www.localroot.net/shell/
+# - https://www.localroot.net/
 # - Google search (keywords like webshells, php backdoor and similar)
 
 # 1n73ction web shell
@@ -22,11 +22,11 @@
 >Ajax/PHP Command Shell<
 # AK-74 Security Team Web-shell
 .:: :[ AK-74 Security Team Web-shell ]: ::.
-# ALFA-SHELL web shell (https://github.com/solevisible)
+# ALFA-SHELL web shell (deprecated, https://github.com/solevisible)
 ~ ALFA TEaM Shell -
 # Andela Yuwono Priv8 Shell web shell
 <title>--==[[ Andela Yuwono Priv8 Shell ]]==--</title>
-# Ani-Shell web shell (http://ani-shell.sourceforge.net/)
+# Ani-Shell web shell (https://ani-shell.sourceforge.net/)
 <title>Ani-Shell | India</title>
 # AnonymousFox PHP web shell
 <input type='submit' value='file' /></form>AnonymousFox

--- a/rules/windows-powershell-commands.data
+++ b/rules/windows-powershell-commands.data
@@ -1,6 +1,6 @@
 # Sources:
 # Microsoft PowerShell Docs: https://github.com/MicrosoftDocs/PowerShell-Docs
-# - curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/MicrosoftDocs/PowerShell-Docs/git/trees/main\?recursive\=1 | jq -r '.tree[] .path | capture("reference/\\d.\\d/(.*)/(?<fn>[A-Z]\\w+-\\w+).md") | .fn' | sort | uniq
+# - curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/MicrosoftDocs/PowerShell-Docs/git/trees/main | jq -r '.tree[] .path | capture("reference/\\d.\\d/(.*)/(?<fn>[A-Z]\\w+-\\w+).md") | .fn' | sort | uniq
 
 powershell
 Add-Computer

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -7,7 +7,7 @@ Welcome to the OWASP Core Rule Set regression testing suite. This suite is meant
 
 Installation
 ============
-The OWASP Core Rule Set project was part of the effort to develop FTW, the Framework for Testing WAFs. As a result, we use this project in order to run our regression testing. FTW is designed to use existing Python testing frameworks to allow for easy to read web based testing, provided in YAML. You can install FTW by from the repository (at https://github.com/CRS-support/ftw) or by running pip.
+The OWASP Core Rule Set project was part of the effort to develop FTW, the Framework for Testing WAFs. As a result, we use this project in order to run our regression testing. FTW is designed to use existing Python testing frameworks to allow for easy to read web based testing, provided in YAML. You can install FTW by from the repository (at https://github.com/coreruleset/ftw) or by running pip.
 
 ```pip install -r requirements.txt```
 

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920274.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920274.yaml
@@ -8,7 +8,7 @@ tests:
   - # Apache will just error on this and return 400
     # as a result we look for forbidden or 400
     # In the future FTW should support OR versus AND output
-    # https://github.com/CRS-support/ftw/issues/19
+    # https://github.com/coreruleset/ftw/issues/19
     test_title: 920274-1
     stages:
       - stage:

--- a/util/crs-rules-check/README.md
+++ b/util/crs-rules-check/README.md
@@ -68,7 +68,7 @@ Optionally, you can add the option `--output=github` (default value is `native`)
 ./util/crs-rules-check/rules-check.py --output=github -r crs-setup.conf.example -r rules/*.conf
 ```
 
-In this case, each line will have a prefix, which could be `::debug` or `::error`. See [this](https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#setting-an-error-message).
+In this case, each line will have a prefix, which could be `::debug` or `::error`. See [this](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message).
 
 Examples
 ========

--- a/util/regexp-tricks/negative-lookahead.py
+++ b/util/regexp-tricks/negative-lookahead.py
@@ -21,7 +21,7 @@ parser.add_argument("--suffix", type=str, default="",
 args = parser.parse_args()
 
 # Return the longest prefix of all list elements. Shamelessly copied from:
-# https://stackoverflow.com/questions/6718196/determine-prefix-from-a-set-of-similar-strings
+# https://stackoverflow.com/questions/6718196/determine-the-common-prefix-of-multiple-strings
 def commonprefix(m):
     "Given a list of pathnames, returns the longest common leading component"
     if not m: return ''


### PR DESCRIPTION
## Proposed changes

- Fix #3230 
- Fix other external hyperlinks

## PR Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/CONTRIBUTING.md) doc
- [ ] I have added positive tests proving my fix/feature works as intended.
- [ ] I have added negative tests that prove my fix/feature considers common cases that might end in false positives
- [ ] In case you changed a regular expression, you are not adding a ReDOS for pcre. You can check this using [regexploit](https://github.com/doyensec/regexploit)
- [ ] My test use the `comment` field to write the expected behaviour
- [x] I have added documentation for the rule or change (when appropriate)

## Further comments

For the external links, I tried to link to the other appropriate sources if the links were 404.

Besides, I think some rules might need to review:
- `rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf`: the RFC is superseded 
- `rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf`: js validator is updated
- `rules/scanners-user-agents.data`, `rules/crawlers-user-agents.data`, and `rules/scanners-user-agents.data`: while some agents are deprecated, perhaps we can remove them directly?

(P.S.) PR template is not working as well :(

## For the reviewer

- [ ] Positive and negative tests were added
- [ ] Tests cover the intended fix/feature properly
- [ ] No usage of dangerous constructs like `ctl:requestBodyAccess=Off` were used in the rule
- [ ] In case a regular expression was changed, [there is no ReDOS](https://github.com/coreruleset/coreruleset/wiki/Testing-for-Regular-Expresion-DoS)
- [ ] Documentation is clear for the rule/change
