### PR TITLE
fix: fix whitespace matching after PHP command (933160 PL1)

### DIFF
--- a/regex-assembly/933160.ra
+++ b/regex-assembly/933160.ra
@@ -10,7 +10,7 @@
 ##! match comments: `/*...*/`, `//...`, `#...`
 ##!$ (?:/\*.*\*/|//.*|#.*
 ##! match white space and quotes
-##!$ \s|\")*
+##!$ |\s|\")*
 
 ##! optional quotes
 ##!$ ['\"]*

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -328,7 +328,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 933160
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\b\(?[\"']*(?:assert(?:_options)?|c(?:hr|reate_function)|e(?:val|x(?:ec|p))|file(?:group)?|glob|i(?:mage(?:gif|(?:jpe|pn)g|wbmp|xbm)|s_a)|md5|o(?:pendir|rd)|p(?:assthru|open|rev)|(?:read|tmp)file|un(?:pac|lin)k|s(?:tat|ubstr|ystem))(?:/(?:\*.*\*/|/.*)|#.*[\s\v]|\")*[\"']*\)?[\s\v]*\(.*\)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\b\(?[\"']*(?:assert(?:_options)?|c(?:hr|reate_function)|e(?:val|x(?:ec|p))|file(?:group)?|glob|i(?:mage(?:gif|(?:jpe|pn)g|wbmp|xbm)|s_a)|md5|o(?:pendir|rd)|p(?:assthru|open|rev)|(?:read|tmp)file|un(?:pac|lin)k|s(?:tat|ubstr|ystem))(?:/(?:\*.*\*/|/.*)|#.*|[\s\v\"])*[\"']*\)?[\s\v]*\(.*\)" \
     "id:933160,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933160.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933160.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: lifeforms, Franziska Bühler
+  author: lifeforms, Franziska Bühler, Max Leske
   description: None
   enabled: true
   name: 933160.yaml
@@ -442,6 +442,22 @@ tests:
       - stage:
           input:
             data: cmd=("system")("whoami")
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: "OWASP CRS test agent"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            method: POST
+            port: 80
+            uri: /
+          output:
+            log_contains: id "933160"
+  - test_title: 933160-29
+    desc: system call in double quotes and parentheses, multiple spaces after command
+    stages:
+      - stage:
+          input:
+            data: cmd=("system  ")("whoami")
             dest_addr: 127.0.0.1
             headers:
               Host: localhost


### PR DESCRIPTION
A missing alternation in the regular expression for matching characters after PHP commands caused `#` comments and whitespace to be matched improperly.

This issue was discovered as part of #3201.