### PR TITLE
fix: prevent FP against brackets in User-Agent header

### DIFF
--- a/regex-assembly/932130.ra
+++ b/regex-assembly/932130.ra
@@ -1,15 +1,4 @@
 ##! Please refer to the documentation at
 ##! https://coreruleset.org/docs/development/regex_assembly/.
 
-##! The contents of 932131.ra must match the contents in this file.
-
-\$\(.*\)
-\$\{.*\}
-<\(.*\)
->\(.*\)
-\$\(\(.*\)\)
-
-##! Find wordlist bypasses using [ ] glob characters, like: /e[t]c
-##! Require a / in front to prevent false positives like [text in brackets]
-/\w*\[!.+\]
-/\w*\[.+\]
+##!> include 932130

--- a/regex-assembly/932131.ra
+++ b/regex-assembly/932131.ra
@@ -1,7 +1,7 @@
 ##! Please refer to the documentation at
 ##! https://coreruleset.org/docs/development/regex_assembly/.
 
-##! The contents of 932131.ra must match the contents in this file.
+##! The contents of this file must stay in line with 932130.ra.
 
 \$\(.*\)
 \$\{.*\}

--- a/regex-assembly/932131.ra
+++ b/regex-assembly/932131.ra
@@ -1,4 +1,7 @@
 ##! Please refer to the documentation at
 ##! https://coreruleset.org/docs/development/regex_assembly/.
 
+##! Rule 932131 uses the same regular expression as 932130 on a
+##! different target.
+
 ##!> include 932130

--- a/regex-assembly/932131.ra
+++ b/regex-assembly/932131.ra
@@ -1,15 +1,4 @@
 ##! Please refer to the documentation at
 ##! https://coreruleset.org/docs/development/regex_assembly/.
 
-##! The contents of this file must stay in line with 932130.ra.
-
-\$\(.*\)
-\$\{.*\}
-<\(.*\)
->\(.*\)
-\$\(\(.*\)\)
-
-##! Find wordlist bypasses using [ ] glob characters, like: /e[t]c
-##! Require a / in front to prevent false positives like [text in brackets]
-/\w*\[!.+\]
-/\w*\[.+\]
+##!> include 932130

--- a/regex-assembly/include/932130.ra
+++ b/regex-assembly/include/932130.ra
@@ -1,0 +1,13 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+\$\(.*\)
+\$\{.*\}
+<\(.*\)
+>\(.*\)
+\$\(\(.*\)\)
+
+##! Find wordlist bypasses using [ ] glob characters, like: /e[t]c
+##! Require a / in front to prevent false positives like [text in brackets]
+/\w*\[!.+\]
+/\w*\[.+\]

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -279,14 +279,14 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # $((foo))  Arithmetic expansion
 # /e[t]c    Shell glob expression to bypass wordlists
 #
+# This rule has a stricter sibling: 932131 (PL2) that applies the same regex to User-Agent and Referer
+#
+# This rule is essential to defend against the Log4J / Log4Shell attacks (see also rule 944150)
+#
 # Regular expression generated from regex-assembly/932130.ra.
 # To update the regular expression run the following shell script
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 932130
-#
-# This rule has a stricter sibling: 932131 (PL2) that applies the same regex to User-Agent and Referer
-#
-# This rule is essential to defend against the Log4J / Log4Shell attacks (see also rule 944150)
 #
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \$(?:\((?:.*|\(.*\))\)|\{.*\})|[<>]\(.*\)|/[0-9A-Z_a-z]*\[!?.+\]" \
     "id:932130,\
@@ -910,7 +910,12 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #
 # Unlike the sibling rule, this rule runs in phase 1.
 #
-SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer "@rx (?:\$(?:\((?:\(.*\)|.*)\)|\{.*})|[<>]\(.*\)|\[!?.+\])" \
+# Regular expression generated from regex-assembly/932131.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 932131
+#
+SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer "@rx \$(?:\((?:.*|\(.*\))\)|\{.*\})|[<>]\(.*\)|/[0-9A-Z_a-z]*\[!?.+\]" \
     "id:932131,\
     phase:1,\
     block,\

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932131.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932131.yaml
@@ -17,7 +17,23 @@ tests:
               Host: "localhost"
             method: "GET"
             port: 80
-            uri: "/"
+            uri: "/get"
             protocol: "http"
           output:
             log_contains: id "932131"
+  - test_title: 932131-2
+    desc: False positive against Facebook for Android user agent
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            headers:
+              Accept: "*/*"
+              User-Agent: "mozilla/5.0(linux android 12 sm-a528b build/sp1a.210812.016 wv) applewebkit/537.36(khtml like gecko) version/4.0 chrome/110.0.5481.154 mobile safari/537.36 [fb_iab/fb4a fbav/403.0.0.27.81 ]"
+              Host: "localhost"
+            method: "GET"
+            port: 80
+            uri: "/get"
+            protocol: "http"
+          output:
+            no_log_contains: id "932131"


### PR DESCRIPTION
The Facebook for Android user agent uses a bracket sequence in the user agent string which triggers FPs for rule 932131. The analysis revealed that this issue had already been fixed in 932130, the sibling rule with the same regular expression, but that the regex-assembly file for 932131 did not exist, which is why the regular expression was not updated.

Fixes #3483