### PR TITLE
fix: Removing duplicate keyword (930130 PL1)

### DIFF
--- a/rules/restricted-files.data
+++ b/rules/restricted-files.data
@@ -135,8 +135,6 @@ wp-config.txt
 /composer.json
 /composer.lock
 /packages.json
-# dotenv
-/.env
 # OSX
 /.DS_Store
 # WS FTP


### PR DESCRIPTION
Removing keyword `/.env` as it's already covered by `.env` on line 19.