### PR TITLE
feat: move 920240 to PL2

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -386,29 +386,6 @@ SecRule REQUEST_URI "@rx \x25" \
     SecRule REQUEST_URI "@validateUrlEncoding" \
         "setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
-SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)application/x-www-form-urlencoded" \
-    "id:920240,\
-    phase:2,\
-    block,\
-    t:none,\
-    msg:'URL Encoding Abuse Attack Attempt',\
-    logdata:'%{MATCHED_VAR}',\
-    tag:'application-multi',\
-    tag:'language-multi',\
-    tag:'platform-multi',\
-    tag:'attack-protocol',\
-    tag:'paranoia-level/1',\
-    tag:'OWASP_CRS',\
-    tag:'capec/1000/255/153/267/72',\
-    ver:'OWASP_CRS/4.0.0-rc2',\
-    severity:'WARNING',\
-    chain"
-    SecRule REQUEST_BODY "@rx \x25" \
-        "chain"
-        SecRule REQUEST_BODY "@validateUrlEncoding" \
-            "setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
-
-
 #
 # Check UTF encoding
 # We only want to apply this check if UTF-8 encoding is actually used by the site, otherwise
@@ -1529,6 +1506,33 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
     SecRule TX:/^header_name_920451_/ "@within %{tx.restricted_headers_extended}" \
         "setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
+
+#
+# Check URL encodings
+#
+# See comment on rule 920220.
+#
+SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)application/x-www-form-urlencoded" \
+    "id:920240,\
+    phase:2,\
+    block,\
+    t:none,\
+    msg:'URL Encoding Abuse Attack Attempt',\
+    logdata:'%{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    tag:'paranoia-level/2',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/255/153/267/72',\
+    ver:'OWASP_CRS/4.0.0-rc2',\
+    severity:'WARNING',\
+    chain"
+    SecRule REQUEST_BODY "@rx \x25" \
+        "chain"
+        SecRule REQUEST_BODY "@validateUrlEncoding" \
+            "setvar:'tx.inbound_anomaly_score_pl2=+%{tx.warning_anomaly_score}'"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:920015,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:920016,phase:2,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"


### PR DESCRIPTION
We decided that this rule produced too many FPs at paranoia level 1. We were discussing removal but settled for moving the rule to paranoia level 2 for v4 and revisit removal later.

Note: the gist of this rule appears to be protection against errors in application level decoding.