### PR TITLE
feat: Adding BlockCypher.log into restricted-files.data (930130 PL1)

### DIFF
--- a/rules/restricted-files.data
+++ b/rules/restricted-files.data
@@ -176,6 +176,8 @@ php_errors.log
 WEB-INF/
 # Fortinet SSL VPN session file
 sslvpn_websession
+# BlockCypher log file used in code examples
+BlockCypher.log
 
 # /proc entries (keep in sync with lfi-os-files.data)
 # grep -E "^proc/" lfi-os-files.data


### PR DESCRIPTION
Adding `BlockCypher.log` into `restricted-files.data` which is a log file name used in code examples. Currently actively accessed by bots.