### PR TITLE
chore: verify nightly release state after creation

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,8 @@ jobs:
           Nightly releases are snapshots of the development activity on the Core Rule Set project that may include new features and bug fixes scheduled for upcoming releases. These releases are made available to make it easier for users to test their existing configurations against the Core Rule Set code base for potential issues or to experiment with new features, with a chance to provide feedback on ways to improve the changes before being released.
 
           As these releases are snapshots of the latest code, you may encounter an issue compared to the latest stable release so users are encouraged to run nightly releases in a non production environment. If you encounter an issue, please check our issue tracker to see if the issue has already been reported; if a report hasn't been made, please report it so we can review the issue and make any needed fixes.
-          EOF)
+          EOF
+          )
 
           gh release create \
             --repo coreruleset/coreruleset \
@@ -35,3 +36,19 @@ jobs:
             nightly
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify release state
+        run: |
+          if gh release list --repo coreruleset/coreruleset --exclude-drafts | grep --quiet nightly; then
+            echo "Nightly release was created properly"
+            exit 0
+          fi
+
+          echo "Nightly release was created as draft. Publishing now."
+
+          gh release edit \
+            --repo coreruleset/coreruleset \
+            --latest \
+            --prerelease \
+            --draft false \
+            nightly


### PR DESCRIPTION
The nightly release is still being created as draft sometimes. Add additional step to verify state and publish release if necessary.