### PR TITLE
chore: debug nightly release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,12 +20,11 @@ jobs:
 
       - name: Create nightly release
         run: |
+          set -x
           read -r -d '' notes <<"EOF"
           Nightly releases are snapshots of the development activity on the Core Rule Set project that may include new features and bug fixes scheduled for upcoming releases. These releases are made available to make it easier for users to test their existing configurations against the Core Rule Set code base for potential issues or to experiment with new features, with a chance to provide feedback on ways to improve the changes before being released.
 
           As these releases are snapshots of the latest code, you may encounter an issue compared to the latest stable release so users are encouraged to run nightly releases in a non production environment. If you encounter an issue, please check our issue tracker to see if the issue has already been reported; if a report hasn't been made, please report it so we can review the issue and make any needed fixes.
-
-          **Note:** Nightly releases using release action are only available via GitHub.
           EOF
 
           gh release create \
@@ -37,3 +36,4 @@ jobs:
             nightly
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_DEBUG: true


### PR DESCRIPTION
The nightly release failed. Running the exact same script on my machine works.