### PR TITLE
fix: Added t:urlDecodeUni for REQUEST_URI / REQUEST_BASENAME checks in phase 1 (921240 PL1, 920440 PL1, 920201 PL2, 920202 PL4)

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1074,7 +1074,7 @@ SecRule REQUEST_BASENAME "@rx \.([^.]+)$" \
     phase:1,\
     block,\
     capture,\
-    t:none,\
+    t:none,t:urlDecodeUni,\
     msg:'URL file extension is restricted by policy',\
     logdata:'%{TX.0}',\
     tag:'application-multi',\
@@ -1368,7 +1368,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     "id:920201,\
     phase:1,\
     block,\
-    t:none,\
+    t:none,t:urlDecodeUni,\
     msg:'Range: Too many fields for pdf request (63 or more)',\
     logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\
@@ -1725,7 +1725,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     "id:920202,\
     phase:1,\
     block,\
-    t:none,\
+    t:none,t:urlDecodeUni,\
     msg:'Range: Too many fields for pdf request (6 or more)',\
     logdata:'%{MATCHED_VAR}',\
     tag:'application-multi',\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -290,7 +290,7 @@ SecRule REQUEST_URI "@rx unix:[^|]*\|" \
     phase:1,\
     block,\
     capture,\
-    t:none,t:lowercase,\
+    t:none,t:urlDecode,t:lowercase,\
     msg:'mod_proxy attack attempt detected',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920201.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920201.yaml
@@ -21,3 +21,19 @@ tests:
             uri: /index.pdf
           output:
             log_contains: id "920201"
+  - test_title: 920201-2
+    desc: This should FAIL with rule 920201 (PL2), filename URI encoded
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              Range: "bytes=10-11, 20-21, 30-31, 40-41, 50-51, 60-61, 70-71, 80-81, 90-91, 100-101, 110-11, 120-21, 130-31, 140-41, 150-51, 160-61, 170-71, 180-81, 190-91, 200-101, 210-11, 220-21, 230-31, 240-41, 250-51, 260-61,  270-71, 280-81, 290-91, 300-101, 310-311, 320-321, 330-331, 340-341, 350-351, 360-361, 370-371, 380-381, 390-391, 400-401, 410-411, 420-421, 430-431, 440-441, 450-451, 460-461, 470-471, 480-481, 490-491, 500-501, 510-511, 520-521, 530-531, 540-541, 550-551, 560-561, 570-571, 580-581, 590-591, 600-601, 610-611, 620-621, 630-631"
+              User-Agent: "OWASP CRS test agent"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: /index%2Epdf
+          output:
+            log_contains: id "920201"

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920202.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920202.yaml
@@ -21,3 +21,19 @@ tests:
             uri: /index.pdf
           output:
             log_contains: id "920202"
+  - test_title: 920202-2
+    desc: This should FAIL with rule 920202 (PL4), file name URI encoded
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              Range: "bytes=10-11, 20-21, 30-31, 40-41, 50-51, 60-61"
+              User-Agent: "OWASP CRS test agent"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: /index%2Epdf
+          output:
+            log_contains: id "920202"

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920440.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920440.yaml
@@ -105,3 +105,23 @@ tests:
             version: HTTP/1.1
           output:
             log_contains: id "920440"
+  - test_title: 920440-6
+    desc: Redis dump file, URI encoded
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Accept-Encoding: gzip,deflate
+              Accept-Language: en-us,en;q=0.5
+              Host: localhost
+              Keep-Alive: "300"
+              Proxy-Connection: keep-alive
+              User-Agent: "OWASP CRS test agent"
+            method: GET
+            port: 80
+            uri: /dump%2Erdb
+            version: HTTP/1.1
+          output:
+            log_contains: id "920440"

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921240.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921240.yaml
@@ -19,3 +19,17 @@ tests:
             uri: "/?unix:AAAAAAAAA|http://coreruleset.org/"
           output:
             log_contains: id "921240"
+  - test_title: 921240-2
+    desc: "Detect attacks against mod_proxy: CVE-2021-40438, URI encoded"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP CRS test agent"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            uri: "/?unix%3AAAAAAAAAA|http://coreruleset.org/"
+          output:
+            log_contains: id "921240"


### PR DESCRIPTION
## The problem

This applies to variables for `REQUEST_URI`, `REQUEST_BASENAME` and `REQUEST_FILENAME`.

ModSec3 does an implicit URL decoding on phase 1 and the same on phase 2.

ModSec2 does no implicit URL decoding on phase 1, but it does it on phase 2.

This allows an attacker to URL encode a URI and bypass detection on phase 1 rules on ModSec2.

Example:  920440 PL1 should detect this: `/dump%2Erdb` as an encoded version of `dump.rdb`.
However it fails do to so in the v4 dev tree.

It used to work up to CRS v3.3, because rule 920440 used to run in phase 2, but when we introduced early blocking for CRS v4, we shifted 920440 and several other rules from phase 2 to phase 1 and the implicit decoding of the payload (see above) was removed for ModSec 2 and we no longer detected the attack.

