### PR TITLE
fix: reduce FPs in 920220

### DIFF
--- a/regex-assembly/920220-chain1.ra
+++ b/regex-assembly/920220-chain1.ra
@@ -1,0 +1,15 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+
+##!^ ^
+##!$ $
+
+##! grab the path, except for the lat path segment (separate rule)
+(.*)/
+##!=>
+##! skip the last path segment, if there is one
+(?:[^?]+)?
+##!=>
+##! grab the query string, if there is one
+(\?.*)?

--- a/regex-assembly/920220-chain1.ra
+++ b/regex-assembly/920220-chain1.ra
@@ -8,7 +8,7 @@
 ##! grab the path, except for the lat path segment (separate rule)
 (.*)/
 ##!=>
-##! skip the last path segment, if there is one
+##! skip the last path segment, if there is one (non-capturing group)
 (?:[^?]+)?
 ##!=>
 ##! grab the query string, if there is one

--- a/regex-assembly/920221.ra
+++ b/regex-assembly/920221.ra
@@ -1,0 +1,12 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+
+##!^ ^
+##!$ $
+
+##! find any percent character
+.*%.*
+##!=>
+##! followed by something that looks like a file extension
+\.[^\s.]+

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -369,6 +369,11 @@ SecRule REQUEST_HEADERS:Connection "@rx \b(?:keep-alive|close),\s?(?:keep-alive|
 # http://localhost/?s=a%20b%20c%'/
 # reason: %'/ is not a valid url encoding
 #
+# Regular expression generated from regex-assembly/920220-chain1.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 920220-chain1
+#
 SecRule REQUEST_URI_RAW "@rx \x25" \
     "id:920220,\
     phase:1,\
@@ -384,18 +389,23 @@ SecRule REQUEST_URI_RAW "@rx \x25" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/267/72',\
     ver:'OWASP_CRS/4.0.0-rc2',\
-    severity:'WARNING',\
+    severity:'CRITICAL',\
     chain"
     SecRule REQUEST_URI_RAW "@rx ^(.*)/(?:[^\?]+)?(\?.*)?$" \
         "capture,\
         chain"
         SecRule TX:1|TX:2 "@validateUrlEncoding" \
             "t:none,t:urlDecodeUni,\
-            setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
+            setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 # Validate URI encoding of the last path segment, only if it does not look like a file name.
 # A file name could easily contain a '%' character that is not part of a URI encoded sequence.
+#
+# Regular expression generated from regex-assembly/920221.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 920221
 #
 SecRule REQUEST_BASENAME "!@rx ^.*%.*\.[^\s\v\.]+$" \
     "id:920221,\
@@ -413,11 +423,11 @@ SecRule REQUEST_BASENAME "!@rx ^.*%.*\.[^\s\v\.]+$" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/267/72',\
     ver:'OWASP_CRS/4.0.0-rc2',\
-    severity:'WARNING',\
+    severity:'CRITICAL',\
     chain"
     SecRule TX:0 "@validateUrlEncoding" \
         "t:none,t:urlDecodeUni,\
-        setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
+        setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)application/x-www-form-urlencoded" \

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -356,8 +356,11 @@ SecRule REQUEST_HEADERS:Connection "@rx \b(?:keep-alive|close),\s?(?:keep-alive|
 #
 # -=[ Rule Logic ]=-
 # There are two different chained rules.    We need to separate them as we are inspecting two
-# different variables - REQUEST_URI and REQUEST_BODY.   For REQUEST_BODY, we only want to
+# different variables - REQUEST_URI_RAW and REQUEST_BODY.   For REQUEST_BODY, we only want to
 # run the @validateUrlEncoding operator if the content-type is application/x-www-form-urlencoding.
+#
+# We exclude the last path segment from validation because it could be a file name, which could
+# easily contain a '%' character that is not part of a URI encoded sequence.
 #
 # -=[ References ]=-
 # http://www.ietf.org/rfc/rfc1738.txt
@@ -366,13 +369,13 @@ SecRule REQUEST_HEADERS:Connection "@rx \b(?:keep-alive|close),\s?(?:keep-alive|
 # http://localhost/?s=a%20b%20c%'/
 # reason: %'/ is not a valid url encoding
 #
-SecRule REQUEST_URI "@rx \x25" \
+SecRule REQUEST_URI_RAW "@rx \x25" \
     "id:920220,\
     phase:1,\
     block,\
-    t:none,\
+    t:none,t:urlDecodeUni,\
     msg:'URL Encoding Abuse Attack Attempt',\
-    logdata:'%{MATCHED_VAR}',\
+    logdata:'%{REQUEST_URI_RAW}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -383,8 +386,39 @@ SecRule REQUEST_URI "@rx \x25" \
     ver:'OWASP_CRS/4.0.0-rc2',\
     severity:'WARNING',\
     chain"
-    SecRule REQUEST_URI "@validateUrlEncoding" \
-        "setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
+    SecRule REQUEST_URI_RAW "@rx ^(.*)/(?:[^\?]+)?(\?.*)?$" \
+        "capture,\
+        chain"
+        SecRule TX:1|TX:2 "@validateUrlEncoding" \
+            "t:none,t:urlDecodeUni,\
+            setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
+
+
+# Validate URI encoding of the last path segment, only if it does not look like a file name.
+# A file name could easily contain a '%' character that is not part of a URI encoded sequence.
+#
+SecRule REQUEST_BASENAME "!@rx ^.*%.*\.[^\s\v\.]+$" \
+    "id:920221,\
+    phase:1,\
+    block,\
+    capture,\
+    t:none,t:urlDecodeUni,\
+    msg:'URL Encoding Abuse Attack Attempt',\
+    logdata:'%{REQUEST_BASENAME}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/255/153/267/72',\
+    ver:'OWASP_CRS/4.0.0-rc2',\
+    severity:'WARNING',\
+    chain"
+    SecRule TX:0 "@validateUrlEncoding" \
+        "t:none,t:urlDecodeUni,\
+        setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
+
 
 SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)application/x-www-form-urlencoded" \
     "id:920240,\

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920220.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920220.yaml
@@ -1,77 +1,121 @@
 ---
 meta:
