### PR TITLE
Update REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf

### DIFF
--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -200,7 +200,7 @@ SecRule REQUEST_FILENAME "@rx /(?:remote|index|public)\.php/" \
     t:none,\
     nolog,\
     ver:'OWASP_CRS/3.3.5',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT PATCH CHECKOUT COPY DELETE LOCK MERGE MKACTIVITY MKCOL MOVE PROPFIND PROPPATCH UNLOCK REPORT TRACE jsonp'"
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT PATCH CHECKOUT COPY DELETE LOCK MERGE MKACTIVITY MKCOL MOVE PROPFIND PROPPATCH UNLOCK REPORT TRACE SEARCH jsonp'"
 
 
 # We need to allow DAV methods for sharing files, and removing shares


### PR DESCRIPTION
Method SEARCH is needed for Nextcloud image gallery. If not set, images are not shown and you get the error

`[Wed Oct 11 11:55:13.159009 2023] [security2:error] [pid 1587527:tid 139948802578176] [remote xxx.xxx.xxx.xxx.:46886] [client xxx.xxx.xxx.xxx] ModSecurity: Access denied with code 403 (phase 2). Match of "within %{tx.allowed_methods}" against "REQUEST_METHOD" required. [file "/usr/local/pd-admin2/httpd-2.4/conf/coreruleset-current/rules/REQUEST-911-METHOD-ENFORCEMENT.conf"] [line "44"] [id "911100"] [msg "Method is not allowed by policy"] [data "SEARCH"] [severity "CRITICAL"] [ver "OWASP_CRS/3.3.5"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-generic"] [tag "paranoia-level/1"] [tag "OWASP_CRS"] [tag "capec/1000/210/272/220/274"] [tag "PCI/12.1"] [hostname "cloud.cajus.name"] [uri "/remote.php/dav/"] [unique_id "ZSZxAZ2_w6VradUXudZIrgAAOhA"]`