### PR TITLE
fix: prevent FPs against click identifiers in query

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -99,7 +99,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #
 # -=[ SQL Function Names ]=-
 #
-# This rule has a stricter sibling to this rule (942152) that checks for SQL function names in 
+# This rule has a stricter sibling to this rule (942152) that checks for SQL function names in
 # request headers referer and user-agent.
 #
 # Regular expression generated from regex-assembly/942151.ra.
@@ -393,7 +393,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
-# This rule has a stricter sibling (942321) that checks for MySQL and PostgreSQL procedures / functions in 
+# This rule has a stricter sibling (942321) that checks for MySQL and PostgreSQL procedures / functions in
 # request headers referer and user-agent.
 #
 # Regular expression generated from regex-assembly/942320.ra.
@@ -1339,6 +1339,33 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"
 
+#
+# -=[ Exclusion rule for 942440 ]=-
+#
+# Prevent FPs against Facebook click identifier
+#
+SecRule ARGS_GET:fbclid "@rx [a-zA-Z0-9_-]{61,61}" \
+    "id:942441,\
+    phase:2,\
+    pass,\
+    t:none,t:urlDecodeUni,\
+    nolog,\
+    ctl:ruleRemoveTargetById=942440;ARGS:fbclid,\
+    ver:'OWASP_CRS/4.0.0-rc2'"
+
+#
+# -=[ Exclusion rule for 942440 ]=-
+#
+# Prevent FPs against Google click identifier
+#
+SecRule ARGS_GET:gclid "@rx [a-zA-Z0-9_-]{91,91}" \
+    "id:942442,\
+    phase:2,\
+    pass,\
+    t:none,t:urlDecodeUni,\
+    nolog,\
+    ctl:ruleRemoveTargetById=942440;ARGS:gclid,\
+    ver:'OWASP_CRS/4.0.0-rc2'"
 
 #
 # -=[ Detect SQL Comment Sequences ]=-
@@ -1406,7 +1433,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
 #
 # Hex encoding detection:
 # (?i:\b0x[a-f\d]{3,}) will match any 3 or more hex bytes after "0x", together forming a hexadecimal payload(e.g 0xf00, 0xf00d and so on)
-# 
+#
 SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:\b0x[a-f\d]{3,})" \
     "id:942450,\
     phase:2,\

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942440.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942440.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "Christian S.J. Peron"
+  author: "Christian S.J. Peron, Max Leske"
   description: None
   enabled: true
   name: 942440.yaml
@@ -305,5 +305,35 @@ tests:
             port: 80
             version: "HTTP/1.1"
             uri: "/callback?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMe--KKF2QT4fwpMeJf36POk6yJV_adQssw-5c"
+          output:
+            no_log_contains: id "942440"
+  - test_title: 942440-19
+    desc: "False positive against Facebook click identifier"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: "OWASP CRS test agent"
+            method: "GET"
+            port: 80
+            version: "HTTP/1.1"
+            uri: "/get/?fbclid=IwAR1dug0BYxe0ukhZ2vKrdQwLAxVFRJ--Q2Y7OBJE_0uId9-Eh-sJWLdVk2E"
+          output:
+            no_log_contains: id "942440"
+  - test_title: 942440-20
+    desc: "False positive against Google click identifier"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: "OWASP CRS test agent"
+            method: "GET"
+            port: 80
+            version: "HTTP/1.1"
+            uri: "/get/?gclid=j0KCQiA1NebBhDDARIsAANiDD3_RJeMv8zScF--mC1jf8fO8PDYJCxD9xdwT7iQ59QIIwL-86ncQtMaAh0lEALw_wcB"
           output:
             no_log_contains: id "942440"

--- a/util/find-rules-without-test/find-rules-without-test.py
+++ b/util/find-rules-without-test/find-rules-without-test.py
@@ -23,7 +23,7 @@ import glob
 import msc_pyparser
 import argparse
 
-EXCLUSION_LIST = ["900", "901", "905", "910", "912", "949", "921170"]
+EXCLUSION_LIST = ["900", "901", "905", "910", "912", "949", "921170", "942441", "942442"]
 oformat = "native"
 
 def find_ids(s, test_cases):


### PR DESCRIPTION
Facebook and Google ad platforms append a query argument to URLs that can contain consecutive sequences of dashes, triggering 942440 in error. This commit adds two rules to exclude these arguments from 942440.

Fixes #2981
Fixes #3005