Unfortunately, this behavior difference did not surface, since we apparently did not have any test for URL encoded payloads where it mattered.

## The Solution

This is a behavior difference that would ideally be fixed in the engine, but it is not quite clear what the right behavior would be given the difference between ModSec2 and ModSec3 and chances are waiting for a fix could delay CRS v4.

So this PR adds the `t:urlDecodeUni` transformation to the rules inspecting `REQUEST_URI` and `REQUEST_BASENAME` in phase 1. None of the rules targetting `REQUEST_FILENAME` is affected, though.

## Implementation

I added the `t:urlDecodeUni` transformation following other rules where this is already done. For the 4 rules affected, I also did a new test with an encoded payload that is now detected on ModSec2.

When thinking about URL encoding, namely of the URI, it makes sense to also look into 920220, which I cover in a separate PR (#3410). This rule looks for invalid URL encoding. The rule is working on `REQUEST_URI`, but think this is wrong. The PR mentioned shifts the target to `REQUEST_URI_RAW`.

Once CRSv4 is out, we may want to look into getting the engines in sync again and looking into systematic coverage of these encoding issues while also addressing double-encoding (an area where we have spotty coverage now).

But for the time being, I think this has got us covered for CRS v4.

I'm adding the `do not merge` label, so we can discuss this or alternative approaches to this problem in the next CRS chat.



## List of rules carrying any of the targets named

```
Rules with target REQUEST_URI

920260 PL1      not affected (phase 2)
920270 PL1      not affected (phase 2)
920450 PL1      not affected (phase 2)
920271 PL2      not affected (phase 2)
920272 PL3      not affected (phase 2)
920460 PL4      not affected (phase 2)
921240 PL1      affected, fixed, new test 921240-2
930100 PL1      not affected (phase 2)
930110 PL1      not affected (phase 2)
933131 PL3      not affected (phase 2)

Rules with target REQUEST_BASENAME
920440 PL1      affected, fixed, new test 920440-6
920200 PL2      not affected (REQUEST_BASENAME is only used to ignore .pdf)
920201 PL2      affected, fixed, new test 920201-2
920202 PL4      affected, fixed, new test 920202-2
942101 PL2      not affected (t:urlDecodeUni already applied)
942160 PL1      not affected (t:urlDecodeUni already applied)

Rules with target REQUEST_FILENAME
920250 PL1      not affected (phase 2)
920500 PL1      not affected (t:urlDecodeUni already applied) 
921190 PL1      not affected (t:urlDecodeUni already applied)
930130 PL1      not affected (t:urlDecodeUni already applied)
931131 PL1      not affected (t:urlDecodeUni already applied)
933150 PL1      not affected (phase 2)
933160 PL1      not affected (phase 2)
933180 PL1      not affected (phase 2)
933210 PL1      not affected (phase 2)
933151 PL2      not affected (phase 2)
933161 PL3      not affected (phase 2)
933211 PL3      not affected (phase 2)
934100 PL1      not affected (phase 2)
934110 PL1      not affected (phase 2)
934160 PL1      not affected (phase 2)
934170 PL1      not affected (phase 2)
934101 PL2      not affected (phase 2)
934120 PL2      not affected (phase 2)
941010 ADMIN    not affected (rules does not apply when it encounters % in URI)
941110 PL1      not affected (phase 2)
941130 PL1      not affected (phase 2)
941140 PL1      not affected (phase 2)
941160 PL1      not affected (phase 2)
941170 PL1      not affected (phase 2)
941180 PL1      not affected (phase 2)
941190 PL1      not affected (phase 2)
941200 PL1      not affected (phase 2)
941210 PL1      not affected (phase 2)
941220 PL1      not affected (phase 2)
941230 PL1      not affected (phase 2)
941240 PL1      not affected (phase 2)
941250 PL1      not affected (phase 2)
941260 PL1      not affected (phase 2)
941270 PL1      not affected (phase 2)
941280 PL1      not affected (phase 2)
941290 PL1      not affected (phase 2)
941300 PL1      not affected (phase 2)
941310 PL1      not affected (phase 2)
941350 PL1      not affected (phase 2)
941360 PL1      not affected (phase 2)
941370 PL1      not affected (phase 2)
941390 PL1      not affected (phase 2)
941400 PL1      not affected (phase 2)
941101 PL2      not affected (t:urlDecodeUni already applied)
941120 PL2      not affected (phase 2)
941150 PL2      not affected (phase 2)
941181 PL2      not affected (phase 2)
941320 PL2      not affected (phase 2)
941330 PL2      not affected (phase 2)
941340 PL2      not affected (phase 2)
941380 PL2      not affected (phase 2)
942550 PL1      not affected (phase 2)
942110 PL2      not affected (phase 2)
942120 PL2      not affected (phase 2)
942101 PL2      not affected (t:urlDecodeUni already applied)
944130 PL2      not affected (phase 2)
```