### PR TITLE
feat(rules): add TsunamiSecurityScanner user-agent

### DIFF
--- a/rules/scanners-user-agents.data
+++ b/rules/scanners-user-agents.data
@@ -86,6 +86,10 @@ sqlmap
 # https://www.cyber.nj.gov/threat-profiles/trojan-variants/sysscan
 sysscan
 
+# Tsunami Security Scanner (OSS Security scanner)
+# https://github.com/google/tsunami-security-scanner
+TsunamiSecurityScanner
+
 w3af.org
 
 # http://www.robotstxt.org/db/webbandit.html


### PR DESCRIPTION
There's a relatively new project https://github.com/google/tsunami-security-scanner/tree/master, however it's already actively used in the wild:

![Screenshot 2024-01-11 at 14 40 04](https://github.com/coreruleset/coreruleset/assets/14996407/baa9bb99-52f7-4e6c-ad72-eff3f424a749)


This adds its user-agent to the ruleset for scanners