### PR TITLE
fix: Replaced MATCHED_VAR in logdata argument by a real target name

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1519,7 +1519,7 @@ SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/
     capture,\
     t:none,t:urlDecodeUni,\
     msg:'Detects basic SQL authentication bypass attempts 4.1/4',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{TX.942521_MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -1530,6 +1530,7 @@ SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/
     tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.0-rc2',\
     severity:'CRITICAL',\
+    setvar:'tx.942521_matched_var_name=%{matched_var_name}',\
     chain"
     SecRule TX:1 "@rx ^(?:and|or)$" \
         "t:none,\

--- a/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
+++ b/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
@@ -56,7 +56,7 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
     capture,\
     t:none,t:lowercase,\
     msg:'Possible Session Fixation Attack: SessionID Parameter Name with Off-Domain Referer',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{TX.943110_MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -66,6 +66,7 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
     tag:'capec/1000/225/21/593/61',\
     ver:'OWASP_CRS/4.0.0-rc2',\
     severity:'CRITICAL',\
+    setvar:'tx.943110_matched_var_name=%{matched_var_name}',\
     chain"
     SecRule REQUEST_HEADERS:Referer "@rx ^(?:ht|f)tps?://(.*?)/" \
         "capture,\
@@ -82,7 +83,7 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
     capture,\
     t:none,t:lowercase,\
     msg:'Possible Session Fixation Attack: SessionID Parameter Name with No Referer',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{TX.943120_MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\
@@ -92,6 +93,7 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
     tag:'capec/1000/225/21/593/61',\
     ver:'OWASP_CRS/4.0.0-rc2',\
     severity:'CRITICAL',\
+    setvar:'tx.943120_matched_var_name=%{matched_var_name}',\
     chain"
     SecRule &REQUEST_HEADERS:Referer "@eq 0" \
         "setvar:'tx.session_fixation_score=+%{tx.critical_anomaly_score}',\


### PR DESCRIPTION
This PR fixes the listed behaviors under issue #3428. The solution is similar like in case of #3409.

changelog comment:

fix: Added missing target name to logdata (942521 PL2, 943110 PL1, 943120 PL1) (Ervin Hegedüs)

Fixes #3428