### PR TITLE
feat: add User-Agent of Tsunami Security Scanner

### DIFF
--- a/rules/scanners-user-agents.data
+++ b/rules/scanners-user-agents.data
@@ -86,6 +86,9 @@ sqlmap
 # https://www.cyber.nj.gov/threat-profiles/trojan-variants/sysscan
 sysscan
 
+# https://github.com/google/tsunami-security-scanner
+TsunamiSecurityScanner
+
 w3af.org
 
 # http://www.robotstxt.org/db/webbandit.html


### PR DESCRIPTION
The tool itself is an open source project by Google, though it has been used by the usual suspects to scan various targets.