### PR TITLE
feat: target Unix commands in Referer header explicitly

### DIFF
--- a/regex-assembly/932200.ra
+++ b/regex-assembly/932200.ra
@@ -1,0 +1,17 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/crs_toolchain/.
+
+##! - bar;cd+/etc;/bin$u/ca*+passwd
+##! - foo;ca\t+/et\c/pa\s\swd
+##! - foo;c'at'+/etc/pa's'swd
+[*?`\x5c'][^/\n]+/
+/[^/]+?[*?`\x5c']
+##! - foo;cat$u+/etc$u/passwd
+##! - foo;c$-at+/et$-c/pas$-swd
+##! - foo;c$_at+/et$_c/pas$_swd
+##! - foo;c$?at+/et$?c/pas$?swd
+##! - foo;c$*at+/et$*c/pas$*swd
+##! - foo;c$@at+/et$@c/pas$@swd
+##! - foo;c$!at+/et$!c/pas$!swd
+##! - foo;c$$at+/et$$c/pas$$swd
+\$[({\[#@!?*\-_$a-zA-Z0-9]

--- a/regex-assembly/932205.ra
+++ b/regex-assembly/932205.ra
@@ -1,0 +1,29 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/crs_toolchain/.
+
+##! Prefix to prevent the first `?` (query string marker
+##! in URLs) from matching any of the later expressions.
+##! If the URL does not have a query string, then instead
+##! look for the first `;`.
+##! Prefix and suffix markers also form two capture groups
+##! that are used for processing and logging in the rule.
+##!^ ^[^.]+\.[^?;]+[?;](.*(
+##!$ ))
+
+##! The following expressions in this file must be identical to the
+##! ones in 932200.
+
+##! - bar;cd+/etc;/bin$u/ca*+passwd
+##! - foo;ca\t+/et\c/pa\s\swd
+##! - foo;c'at'+/etc/pa's'swd
+[*?`\x5c'][^/\n]+/
+/[^/]+?[*?`\x5c']
+##! - foo;cat$u+/etc$u/passwd
+##! - foo;c$-at+/et$-c/pas$-swd
+##! - foo;c$_at+/et$_c/pas$_swd
+##! - foo;c$?at+/et$?c/pas$?swd
+##! - foo;c$*at+/et$*c/pas$*swd
+##! - foo;c$@at+/et$@c/pas$@swd
+##! - foo;c$!at+/et$!c/pas$!swd
+##! - foo;c$$at+/et$$c/pas$$swd
+\$[({\[#@!?*\-_$a-zA-Z0-9]

--- a/regex-assembly/932206.ra
+++ b/regex-assembly/932206.ra
@@ -1,0 +1,25 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/crs_toolchain/.
+
+##! Prefix to ensure that the rule only matches when the
+##! value of the Referer header is not a URL (illegal header
+##! value).
+##!^ ^[^.]*?
+
+##! The following expressions in this file must be identical to the
+##! ones in 932200.
+
+##! - bar;cd+/etc;/bin$u/ca*+passwd
+##! - foo;ca\t+/et\c/pa\s\swd
+##! - foo;c'at'+/etc/pa's'swd
+[*?`\x5c'][^/\n]+/
+/[^/]+?[*?`\x5c']
+##! - foo;cat$u+/etc$u/passwd
+##! - foo;c$-at+/et$-c/pas$-swd
+##! - foo;c$_at+/et$_c/pas$_swd
+##! - foo;c$?at+/et$?c/pas$?swd
+##! - foo;c$*at+/et$*c/pas$*swd
+##! - foo;c$@at+/et$@c/pas$@swd
+##! - foo;c$!at+/et$!c/pas$!swd
+##! - foo;c$$at+/et$$c/pas$$swd
+\$[({\[#@!?*\-_$a-zA-Z0-9]

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -923,7 +923,7 @@ SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer "@rx (?:\$(?:\((?:\(.
 #
 # Regex notes: https://regex101.com/r/V6wrCO/1
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:Referer|REQUEST_HEADERS:User-Agent|ARGS_NAMES|ARGS|XML:/* "@rx (?:[*?`\x5c'][^/\n]+/|\$[({\[#@!?*\-_$a-zA-Z0-9]|/[^/]+?[*?`\x5c'])" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:Referer|REQUEST_HEADERS:User-Agent|ARGS_NAMES|ARGS|XML:/* "@rx ['\*\?\x5c`][^\n/]+/|/[^/]+?['\*\?\x5c`]|\$[!#-\$\(\*\-0-9\?-\[_a-\{]" \
     "id:932200,\
     phase:2,\
     block,\

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -923,7 +923,12 @@ SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer "@rx (?:\$(?:\((?:\(.
 #
 # Regex notes: https://regex101.com/r/V6wrCO/1
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:Referer|REQUEST_HEADERS:User-Agent|ARGS_NAMES|ARGS|XML:/* "@rx ['\*\?\x5c`][^\n/]+/|/[^/]+?['\*\?\x5c`]|\$[!#-\$\(\*\-0-9\?-\[_a-\{]" \
+# Regular expression generated from regex-assembly/932200.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 932200
+#
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|ARGS_NAMES|ARGS|XML:/* "@rx ['\*\?\x5c`][^\n/]+/|/[^/]+?['\*\?\x5c`]|\$[!#-\$\(\*\-0-9\?-\[_a-\{]" \
     "id:932200,\
     phase:2,\
     block,\
@@ -942,6 +947,84 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     ver:'OWASP_CRS/4.0.0-rc1',\
     severity:'CRITICAL',\
     setvar:'tx.932200_matched_var_name=%{matched_var_name}',\
+    chain"
+    SecRule MATCHED_VAR "@rx /" \
+        "t:none,t:urlDecodeUni,\
+        chain"
+        SecRule MATCHED_VAR "@rx \s" \
+            "t:none,t:urlDecodeUni,\
+            setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+            setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+
+#
+# -=[ Rule 932205 ]=-
+#
+# Sibling of 932200 targeting the Referer header. URLs cause false positives in rule 932200
+# and must be handled with additional checks.
+#
+# Regular expression generated from regex-assembly/932205.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 932205
+#
+SecRule REQUEST_HEADERS:Referer "@rx ^[^\.]+\.[^;\?]+[;\?](.*(['\*\?\x5c`][^\n/]+/|/[^/]+?['\*\?\x5c`]|\$[!#-\$\(\*\-0-9\?-\[_a-\{]))" \
+    "id:932205,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:lowercase,t:urlDecodeUni,\
+    msg:'RCE Bypass Technique',\
+    logdata:'Matched Data: %{TX.2} found within %{TX.932205_MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
+    tag:'paranoia-level/2',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/248/88',\
+    tag:'PCI/6.5.2',\
+    ver:'OWASP_CRS/4.0.0-rc1',\
+    severity:'CRITICAL',\
+    setvar:'tx.932205_matched_var_name=%{matched_var_name}',\
+    chain"
+    SecRule TX:1 "@rx /" \
+        "t:none,t:urlDecodeUni,\
+        chain"
+        SecRule TX:1 "@rx \s" \
+            "t:none,t:urlDecodeUni,\
+            setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+            setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+
+#
+# -=[ Rule 932206 ]=-
+#
+# Sibling of 932200 targeting the Referer header. URLs cause false positives in rule 932200
+# and must be handled with additional checks.
+#
+# Regular expression generated from regex-assembly/932206.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 932206
+#
+SecRule REQUEST_HEADERS:Referer "@rx ^[^\.]*?(?:['\*\?\x5c`][^\n/]+/|/[^/]+?['\*\?\x5c`]|\$[!#-\$\(\*\-0-9\?-\[_a-\{])" \
+    "id:932206,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:lowercase,t:urlDecodeUni,\
+    msg:'RCE Bypass Technique',\
+    logdata:'Matched Data: %{TX.0} found within %{TX.932206_MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
+    tag:'paranoia-level/2',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/248/88',\
+    tag:'PCI/6.5.2',\
+    ver:'OWASP_CRS/4.0.0-rc1',\
+    severity:'CRITICAL',\
+    setvar:'tx.932206_matched_var_name=%{matched_var_name}',\
     chain"
     SecRule MATCHED_VAR "@rx /" \
         "t:none,t:urlDecodeUni,\

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932205.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932205.yaml
@@ -1,0 +1,92 @@
+---
+meta:
+  author: "Max Leske"
+  description: RCE Bypass
+  enabled: true
+  name: 932205.yaml
+tests:
+  - test_title: 932205-1
+    desc: Referer without query string, trying to evade query string match
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: "OWASP CRS test agent"
+              Referer: "www.google.com;c$?at+/etc/passwd"
+            method: GET
+            port: 80
+            uri: /get
+            version: HTTP/1.0
+          output:
+            log_contains: id "932205"
+  - test_title: 932205-2
+    desc: Referer header with query string and obvious payload
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: "OWASP CRS test agent"
+              Referer: "www.google.com?param=;/bin/ca?+/et*/passwd"
+            method: GET
+            port: 80
+            uri: /get
+            version: HTTP/1.0
+          output:
+            log_contains: id "932205"
+  - test_title: 932205-3
+    desc: Referer header with canonical path, query string and obvious payload
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: "OWASP CRS test agent"
+              Referer: "www.google.com/?param=;/bin/ca?+/et*/passwd"
+            method: GET
+            port: 80
+            uri: /get
+            version: HTTP/1.0
+          output:
+            log_contains: id "932205"
+  - test_title: 932205-4
+    desc: False positive test against query string and space in a parameter
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: "OWASP CRS test agent"
+              Referer: "http://www.example.com/page?param=test+test"
+            method: GET
+            port: 80
+            uri: /get
+            version: HTTP/1.0
+          output:
+            no_log_contains: id "932205"
+  - test_title: 932205-5
+    desc: False positive test against query string and space in path
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: "OWASP CRS test agent"
+              Referer: "http://www.example.com/page%20test?param=test"
+            method: GET
+            port: 80
+            uri: /get
+            version: HTTP/1.0
+          output:
+            no_log_contains: id "932205"

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932206.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932206.yaml
@@ -1,0 +1,58 @@
+---
+meta:
+  author: "Max Leske"
+  description: RCE Bypass
+  enabled: true
+  name: 932206.yaml
+tests:
+  - test_title: 932206-1
+    desc: Referer header without URL
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: "OWASP CRS test agent"
+              Referer: "/bin/ca't'+/et*/passwd"
+            method: GET
+            port: 80
+            uri: /get
+            version: HTTP/1.0
+          output:
+            log_contains: id "932206"
+  - test_title: 932206-2
+    desc: False positive test against URL
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: "OWASP CRS test agent"
+              Referer: "http://www.example.com/page?param=test+test"
+            method: GET
+            port: 80
+            uri: /get
+            version: HTTP/1.0
+          output:
+            no_log_contains: id "932206"
+  - test_title: 932206-3
+    desc: False positive test against query string and space in path
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: "OWASP CRS test agent"
+              Referer: "http://www.example.com/page%20test?param=test"
+            method: GET
+            port: 80
+            uri: /get
+            version: HTTP/1.0
+          output:
+            no_log_contains: id "932206"


### PR DESCRIPTION
New rules 932205, 932206 to handle the Referer header explicitly.
    
The regular expression in 932200 leads to false positives against URLs
with query strings (due to the `?`). 932205 uses an additional prefix in
the regular expression that matches the first `?` so that the following
expressions will only match question marks that are part of the payload.

932206 uses an additional prefix to match only when the Referer value is
not a URL (which is illegal). 932206 is thus equivalent to 932200 but is
required to distinguish the case where the Referer header does actually
contain a URL.

Fixes #3180.