### PR TITLE
fix(PHP): Too common phrases matched

### DIFF
--- a/rules/php-errors.data
+++ b/rules/php-errors.data
@@ -2066,8 +2066,10 @@ must be between 0 and
 must be between 2 and
 must be greater than 0 and less than
 must be greater than or equal to
-must be less than
-must be less than or equal to
+# Commented out according to this: https://github.com/coreruleset/coreruleset/issues/3390
+#must be less than
+# Commented out according to this: https://github.com/coreruleset/coreruleset/issues/3390
+#must be less than or equal to
 must be less than or equal to argument #
 # must be of type
 must be of type ?


### PR DESCRIPTION
Fixes #3390.
Fixes https://github.com/coreruleset/wordpress-rule-exclusions-plugin/issues/25.