### PR TITLE
fix: move rule back to PL2 where it was originally supposed to be (934101 PL2) (Christian Folini)

### DIFF
--- a/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
+++ b/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
@@ -71,29 +71,6 @@ SecRule REQUEST_FILENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIE
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
-
-SecRule REQUEST_FILENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:close|exists|fork|(?:ope|spaw)n|re(?:ad|quire)|w(?:atch|rite))[\s\v]*\(" \
-    "id:934101,\
-    phase:2,\
-    block,\
-    capture,\
-    t:none,t:urlDecodeUni,t:jsDecode,t:base64Decode,t:urlDecodeUni,t:jsDecode,\
-    msg:'Node.js Injection Attack 2/2',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-javascript',\
-    tag:'platform-multi',\
-    tag:'attack-rce',\
-    tag:'attack-injection-generic',\
-    tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.0.0-rc2',\
-    severity:'CRITICAL',\
-    multiMatch,\
-    setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
-
 # -=[ SSRF Attacks ]=-
 #
 # We provide only partial protection to SSRF. DNS Rebinding attacks needs
@@ -261,6 +238,29 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:934014,phase:2,pass,nolog,skipAf
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
+
+# This rule is a stricter sibling of 934100.
+SecRule REQUEST_FILENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:close|exists|fork|(?:ope|spaw)n|re(?:ad|quire)|w(?:atch|rite))[\s\v]*\(" \
+    "id:934101,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:urlDecodeUni,t:jsDecode,t:base64Decode,t:urlDecodeUni,t:jsDecode,\
+    msg:'Node.js Injection Attack 2/2',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-javascript',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
+    tag:'attack-injection-generic',\
+    tag:'paranoia-level/2',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/242',\
+    ver:'OWASP_CRS/4.0.0-rc2',\
+    severity:'CRITICAL',\
+    multiMatch,\
+    setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # -=[ SSRF Attacks ]=-
 #


### PR DESCRIPTION
This rule was contributed during the 2022 BB.

It was meant to be a stricter sibling, but it resided among the PL1 rules and we did not catch this during the review.

Later in 2022, when we cleaned up PL scoring variable bugs and tags, the rule was re-tagged as PL1 based on the position among the PL1 rules.

This PR moves the rule back to PL2.

This shift is needed so rule 934150 gets an isolated test at PL1 (as long as 934101 remains at PL1, 934101 will always trigger when testing for 934150 since 934101 happens to be a subset of 934150).