### PR TITLE
feat: Bring CONTRIBUTING.MD back in line w/ HTML version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@
 * Adhere to an 80 character line length limit where possible.
 * Add comments where possible and clearly explain any new rules.
 * Comments must not appear between chained rules and should instead be placed before the start of a rule chain.
-* All [chained rules](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-%28v2.x%29#chain) should be indented like so, for readability:
+* All [chained rules](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-(v2.x)#chain) should be indented like so, for readability:
 ```
 SecRule .. .. \
     "..."
@@ -436,6 +436,22 @@ encoded_request: "R0VUIFwgSFRUUA0KDQoK"
 where `R0VUIFwgSFRUUA0KDQoK` is the base64-encoded equivalent of `GET \ HTTP\r\n\r\n`.
 
 The older method of using `raw_request` is deprecated as it's difficult to maintain and less portable than `encoded_request`.
+
+### Using The Correct HTTP Endpoint
+
+The CRS project uses [kennthreitz/httpbin](https://hub.docker.com/r/kennethreitz/httpbin) as the backend server for tests. This backend provides one dedicated endpoint for each HTTP method. Tests should target these endpoints to:
+
+- improve test throughput (prevent HTML from being returned by the backend)
+- add automatic HTTP method verification (the backend will respond with status code `405` (method not allowed) to requests whose method does not match the endpoint)
+
+Test URIs should be structured as follows, where `<method>` must be replaced by the name of the HTTP method the test uses:
+
+```yaml
+#...
+          method: <method>
+          uri: /<method>/some/arbitrary/url
+#...
+```
 
 ## Further Guidance on Rule Writing
 


### PR DESCRIPTION
PR brings the CONTRIBUTING.MD document in the core CRS repo back in line with the HTML version over in the CRS documentation repo. (New content added regarding tests; made a hyperlink consistent across both versions.)