### PR TITLE
feat(util): extend spell script

### DIFF
--- a/util/fp-finder/spell.sh
+++ b/util/fp-finder/spell.sh
@@ -1,20 +1,34 @@
 #!/bin/bash
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# This script finds common English words in .data files (if no argument provided).
+# Or it finds english words in the provided input file (one argument).
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 RULES_DIR="${SCRIPT_DIR}/../../rules/"
 
-for datafile in "$RULES_DIR"*.data; do
-    DATAFILE_NAME=${datafile##*/}
-    
-    echo "-> checking ${DATAFILE_NAME}"
-
-    for word in $(grep -E '^[a-z]+$' "${datafile}" | uniq | sort); do
+# If no argument provided:
+if [ $# -eq 0 ]
+  then
+    for datafile in "$RULES_DIR"*.data; do
+      DATAFILE_NAME=${datafile##*/}
+      echo "-> checking ${DATAFILE_NAME}"
+      for word in $(grep -E '^[a-z]+$' "${datafile}" | uniq | sort); do
         IS_NOT_ENGLISH=$(echo "${word}" | spell | wc -l)
         if [ "${IS_NOT_ENGLISH}" -lt 1 ]; then
             echo "   \`- found English word: ${word}"
         fi
-    done
-
+      done
     echo ""
-done
+  done
+# If argument provided, check this file:
+else
+  datafile=$SCRIPT_DIR/../../$1
+  DATAFILE_NAME=${datafile##*/}
+  for word in $(grep -E '[a-z]+$' "${datafile}" | grep -vE [#@\\] | uniq | sort); do
+    IS_NOT_ENGLISH=$(echo "${word}" | spell | wc -l)
+    if [ "${IS_NOT_ENGLISH}" -lt 1 ]; then
+      echo "   \`- found English word: ${word}"
+    fi
+  done
+  echo ""
+fi

--- a/util/fp-finder/spell.sh
+++ b/util/fp-finder/spell.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 # This script finds common English words in .data files (if no argument provided).
-# Or it finds english words in the provided input file (one argument).
+#
+# Or it finds english words in the provided input file (one argument). Example:
+#  bash util/fp-finder/spell.sh regex-assembly/932380.ra
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 RULES_DIR="${SCRIPT_DIR}/../../rules/"


### PR DESCRIPTION
This PR extends the existing script spell.sh that checks for common English words. Currently, the script only checks for common English words in data files.

The script now takes one argument where an ra file can be given for example.
This extended spell.sh will then be used to generate the exclude list for PR #3170.

Feedback is very welcome.