### PR TITLE
fix: don't use `read` for multiline variables

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,12 +20,11 @@ jobs:
 
       - name: Create nightly release
         run: |
-          set -x
-          read -r -d '' notes <<"EOF"
+          notes=$(cat <<"EOF"
           Nightly releases are snapshots of the development activity on the Core Rule Set project that may include new features and bug fixes scheduled for upcoming releases. These releases are made available to make it easier for users to test their existing configurations against the Core Rule Set code base for potential issues or to experiment with new features, with a chance to provide feedback on ways to improve the changes before being released.
 
           As these releases are snapshots of the latest code, you may encounter an issue compared to the latest stable release so users are encouraged to run nightly releases in a non production environment. If you encounter an issue, please check our issue tracker to see if the issue has already been reported; if a report hasn't been made, please report it so we can review the issue and make any needed fixes.
-          EOF
+          EOF)
 
           gh release create \
             --repo coreruleset/coreruleset \
@@ -36,4 +35,3 @@ jobs:
             nightly
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_DEBUG: true


### PR DESCRIPTION
The shell on the runner doesn't accept the `read -r -d '' name` format. Not sure why. I've replaced it with a sub shell expression (tested in a separate repository).