-  author: "csanders-git"
+  author: "csanders-git, Max Leske"
   enabled: true
   name: "920220.yaml"
-  description: "Tests to trigger rule 920220"
+  description: "Detect invalid URI encoding in the request URI"
 tests:
-  - # This gets a percent but not a number after, invalid
-    test_title: 920220-1
+  - test_title: 920220-1
+    description: Detect invalid URI encoding in decoded URI (`%w20`)
     stages:
       - stage:
           input:
             dest_addr: "127.0.0.1"
             port: 80
-            uri: "/?x=%w20"
+            uri: "/get?x=%25w20"
             headers:
               User-Agent: "OWASP CRS test agent"
               Host: "localhost"
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
           output:
             log_contains: "id \"920220\""
-  - # We have a valid percent encoding here
-    test_title: 920220-2
+  - test_title: 920220-2
+    description: Detect invalid URI encoding in decoded URI (`%1G`)
     stages:
       - stage:
           input:
             dest_addr: "127.0.0.1"
             port: 80
-            uri: "/?x=xyz%20%99"
+            uri: "/get?x=%251G"
+            headers:
+              User-Agent: "OWASP CRS test agent"
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          output:
+            log_contains: "id \"920220\""
+  - test_title: 920220-3
+    description: Do not trigger for valid URI encoding in decoded URI (`xyz zyx`)
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            uri: "get/?x=xyz%20zyx"
             headers:
               User-Agent: "OWASP CRS test agent"
               Host: "localhost"
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
           output:
             no_log_contains: "id \"920220\""
-  - # url encoding includes spaces as plusses, this is valid
-    test_title: 920220-3
+  - test_title: 920220-4
+    description: Do not trigger for spaces encoded as `+`, which is valid
     stages:
       - stage:
           input:
             dest_addr: "127.0.0.1"
             port: 80
-            uri: "/?test=This+is+a+test"
+            uri: "/get?test=This+is+a+test"
             headers:
               User-Agent: "OWASP CRS test agent"
               Host: "localhost"
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
           output:
             no_log_contains: "id \"920220\""
-  - # testURL Encoding Abuse Attack Attempt from old modsec regressions
-    test_title: 920220-4
+  - test_title: 920220-5
+    description: |
+      Detect incomplete URI encoding sequence (`bxy`, with crippled encoding of `b`).
+      Note that the second character must not complete the `%6` to a valid sequence.
     stages:
       - stage:
           input:
             dest_addr: "127.0.0.1"
             port: 80
-            uri: "/?parm=%7%6F%6D%65%74%65%78%74%5F%31%32%33%"
+            uri: "/get?parm=%6%78%79"
             headers:
               User-Agent: "OWASP CRS test agent"
               Host: "localhost"
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
           output:
             log_contains: "id \"920220\""
-  - # testURL Encoding Abuse Attack Attempt from old modsec regressions
-    test_title: 920220-5
+  - test_title: 920220-6
+    description: Detect incomplete URI encoding sequence, single `%` (`bad%`)
     stages:
       - stage:
           input:
             dest_addr: "127.0.0.1"
             port: 80
-            uri: "/?parm=%1G"
+            uri: "/get?parm=%62%61%64%"
             headers:
               User-Agent: "OWASP CRS test agent"
               Host: "localhost"
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
           output:
             log_contains: "id \"920220\""
+  - test_title: 920220-7
+    description: Do not inspect file names for invalid URI encoding (`Taxes20%Done.txt`)
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            uri: "/get/Taxes20%25Done.txt"
+            headers:
+              User-Agent: "OWASP CRS test agent"
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          output:
+            no_log_contains: "id \"920220\""
+  - test_title: 920220-8
+    description: Do not inspect file names for invalid URI encoding (`Taxes20%Done.txt`), with query
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            uri: "/get/Taxes20%25Done.txt?x%20y"
+            headers:
+              User-Agent: "OWASP CRS test agent"
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          output:
+            no_log_contains: "id \"920220\""

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920221.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920221.yaml
@@ -1,0 +1,35 @@
+---
+meta:
+  author: ", Max Leske"
+  enabled: true
+  name: "920221.yaml"
+  description: "Detect invalid URI encoding in the last path segment of the URI"
+tests:
+  - test_title: 920221-1
+    description: Detect invalid URI encoding in decoded URI (`%w20`)
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            uri: "/get/%25w20"
+            headers:
+              User-Agent: "OWASP CRS test agent"
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          output:
+            log_contains: "id \"920221\""
+  - test_title: 920221-2
+    description: Ignore invalid URI encoding if the last path segment looks like file name (`%w20`)
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            port: 80
+            uri: "/get/%25w20.txt"
+            headers:
+              User-Agent: "OWASP CRS test agent"
+              Host: "localhost"
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          output:
+            no_log_contains: "id \"920221\""


### PR DESCRIPTION
- use `t:urlDecodeUni` to ensure that the URI has been decoded in phase 1
- don't check the last path segment in 920220
- check the last path segment in new rule 920221, only if it does not look like a file name
- fix tests of 920220 to satisfy the following criteria:
  * the raw request URI must have valid encoding
  * if the decoded last path segment is a file it must not be checked for invalid URI encoding
  * validate the decoded URI (except for file name)