### PR TITLE
perf: move 932237, 932205, 932206 and 932161 to phase 1

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -1002,7 +1002,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #
 SecRule REQUEST_HEADERS:Referer "@rx ^[^\.]+\.[^;\?]+[;\?](.*(['\*\?\x5c`][^\n/]+/|/[^/]+?['\*\?\x5c`]|\$[!#-\$\(\*\-0-9\?-\[_a-\{]))" \
     "id:932205,\
-    phase:2,\
+    phase:1,\
     block,\
     capture,\
     t:none,t:lowercase,t:urlDecodeUni,\
@@ -1041,7 +1041,7 @@ SecRule REQUEST_HEADERS:Referer "@rx ^[^\.]+\.[^;\?]+[;\?](.*(['\*\?\x5c`][^\n/]
 #
 SecRule REQUEST_HEADERS:Referer "@rx ^[^\.]*?(?:['\*\?\x5c`][^\n/]+/|/[^/]+?['\*\?\x5c`]|\$[!#-\$\(\*\-0-9\?-\[_a-\{])" \
     "id:932206,\
-    phase:2,\
+    phase:1,\
     block,\
     capture,\
     t:none,t:lowercase,t:urlDecodeUni,\
@@ -1445,7 +1445,7 @@ SecRule REQUEST_HEADERS:Referer|REQUEST_HEADERS:User-Agent "@rx (?i)(?:^|b[\"'\)
 #
 SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer "@pmFromFile unix-shell.data" \
     "id:932161,\
-    phase:2,\
+    phase:1,\
     block,\
     capture,\
     t:none,t:cmdLine,t:normalizePath,\
@@ -1568,7 +1568,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 #
 SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer "@rx (?i)\b(?:7z[arx]?|(?:(?:GE|POS)T|HEAD)[\s\v&\)<>\|]|a(?:(?:b|w[ks]|l(?:ias|pine)|xel)[\s\v&\)<>\|]|pt(?:(?:itude)?[\s\v&\)<>\|]|-get)|r(?:[\s\v&\)<>j\|]|(?:p|ch)[\s\v&\)<>\|]|ia2c)|s(?:h?[\s\v&\)<>\|]|cii(?:-xfr|85)|pell)|t(?:[\s\v&\)<>\|]|obm)|dd(?:group|user)|getty|nsible-playbook)|b(?:z(?:z[\s\v&\)<>\|]|c(?:at|mp)|diff|e(?:grep|xe)|f?grep|ip2(?:recover)?|less|more)|a(?:s(?:e(?:32|64|n(?:ame[\s\v&\)<>\|]|c))|h[\s\v&\)<>\|])|tch[\s\v&\)<>\|])|lkid|pftrace|r(?:eaksw|idge[\s\v&\)<>\|])|sd(?:cat|iff|tar)|u(?:iltin|n(?:dler[\s\v&\)<>\|]|zip2)|s(?:ctl|ybox))|y(?:ebug|obu))|c(?:[8-9]9|(?:a(?:t|ncel|psh)|c)[\s\v&\)<>\|]|mp|p(?:[\s\v&\)<>\|]|io|ulimit)|s(?:h|plit|vtool)|u(?:t[\s\v&\)<>\|]|psfilter)|ertbot|h(?:attr|(?:dir|root)[\s\v&\)<>\|]|eck_(?:by_ssh|cups|log|memory|raid|s(?:sl_cert|tatusfile))|(?:flag|pas)s|g(?:passwd|rp)|mod|o(?:om|wn)|sh)|lang(?:[\s\v&\)<>\|]|\+\+)|o(?:(?:b|pro)c|(?:lumn|m(?:m(?:and)?|p(?:oser|ress)))[\s\v&\)<>\|]|w(?:say|think))|r(?:ash[\s\v&\)<>\|]|on(?:tab)?))|d(?:(?:[du]|i(?:(?:alo)?g|r|ff)|a(?:sh|te))[\s\v&\)<>\|]|n?f|hclient|m(?:esg|idecode|setup)|o(?:as|(?:cker|ne)[\s\v&\)<>\|]|sbox)|pkg|vips)|e(?:(?:[bd]|cho)[\s\v&\)<>\|]|n(?:v(?:[\s\v&\)<>\|]|-update)|d(?:if|sw))|qn|s(?:[\s\v&\)<>h\|]|ac)|x(?:(?:ec)?[\s\v&\)<>\|]|iftool|p(?:(?:and|(?:ec|or)t)[\s\v&\)<>\|]|r))|2fsck|(?:asy_instal|va)l|fax|grep|macs)|f(?:(?:c|etch|lock|unction)[\s\v&\)<>\|]|d|g(?:rep)?|i(?:(?:n(?:d|ger)|sh)?[\s\v&\)<>\|]|le(?:[\s\v&\)<>\|]|test))|mt|tp(?:[\s\v&\)<>\|]|stats|who)|acter|o(?:ld[\s\v&\)<>\|]|reach)|ping)|g(?:c(?:c[^\s\v]|ore)|db|e(?:(?:m|tfacl)[\s\v&\)<>\|]|ni(?:e[\s\v&\)<>\|]|soimage))|hci?|i(?:(?:t|mp)[\s\v&\)<>\|]|nsh)|(?:o|awk)[\s\v&\)<>\|]|pg|r(?:c|ep[\s\v&\)<>\|]|oup(?:[\s\v&\)<>\|]|mod))|tester|unzip|z(?:cat|exe|ip))|h(?:(?:d|up|ash|i(?:ghlight|story))[\s\v&\)<>\|]|e(?:ad[\s\v&\)<>\|]|xdump)|ost(?:id|name)|ping3|t(?:digest|op|passwd))|i(?:d|p(?:6?tables|config)?|rb|conv|f(?:config|top)|nstall[\s\v&\)<>\|]|onice|spell)|j(?:js|q|ava[\s\v&\)<>\|]|exec|o(?:(?:bs|in)[\s\v&\)<>\|]|urnalctl)|runscript)|k(?:s(?:h|shell)|ill(?:[\s\v&\)<>\|]|all)|nife[\s\v&\)<>\|])|l(?:d(?:d?[\s\v&\)<>\|]|config)|(?:[np]|ynx)[\s\v&\)<>\|]|s(?:-F|b_release|cpu|hw|mod|of|pci|usb)?|ua(?:[\s\v&\)<>\|]|(?:la)?tex)|z(?:[\s\v&\)4<>\|]|4c(?:at)?|c(?:at|mp)|diff|[e-f]?grep|less|m(?:a(?:dec|info)?|ore))|a(?:st(?:[\s\v&\)<>\|]|comm|log(?:in)?)|tex[\s\v&\)<>\|])|ess(?:[\s\v&\)<>\|]|echo|(?:fil|pip)e)|ftp(?:get)?|o(?:(?:ca(?:l|te)|ok)[\s\v&\)<>\|]|g(?:inctl|(?:nam|sav)e)|setup)|trace|wp-(?:d(?:ownload|ump)|mirror|request))|m(?:a(?:(?:n|ke)[\s\v&\)<>\|]|il(?:[\s\v&\)<>q\|]|x[\s\v&\)<>\|])|ster\.passwd|wk)|tr|(?:v|utt)[\s\v&\)<>\|]|k(?:dir[\s\v&\)<>\|]|fifo|nod|temp)|locate|o(?:(?:re|unt)[\s\v&\)<>\|]|squitto)|sg(?:attrib|c(?:at|onv)|filter|merge|uniq)|ysql(?:admin|dump(?:slow)?|hotcopy|show)?)|n(?:c(?:[\s\v&\)<>\|]|\.(?:openbsd|traditional)|at)|e(?:t(?:[\s\v&\)<>\|]|(?:c|st)at|kit-ftp|plan)|ofetch)|(?:(?:ul)?l|ice)[\s\v&\)<>\|]|m(?:[\s\v&\)<>\|]|ap)|p(?:m[\s\v&\)<>\|]|ing)|a(?:no[\s\v&\)<>\|]|sm|wk)|o(?:de[\s\v&\)<>\|]|hup)|roff|s(?:enter|lookup|tat))|o(?:(?:d|ctave)[\s\v&\)<>\|]|nintr|p(?:en(?:ssl|v(?:pn|t))|kg))|p(?:a(?:(?:x|cman|rted|tch)[\s\v&\)<>\|]|s(?:swd|te[\s\v&\)<>\|]))|d(?:b|f(?:la)?tex|ksh)|f(?:[\s\v&\)<>\|]|tp)|g(?:rep)?|hp(?:[\s\v&\)57<>\|]|-cgi)|i(?:(?:co?|ng)[\s\v&\)<>\|]|p[^\s\v]|dstat|gz)|k(?:g(?:_?info)?|exec|ill)|r(?:y?[\s\v&\)<>\|]|int(?:env|f[\s\v&\)<>\|]))|s(?:[\s\v&\)<>\|]|ed|ftp|ql)?|t(?:x|ar(?:diff|grep)?)|wd(?:\.db)?|xz|er(?:(?:f|ms)[\s\v&\)<>\|]|l(?:[\s\v&\)5<>\|]|sh))|opd|u(?:ppet[\s\v&\)<>\|]|shd)|y(?:thon[2-3]|3?versions))|r(?:a(?:r[\s\v&\)<>\|]|k(?:e[\s\v&\)<>\|]|u))|c(?:p[\s\v&\)<>\|])?|e(?:(?:d(?:carpet)?|v|name|p(?:eat|lace))[\s\v&\)<>\|]|a(?:delf|lpath)|stic)|m(?:(?:dir)?[\s\v&\)<>\|]|user)|pm(?:[\s\v&\)<>\|]|db|(?:quer|verif)y)|bash|l(?:ogin|wrap)|nano|oute[\s\v&\)<>\|]|sync|u(?:by[^\s\v]|n-(?:mailcap|parts))|vi(?:ew|m))|s(?:c(?:p|hed|r(?:een|ipt)[\s\v&\)<>\|])|e(?:(?:d|lf|rvice)[\s\v&\)<>\|]|t(?:(?:facl)?[\s\v&\)<>\|]|arch|env|sid)|ndmail)|(?:g|ash)[\s\v&\)<>\|]|h(?:(?:adow|ells)?[\s\v&\)<>\|]|\.distrib|u(?:f|tdown[\s\v&\)<>\|]))|s(?:[\s\v&\)<>\|]|h(?:[\s\v&\)<>\|]|-key(?:ge|sca)n|pass))|u(?:[\s\v&\)<>\|]|do)|vn|diff|ftp|l(?:eep[\s\v&\)<>\|]|sh)|mbclient|o(?:cat|elim|(?:rt|urce)[\s\v&\)<>\|])|p(?:lit[\s\v&\)<>\|]|wd\.db)|qlite3|t(?:art-stop-daemon|d(?:buf|err|in|out)|r(?:ace|ings[\s\v&\)<>\|]))|ys(?:ctl|tem(?:ctl|d-resolve)))|t(?:a(?:c|r[\s\v&\)<>\|]|il[\s\v&\)<>f\|]|sk(?:[\s\v&\)<>\|]|set))|bl|c(?:p(?:[\s\v&\)<>\|]|dump|ing|traceroute)|l?sh)|e(?:[ex][\s\v&\)<>\|]|lnet)|i(?:c[\s\v&\)<>\|]|me(?:(?:out)?[\s\v&\)<>\|]|datectl))|o(?:p|uch[\s\v&\)<>\|])|ftp|mux|r(?:aceroute6?|off)|shark)|u(?:dp|l(?:imit)?[\s\v&\)<>\|]|n(?:ame|(?:compress|s(?:et|hare))[\s\v&\)<>\|]|expand|iq|l(?:ink[\s\v&\)<>\|]|z(?:4|ma))|(?:pig|x)z|rar|z(?:ip[\s\v&\)<>\|]|std))|p(?:2date[\s\v&\)<>\|]|date-alternatives)|ser(?:(?:ad|mo)d|del)|u(?:de|en)code)|v(?:i(?:(?:ew)?[\s\v&\)<>\|]|m(?:[\s\v&\)<>\|]|diff)|gr|pw|rsh)|algrind|olatility[\s\v&\)<>\|])|w(?:[\s\v&\)<>c\|]|h(?:o(?:[\s\v&\)<>\|]|ami|is)?|iptail[\s\v&\)<>\|])|a(?:ll|tch)[\s\v&\)<>\|]|i(?:reshark|sh[\s\v&\)<>\|]))|x(?:(?:x|pa)d|z(?:[\s\v&\)<>\|]|c(?:at|mp)|d(?:ec|iff)|[e-f]?grep|less|more)|args|e(?:la)?tex|mo(?:dmap|re)|term)|y(?:(?:e(?:s|lp)|arn)[\s\v&\)<>\|]|um)|z(?:ip(?:[\s\v&\)<>\|]|c(?:loak|mp)|details|grep|info|(?:merg|not)e|split|tool)|s(?:h|oelim|td(?:(?:ca|m)t|grep|less)?)|athura|c(?:at|mp)|diff|e(?:grep|ro[\s\v&\)<>\|])|f?grep|less|more|run|ypper))(?:\b|[^0-9A-Z_a-z])" \
     "id:932237,\
-    phase:2,\
+    phase:1,\
     block,\
     capture,\
     t:none,t:cmdLine,t:normalizePath,\


### PR DESCRIPTION
A few RCE rules are only inspecting the HTTP headers in phase 2. These rules don't need access to the data in phase 2 and can be ran in phase 1 with a small performance boost.

closes https://github.com/coreruleset/coreruleset/issues/3458