### PR TITLE
chore: try to fix draft nightlies by using GH CLI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,26 +12,28 @@ jobs:
       - name: "Checkout repo"
         uses: actions/checkout@v4
 
-      - name: "Remove nightly tag before creating new release (ensures that tag is updated)"
-        uses: dev-drprasad/delete-tag-and-release@v0.2.1
-        with:
-          delete_release: true
-          tag_name: nightly
+      - name: Delete previous nightly release
+        run: |
+          gh release delete --repo coreruleset/coreruleset --cleanup-tag --yes nightly
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Deploy using Release Action
-        uses: ncipollo/release-action@v1
-        with:
-          name: Latest Nightly
-          tag: nightly
-          commit: v4.0/dev
-          allowUpdates: true
-          prerelease: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-          body: |
-            Nightly releases are snapshots of the development activity on the Core Rule Set project that may include new features and bug fixes scheduled for upcoming releases. These releases are made available to make it easier for users to test their existing configurations against the Core Rule Set code base for potential issues or to experiment with new features, with a chance to provide feedback on ways to improve the changes before being released.
+      - name: Create nightly release
+        run: |
+          read -r -d '' notes <<"EOF"
+          Nightly releases are snapshots of the development activity on the Core Rule Set project that may include new features and bug fixes scheduled for upcoming releases. These releases are made available to make it easier for users to test their existing configurations against the Core Rule Set code base for potential issues or to experiment with new features, with a chance to provide feedback on ways to improve the changes before being released.
 
-            As these releases are snapshots of the latest code, you may encounter an issue compared to the latest stable release so users are encouraged to run nightly releases in a non production environment. If you encounter an issue, please check our issue tracker to see if the issue has already been reported; if a report hasn't been made, please report it so we can review the issue and make any needed fixes.
+          As these releases are snapshots of the latest code, you may encounter an issue compared to the latest stable release so users are encouraged to run nightly releases in a non production environment. If you encounter an issue, please check our issue tracker to see if the issue has already been reported; if a report hasn't been made, please report it so we can review the issue and make any needed fixes.
 
-            **Note:** Nightly releases using release action are only available via GitHub.
+          **Note:** Nightly releases using release action are only available via GitHub.
+          EOF
+
+          gh release create \
+            --repo coreruleset/coreruleset \
+            --latest \
+            --prerelease \
+            --title "Latest Nightly" \
+            --notes "${notes}" \
+            nightly
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The actions we've been using to publish the nightly release sometimes publish the nightly as draft and we have no idea why. We're now simply using the GH CLI to do the same thing. If that continues to be problematic it will hopefully be simpler to debug.