### PR TITLE
fix: JSON Unicode reflection for tests

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -69,8 +69,9 @@ services:
     depends_on:
       - backend
 
-  # our test originally targeted www.example.com as backend
-  # and that would do real traffic, to a real site
-  #
   backend:
-    image: docker.io/kennethreitz/httpbin
+    # Use go-httpbin instead of httpbin to ensure that Unicode bytes in JSON
+    # are not reflected as JSON Unicode escape sequences but as the data
+    # actualy sent.
+    image: mccutchen/go-httpbin
+    command: ["/bin/go-httpbin", "-port", "80"]


### PR DESCRIPTION
httpbin does not properly reflect Unicode sequences but returns JSON Unicode escape sequences instead. This can break response tests that rely on the data in the response to be an exact copy of the request data. See https://github.com/coreruleset/go-ftw/issues/198.

This PR switches the backend for tests from httpbin to the go-httpbin port, as the port behaves correctly.