### PR TITLE
fix: 934131 tfunc sequences

### DIFF
--- a/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
+++ b/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
@@ -318,7 +318,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     phase:2,\
     block,\
     capture,\
-    t:none,t:urlDecodeUni,t:jsDecode,t:base64Decode,t:urlDecodeUni,t:jsDecode,\
+    t:none,t:base64DecodeExt,t:urlDecodeUni,t:jsDecode,t:base64DecodeExt,t:urlDecodeUni,t:jsDecode,\
     msg:'JavaScript Prototype Pollution',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\


### PR DESCRIPTION
libModSecurity fails to base64 decode a string if it contains a whitespace char. It happens when the base64 string contains a `+` that is decoded by `t:urlDecodeUni` transformation function. In this solution I prepend another base64 decode function at the beginning.