### PR TITLE
feat: new isolated test 941100-6 (941100 PL1) (Christian Folini)

### DIFF
--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941100.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941100.yaml
@@ -88,12 +88,14 @@ tests:
       - stage:
           input:
             dest_addr: 127.0.0.1
-            method: GET
+            method: POST
             port: 80
-            uri: /get?foo=<xss onbeforehellfreezes%3Daler%77(1)>
+            uri: /post
             headers:
               User-Agent: "OWASP CRS test agent"
               Host: localhost
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            data:
+                foo=<xss onbeforehellfreezes%3Daler%77(1)>
           output:
             log_contains: id "941100"

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941100.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941100.yaml
@@ -82,3 +82,18 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
           output:
             no_log_contains: id "941100"
+  - test_title: 941100-5
+    desc: Status Page Test - simplified XSS testing of libinjection in ARGS
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            method: GET
+            port: 80
+            uri: /get?foo=<xss bar%3Daler%77(1)>
+            headers:
+              User-Agent: "OWASP CRS test agent"
+              Host: localhost
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          output:
+            log_contains: id "941100"

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941100.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941100.yaml
@@ -82,7 +82,7 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
           output:
             no_log_contains: id "941100"
-  - test_title: 941100-5
+  - test_title: 941100-6
     desc: Status Page Test - simplified XSS testing of libinjection in ARGS
     stages:
       - stage:

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941100.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941100.yaml
@@ -90,7 +90,7 @@ tests:
             dest_addr: 127.0.0.1
             method: GET
             port: 80
-            uri: /get?foo=<xss bar%3Daler%77(1)>
+            uri: /get?foo=<xss onbeforehellfreezes%3Daler%77(1)>
             headers:
               User-Agent: "OWASP CRS test agent"
               Host: localhost


### PR DESCRIPTION
Status page test. See https://github.com/coreruleset/coreruleset/issues/3351

The payload used on this test is loosely based on one of the examples on the portswigger XSS cheatsheet.

I took said payload and reduced it and re-encoded it to go around the other rules triggering. 

I also had to pick a JS event name that is not yet in use (or other XSS rule  941160 PL1 would trigger). I think this is warranted since there might always new JS events that 941160 does not yet detect.

So I think the result is a test that is isolated and still triggers on something that might be an attack.