### PR TITLE
fix: moves FP prone phrase `file size is` to PL2

### DIFF
--- a/rules/php-errors-pl2.data
+++ b/rules/php-errors-pl2.data
@@ -1,5 +1,6 @@
 # For more information, see comments at the beginning of the php-errors.data file.
 
+File size is
 Invalid date
 Static function
 The function

--- a/rules/php-errors.data
+++ b/rules/php-errors.data
@@ -1782,7 +1782,6 @@ Failed to set up data channel:
 Failed to stat
 Fatal error:
 File cached script loaded into memory '
-File size is
 Flexible array member in union at line
 Flexible array member not at end of struct at line
 Forced restart at

--- a/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
+++ b/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
@@ -25,3 +25,63 @@ tests:
             data: "Maximum allowed file size is 10 MB"
           output:
             no_log_contains: id "953100"
+  - test_title: 953100-2
+    desc: "'Invalid date' Wordpress FP, it should not match at PL1"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP CRS test agent"
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Accept-Encoding: "gzip,deflate"
+              Accept-Language: "en-us,en;q=0.5"
+              Content-Type: "text/plain"
+            method: "GET"
+            version: "HTTP/1.0"
+            uri: "/anything"
+            data: "Invalid date selected"
+          output:
+            no_log_contains: id "953100"
+  - test_title: 953100-3
+    desc: "'The function' might lead to FPs, it should not match at PL1"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP CRS test agent"
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Accept-Encoding: "gzip,deflate"
+              Accept-Language: "en-us,en;q=0.5"
+              Content-Type: "text/plain"
+            method: "GET"
+            version: "HTTP/1.0"
+            uri: "/anything"
+            data: "please review the function"
+          output:
+            no_log_contains: id "953100"
+  - test_title: 953100-4
+    desc: "'Static function' might lead to FPs, it should not match at PL1"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP CRS test agent"
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Accept-Encoding: "gzip,deflate"
+              Accept-Language: "en-us,en;q=0.5"
+              Content-Type: "text/plain"
+            method: "GET"
+            version: "HTTP/1.0"
+            uri: "/anything"
+            data: "This is a static function"
+          output:
+            no_log_contains: id "953100"

--- a/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
+++ b/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
@@ -1,0 +1,27 @@
+---
+meta:
+  author: "M4tteoP"
+  enabled: true
+  name: "953100.yaml"
+  description: "Tests for rule 953100"
+tests:
+  - test_title: 953100-1
+    desc: "'File size is' leads to FPs, it should not match at PL1"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP CRS test agent"
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Accept-Encoding: "gzip,deflate"
+              Accept-Language: "en-us,en;q=0.5"
+              Content-Type: "text/plain"
+            method: "GET"
+            version: "HTTP/1.0"
+            uri: "/anything"
+            data: "Maximum allowed file size is 10 MB"
+          output:
+            no_log_contains: id "953100"

--- a/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953101.yaml
+++ b/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953101.yaml
@@ -1,0 +1,27 @@
+---
+meta:
+  author: "M4tteoP"
+  enabled: true
+  name: "953101.yaml"
+  description: "Tests for rule 953101"
+tests:
+  - test_title: 953101-1
+    desc: "'File size is' leads to FPs at PL1, it should match at PL2"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP CRS test agent"
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Accept-Encoding: "gzip,deflate"
+              Accept-Language: "en-us,en;q=0.5"
+              Content-Type: "text/plain"
+            method: "GET"
+            version: "HTTP/1.0"
+            uri: "/anything"
+            data: "Maximum allowed file size is 10 MB"
+          output:
+            log_contains: id "953101"

--- a/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953101.yaml
+++ b/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953101.yaml
@@ -25,3 +25,63 @@ tests:
             data: "Maximum allowed file size is 10 MB"
           output:
             log_contains: id "953101"
+  - test_title: 953101-2
+    desc: "'Invalid date' leads to FPs at PL1, it should match at PL2"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP CRS test agent"
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Accept-Encoding: "gzip,deflate"
+              Accept-Language: "en-us,en;q=0.5"
+              Content-Type: "text/plain"
+            method: "GET"
+            version: "HTTP/1.0"
+            uri: "/anything"
+            data: "Invalid date selected"
+          output:
+            log_contains: id "953101"
+  - test_title: 953101-3
+    desc: "'The function' might lead to FPs at PL1, it should match at PL2"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP CRS test agent"
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Accept-Encoding: "gzip,deflate"
+              Accept-Language: "en-us,en;q=0.5"
+              Content-Type: "text/plain"
+            method: "GET"
+            version: "HTTP/1.0"
+            uri: "/anything"
+            data: "Please review the function"
+          output:
+            log_contains: id "953101"
+  - test_title: 953101-4
+    desc: "'Static function' might lead to FPs at PL1, it should match at PL2"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP CRS test agent"
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Accept-Encoding: "gzip,deflate"
+              Accept-Language: "en-us,en;q=0.5"
+              Content-Type: "text/plain"
+            method: "GET"
+            version: "HTTP/1.0"
+            uri: "/anything"
+            data: "This is a static function"
+          output:
+            log_contains: id "953101"


### PR DESCRIPTION
`File size is` phrase leads to false positives. [It has been agreed](https://github.com/coreruleset/coreruleset/issues/3279#issuecomment-1724191613) to move it from `rules/php-errors.data` to `rules/php-errors-pl2.data`. Now it will be matched by `953101`, at PL2. 

Closes https://github.com/coreruleset/coreruleset/issues/3304