### PR TITLE
fix: PCRE/libModSecurity related issue with regex

### DIFF
--- a/regex-assembly/920260.ra
+++ b/regex-assembly/920260.ra
@@ -1,0 +1,6 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##!+ i
+
+%uff[0-9a-f]{2}

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -456,7 +456,12 @@ SecRule TX:CRS_VALIDATE_UTF8_ENCODING "@eq 1" \
 # https://www.checkpoint.com/defense/advisories/public/2007/cpai-2007-201.html
 # https://github.com/SpiderLabs/owasp-modsecurity-crs/issues/719
 #
-SecRule REQUEST_URI|REQUEST_BODY "@rx \%u[fF]{2}[0-9a-fA-F]{2}" \
+# Regular expression generated from regex-assembly/920260.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 920260
+#
+SecRule REQUEST_URI|REQUEST_BODY "@rx (?i)%uff[0-9a-f]{2}" \
     "id:920260,\
     phase:2,\
     block,\


### PR DESCRIPTION
This PR fixes an issue related to PCRE/libModSecurity that prevents to match "uFF" with `[fF]{2}` regular expression syntax