### PR TITLE
fix: solve false positive by shifting ``Field cannot be empty`` to PL2 (953100 PL1, 953101 PL2) (Esad Cetiner)

### DIFF
--- a/rules/php-errors-pl2.data
+++ b/rules/php-errors-pl2.data
@@ -1,5 +1,6 @@
 # For more information, see comments at the beginning of the php-errors.data file.
 
+cannot be empty
 File size is
 Invalid date
 Static function

--- a/rules/php-errors.data
+++ b/rules/php-errors.data
@@ -833,7 +833,6 @@ cannot be PDO::FETCH_LAZY in PDOStatement::fetchAll()
 cannot be a class constant
 cannot be a recursive array
 cannot be an array when working on a single string
-cannot be empty
 cannot be empty when HMAC is requested
 cannot be null for non-static methods
 cannot be null for the chosen cipher algorithm

--- a/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
+++ b/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "M4tteoP"
+  author: "M4tteoP, Esad Cetiner"
   enabled: true
   name: "953100.yaml"
   description: "Tests for rule 953100"
@@ -83,5 +83,25 @@ tests:
             version: "HTTP/1.0"
             uri: "/anything"
             data: "This is a static function"
+          output:
+            no_log_contains: id "953100"
+  - test_title: 953100-5
+    desc: "'cannot be empty is too common for PL-1 GH isue #3399"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP CRS test agent"
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Accept-Encoding: "gzip,deflate"
+              Accept-Language: "en-us,en;q=0.5"
+              Content-Type: "text/plain"
+            method: "GET"
+            version: "HTTP/1.0"
+            uri: "/anything"
+            data: "Field cannot be empty."
           output:
             no_log_contains: id "953100"

--- a/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953101.yaml
+++ b/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953101.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "M4tteoP"
+  author: "M4tteoP, Esad Cetiner"
   enabled: true
   name: "953101.yaml"
   description: "Tests for rule 953101"
@@ -85,3 +85,23 @@ tests:
             data: "This is a static function"
           output:
             log_contains: id "953101"
+  - test_title: 953101-5
+    desc: "'cannot be empty is too common for PL-1, it should match at PL-2 GH isue #3399"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP CRS test agent"
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Accept-Encoding: "gzip,deflate"
+              Accept-Language: "en-us,en;q=0.5"
+              Content-Type: "text/plain"
+            method: "GET"
+            version: "HTTP/1.0"
+            uri: "/anything"
+            data: "cannot be empty."
+          output:
+            no_log_contains: id "953101"

--- a/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953101.yaml
+++ b/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953101.yaml
@@ -104,4 +104,4 @@ tests:
             uri: "/anything"
             data: "cannot be empty."
           output:
-            no_log_contains: id "953101"
+            log_contains: id "953101"


### PR DESCRIPTION
closes #3399 