### PR TITLE
fix(test): 920181-1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: "Install dependencies"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GO_FTW_VERSION: '0.4.8'
+          GO_FTW_VERSION: '0.6.3'
         run: |
           gh release download -R coreruleset/go-ftw v${GO_FTW_VERSION} -p "ftw_${GO_FTW_VERSION}_linux_amd64.tar.gz" -O - | tar -xzvf - ftw
 

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920181.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920181.yaml
@@ -20,13 +20,9 @@ tests:
               Content-Type: "application/x-www-form-urlencoded"
               Transfer-Encoding: "chunked"
               User-Agent: "OWASP CRS test agent"
-            data: |
-              7
-              foo=bar
-              0
+            data: "7\x0D\x0Afoo=bar\x0D\x0A0\x0D\x0A\x0D\x0A"
             stop_magic: true
           output:
-            # Apache unsets the Content-Length header if
-            # Transfer-Encoding is found!
-            # status: 200 # TODO: currently Apache returns 400, we need to fix raw body handling in go-ftw
+            # Apache unsets the Content-Length header if Transfer-Encoding is found!
+            status: [200]
             no_log_contains: id "920181"

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920181.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920181.yaml
@@ -28,5 +28,5 @@ tests:
           output:
             # Apache unsets the Content-Length header if
             # Transfer-Encoding is found!
-            status: [200]
+            # status: 200 # TODO: currently Apache returns 400, we need to fix raw body handling in go-ftw
             no_log_contains: id "920181"

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920181.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920181.yaml
@@ -12,7 +12,7 @@ tests:
             dest_addr: "127.0.0.1"
             port: 80
             method: "POST"
-            uri: "/"
+            uri: "/anything"
             headers:
               Host: "localhost"
               Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
@@ -28,4 +28,5 @@ tests:
           output:
             # Apache unsets the Content-Length header if
             # Transfer-Encoding is found!
+            status: [200]
             no_log_contains: id "920181"


### PR DESCRIPTION
Fixes 920181-1 pointing to /anything that supports POST requests and ensuring that the response code is `200`.