### PR TITLE
feat: Reuse rule ID's 950011, 950012 and 950018 for consistent operation

### DIFF
--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -23,8 +23,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:950010,phase:3,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:950011,phase:4,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:950011,phase:3,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:950012,phase:4,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #

--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -15,7 +15,7 @@
 # identifiers again, so that the skip rules of PL can be defined in the
 # same way for all files.
 # Rule id 950130 has been kept - this ID also was introduced at first
-# rule to avoid the collosion.
+# rule to avoid the collision.
 
 #
 # -= Paranoia Level 0 (empty) =- (apply unconditionally)

--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -8,10 +8,14 @@
 # Please see the enclosed LICENSE file for full details.
 # ------------------------------------------------------------------------
 
-# The paranoia level skip rules 950020, 950021 and 950022 have odd
-# numbers not in sync with other paranoia level skip rules in other
-# files. This is done to avoid rule id collisions with CRSv2.
-# This is also true for rule 950130.
+# We reused paranoia level skip rules 950010, 950011, and 950018.
+# These rule identifiers were in use in CRSv2, so we used different
+# identifiers in CRSv3 to avoid conflicts (950020, 950021 and 950022).
+# In CRSv4, for the sake of a consistent structure, we use these
+# identifiers again, so that the skip rules of PL can be defined in the
+# same way for all files.
+# Rule id 950130 has been kept - this ID also was introduced at first
+# rule to avoid the collosion.
 
 #
 # -= Paranoia Level 0 (empty) =- (apply unconditionally)
@@ -19,8 +23,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:950020,phase:3,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:950021,phase:4,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:950010,phase:3,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:950011,phase:4,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -121,7 +125,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:950016,phase:4,pass,nolog,skipAf
 
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:950017,phase:3,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:950022,phase:4,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:950018,phase:4,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #


### PR DESCRIPTION
We reused paranoia level skip rules 950010, 950011, and 950018.

These rule identifiers were in use in CRSv2, so we used different identifiers in CRSv3 to avoid conflicts (950020, 950021 and 950022). In CRSv4, for the sake of a consistent structure, we use these identifiers again, so that the skip rules of PL can be defined in the same way for all files (rule_id MOD 100 < 20).

Rule id 950130 has been kept - this ID also was introduced at first rule to avoid the collision.
