### PR TITLE
fix: perf rule 941010

### DIFF
--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -60,7 +60,7 @@ SecRule REQUEST_FILENAME "!@validateByteRange 20, 45-47, 48-57, 65-90, 95, 97-12
     pass,\
     t:none,\
     nolog,\
-    ctl:ruleRemoveTargetById=941100-941999;REQUEST_FILENAME"
+    ctl:ruleRemoveTargetByTag=xss-perf-disable;REQUEST_FILENAME"
 
 
 #
@@ -114,6 +114,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
@@ -143,6 +144,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
@@ -171,6 +173,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
@@ -203,6 +206,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
@@ -227,6 +231,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
@@ -253,6 +258,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
@@ -279,6 +285,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
@@ -300,6 +307,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
@@ -321,6 +329,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
@@ -342,6 +351,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
@@ -363,6 +373,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
@@ -384,6 +395,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
@@ -405,6 +417,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
@@ -426,6 +439,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
@@ -447,6 +461,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
@@ -468,6 +483,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
@@ -489,6 +505,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
@@ -510,6 +527,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
@@ -569,6 +587,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-tomcat',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
@@ -598,6 +617,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-internet-explorer',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
@@ -639,6 +659,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242/63',\
@@ -666,6 +687,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS|REQU
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242/63',\
@@ -697,6 +719,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
@@ -726,6 +749,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
@@ -756,6 +780,7 @@ SecRule REQUEST_FILENAME|REQUEST_HEADERS:Referer "@detectXSS" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     tag:'paranoia-level/2',\
@@ -789,6 +814,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
@@ -814,6 +840,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     tag:'paranoia-level/2',\
@@ -841,6 +868,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
@@ -927,6 +955,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242/63',\
     tag:'PCI/6.5.1',\
@@ -948,6 +977,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     tag:'PCI/6.5.1',\
@@ -972,6 +1002,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     tag:'PCI/6.5.1',\
@@ -1005,6 +1036,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242/63',\
     tag:'paranoia-level/2',\

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -47,8 +47,8 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:941012,phase:2,pass,nolog,skipAf
 # - ascii 95 (underscore)
 # - ascii 97-122 (a-z)
 #
-# If just these characters are present, we remove REQUEST_FILENAME from the target
-# list of all the 941xxx rules starting 941100.
+# If just these characters are present, we make use of a special tag to remove
+# REQUEST_FILENAME from the target list of all the 941xxx rules starting 941100.
 #
 # Please note that it would be preferable to start without REQUEST_FILENAME in the
 # target list and to add it on a case to case base, but the rule language does not
@@ -88,6 +88,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-xss',\
+    tag:'xss-perf-disable',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\


### PR DESCRIPTION
To address the compatibility issue between v2 and v3, this pull request removes the 'range' component from 941010 in favor of using `ruleRemoveTargetByTag`