### PR TITLE
fix: remove chain rule from 932260

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -494,11 +494,8 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     ver:'OWASP_CRS/4.0.0-rc2',\
     severity:'CRITICAL',\
     setvar:'tx.932260_matched_var_name=%{matched_var_name}',\
-    chain"
-    SecRule MATCHED_VAR "!@rx [0-9]\s*\'\s*[0-9]" \
-        "t:none,\
-        setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # [ Unix shell history invocation ]
 #

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932260.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932260.yaml
@@ -445,3 +445,22 @@ tests:
             version: HTTP/1.1
           output:
             log_contains: id "932260"
+  - test_title: 932260-28
+    desc: |
+      Match despite quote evasion attempt.
+      932260 accidentally contained a chain rule for some time that enabled
+      trivial bypasses, by excluding matches against number separators (see 932240).
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              User-Agent: "OWASP CRS test agent"
+              Host: localhost
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+            method: get
+            port: 80
+            uri: /get/?a=whoami;0'0'"
+            version: HTTP/1.1
+          output:
+            log_contains: id "932260"


### PR DESCRIPTION
932260 was copied from 932240, which includes a chain rule to prevent false positives against number separators. This chain rule makes no sense for 932260 and is actually detrimental, as it enables trivial bypasses.