### PR TITLE
fix: detect MySQL optimizer hints

### DIFF
--- a/regex-assembly/942500.ra
+++ b/regex-assembly/942500.ra
@@ -1,0 +1,9 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##!> define comment-contents (?:[\w\s=_\-()]+)
+##!> define c-style-modifiers \s*?[!+]
+
+##!+ i
+
+/\*{{c-style-modifiers}}{{comment-contents}}?\*/

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -502,7 +502,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # The minimal string that triggers this regexp is: /*!*/ or /*+*/.
 # The rule 942500 is related to 942440 which catches both /*! and */ independently.
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:/\*[!+](?:[\w\s=_\-()]+)?\*/)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)/\*[\s\v]*?[!\+](?:[\s\v\(-\)\-0-9=A-Z_a-z]+)?\*/" \
     "id:942500,\
     phase:2,\
     block,\
@@ -520,6 +520,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'PCI/6.5.2',\
     ver:'OWASP_CRS/4.0.0-rc2',\
     severity:'CRITICAL',\
+    multiMatch,\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -502,6 +502,11 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # The minimal string that triggers this regexp is: /*!*/ or /*+*/.
 # The rule 942500 is related to 942440 which catches both /*! and */ independently.
 #
+# Regular expression generated from regex-assembly/942500.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 942500
+#
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)/\*[\s\v]*?[!\+](?:[\s\v\(-\)\-0-9=A-Z_a-z]+)?\*/" \
     "id:942500,\
     phase:2,\

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942500.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942500.yaml
@@ -1,12 +1,12 @@
 ---
 meta:
-  author: "Franziska Buehler"
-  description: None
+  author: "Franziska Buehler, Max Leske"
+  description: "Detection of MySQL injection evasion attempts using special comments"
   enabled: true
   name: 942500.yaml
 tests:
   - test_title: 942500-1
-    desc: "MySQL in-line comment detection"
+    desc: "Use of portability comment (/*!...*/) as evasion technique"
     stages:
       - stage:
           input:
@@ -22,6 +22,52 @@ tests:
           output:
             log_contains: id "942500"
   - test_title: 942500-2
+    desc: "Use of portability comment (/*!...*/) as evasion technique, with space before !"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: "OWASP CRS test agent"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/?id=9999+or+{if+length((/*+!5000select+username/*!50000from*/user+where+id=1))>0}"
+            version: HTTP/1.0
+          output:
+            log_contains: id "942500"
+  - test_title: 942500-3
+    desc: "Use of optimizer hints (/*+...*/) as evasion technique"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: "OWASP CRS test agent"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/get?test=9999+or+%2F*%2Boptimizer+hint+*%2F+true"
+          output:
+            log_contains: id "942500"
+  - test_title: 942500-4
+    desc: "Use of optimizer hints (/*+...*/) as evasion technique with space before +"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: "OWASP CRS test agent"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: GET
+            port: 80
+            uri: "/get?test=9999+or+%2F*+%2Boptimizer+hint+*%2F+true"
+          output:
+            log_contains: id "942500"
+  - test_title: 942500-5
     desc: "Status Page Test - MySQL inline comment detected"
     stages:
       - stage:


### PR DESCRIPTION
- Detection of optimizer hint comments in MySQL was broken because of the use of `urlDecodeUni`, which converted the `+` character into a space. The rule now uses `multiMatch` to detect the `+` character with and without URL encoding
- The original rule did not take into account that whitespace is optional before the comment modifiers. This comment fixes that issue.

Fixes #3359