### PR TITLE
fix: Added missing target name to logdata

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -1151,7 +1151,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS|XML:
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/4.0.0-rc2',\
     severity:'CRITICAL',\
-    setvar:'tx.932240_matched_var_name=%{MATCHED_VAR_NAME}',\
+    setvar:'tx.932240_matched_var_name=%{matched_var_name}',\
     chain"
     SecRule MATCHED_VAR "!@rx [0-9]\s*\'\s*[0-9]" \
         "t:none,\

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -482,7 +482,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     capture,\
     t:none,\
     msg:'Remote Command Execution: Direct Unix Command Execution',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{TX.932260_MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-shell',\
     tag:'platform-unix',\
@@ -493,6 +493,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/4.0.0-rc2',\
     severity:'CRITICAL',\
+    setvar:'tx.932260_matched_var_name=%{matched_var_name}',\
     chain"
     SecRule MATCHED_VAR "!@rx [0-9]\s*\'\s*[0-9]" \
         "t:none,\
@@ -1139,7 +1140,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS|XML:
     capture,\
     t:none,\
     msg:'Remote Command Execution: Unix Command Injection evasion attempt detected',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{TX.932240_MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-shell',\
     tag:'platform-unix',\
@@ -1150,6 +1151,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS|XML:
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/4.0.0-rc2',\
     severity:'CRITICAL',\
+    setvar:'tx.932240_matched_var_name=%{MATCHED_VAR_NAME}',\
     chain"
     SecRule MATCHED_VAR "!@rx [0-9]\s*\'\s*[0-9]" \
         "t:none,\


### PR DESCRIPTION
There is an issue reported by @EsadCetiner on [Slack](https://owasp.slack.com/archives/CBKGH8A5P/p1702120465984659), namely in case of rule [932240](https://github.com/coreruleset/coreruleset/blob/d544d8d2ee1c739612958bf3c5a9c7bfc29f35bf/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf#L1135-L1157) triggering the target is not in the log - that is, it is there, but only the `MATCHED_VAR`.

The solution is the same as we use at rules [932206](https://github.com/coreruleset/coreruleset/blob/d544d8d2ee1c739612958bf3c5a9c7bfc29f35bf/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf#L1039-L1057) and [932200](https://github.com/coreruleset/coreruleset/blob/d544d8d2ee1c739612958bf3c5a9c7bfc29f35bf/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf#L961-L980): set a new TX variable by value of `MATCHED_VAR_NAME`, wich used in the `logdata` argument.

There is no other affected rule (which uses this format of `logdata` and later uses that target).


changelog comment:

fix: Added missing target name to logdata (932260 PL1, 932240 PL2) (Ervin Hegedüs)
