### PR TITLE
fix: adding missing tags and ver action

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -345,8 +345,8 @@ SecRule REQBODY_PROCESSOR "!@rx (?:URLENCODED|MULTIPART|XML|JSON)" \
     noauditlog,\
     msg:'Enabling body inspection',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.0.1-dev',\
-    ctl:forceRequestBodyVariable=On"
+    ctl:forceRequestBodyVariable=On,\
+    ver:'OWASP_CRS/4.0.1-dev'"
 
 # Force body processor URLENCODED
 SecRule TX:enforce_bodyproc_urlencoded "@eq 1" \
@@ -433,8 +433,8 @@ SecRule TX:sampling_rnd100 "!@lt %{tx.sampling_percentage}" \
     noauditlog,\
     msg:'Sampling: Disable the rule engine based on sampling_percentage %{TX.sampling_percentage} and random number %{TX.sampling_rnd100}',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.0.1-dev',\
-    ctl:ruleRemoveByTag=OWASP_CRS"
+    ctl:ruleRemoveByTag=OWASP_CRS,\
+    ver:'OWASP_CRS/4.0.1-dev'"
 
 SecMarker "END-SAMPLING"
 

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -344,9 +344,9 @@ SecRule REQBODY_PROCESSOR "!@rx (?:URLENCODED|MULTIPART|XML|JSON)" \
     nolog,\
     noauditlog,\
     msg:'Enabling body inspection',\
-    ctl:forceRequestBodyVariable=On,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.0.1-dev'"
+    ver:'OWASP_CRS/4.0.1-dev',\
+    ctl:forceRequestBodyVariable=On"
 
 # Force body processor URLENCODED
 SecRule TX:enforce_bodyproc_urlencoded "@eq 1" \
@@ -432,9 +432,9 @@ SecRule TX:sampling_rnd100 "!@lt %{tx.sampling_percentage}" \
     log,\
     noauditlog,\
     msg:'Sampling: Disable the rule engine based on sampling_percentage %{TX.sampling_percentage} and random number %{TX.sampling_rnd100}',\
-    ctl:ruleRemoveByTag=OWASP_CRS,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.0.1-dev'"
+    ver:'OWASP_CRS/4.0.1-dev',\
+    ctl:ruleRemoveByTag=OWASP_CRS"
 
 SecMarker "END-SAMPLING"
 

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -59,6 +59,7 @@ SecRule &TX:crs_setup_version "@eq 0" \
     log,\
     auditlog,\
     msg:'ModSecurity CRS is deployed without configuration! Please copy the crs-setup.conf.example template to crs-setup.conf, and include the crs-setup.conf file in your webserver configuration before including the CRS rules. See the INSTALL file in the CRS directory for detailed instructions',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL'"
 
@@ -77,6 +78,7 @@ SecRule &TX:inbound_anomaly_score_threshold "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.inbound_anomaly_score_threshold=5'"
 
@@ -86,6 +88,7 @@ SecRule &TX:outbound_anomaly_score_threshold "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.outbound_anomaly_score_threshold=4'"
 
@@ -95,6 +98,7 @@ SecRule &TX:reporting_level "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.reporting_level=4'"
 
@@ -104,6 +108,7 @@ SecRule &TX:early_blocking "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.early_blocking=0'"
 
@@ -113,6 +118,7 @@ SecRule &TX:blocking_paranoia_level "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.blocking_paranoia_level=1'"
 
@@ -122,6 +128,7 @@ SecRule &TX:detection_paranoia_level "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.detection_paranoia_level=%{TX.blocking_paranoia_level}'"
 
@@ -131,6 +138,7 @@ SecRule &TX:sampling_percentage "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.sampling_percentage=100'"
 
@@ -140,6 +148,7 @@ SecRule &TX:critical_anomaly_score "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.critical_anomaly_score=5'"
 
@@ -148,6 +157,7 @@ SecRule &TX:error_anomaly_score "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.error_anomaly_score=4'"
 
@@ -156,6 +166,7 @@ SecRule &TX:warning_anomaly_score "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.warning_anomaly_score=3'"
 
@@ -164,6 +175,7 @@ SecRule &TX:notice_anomaly_score "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.notice_anomaly_score=2'"
 
@@ -173,6 +185,7 @@ SecRule &TX:allowed_methods "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.allowed_methods=GET HEAD POST OPTIONS'"
 
@@ -182,6 +195,7 @@ SecRule &TX:allowed_request_content_type "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |multipart/related| |text/xml| |application/xml| |application/soap+xml| |application/json| |application/cloudevents+json| |application/cloudevents-batch+json|'"
 
@@ -191,6 +205,7 @@ SecRule &TX:allowed_request_content_type_charset "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.allowed_request_content_type_charset=|utf-8| |iso-8859-1| |iso-8859-15| |windows-1252|'"
 
@@ -200,6 +215,7 @@ SecRule &TX:allowed_http_versions "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.allowed_http_versions=HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0 HTTP/3 HTTP/3.0'"
 
@@ -209,6 +225,7 @@ SecRule &TX:restricted_extensions "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .rdb/ .resources/ .resx/ .sql/ .swp/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'"
 
@@ -218,6 +235,7 @@ SecRule &TX:restricted_headers_basic "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.restricted_headers_basic=/content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/'"
 
@@ -227,6 +245,7 @@ SecRule &TX:restricted_headers_extended "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.restricted_headers_extended=/accept-charset/'"
 
@@ -236,6 +255,7 @@ SecRule &TX:enforce_bodyproc_urlencoded "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.enforce_bodyproc_urlencoded=0'"
 
@@ -245,6 +265,7 @@ SecRule &TX:crs_validate_utf8_encoding "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.crs_validate_utf8_encoding=0'"
 
@@ -262,6 +283,7 @@ SecAction \
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.blocking_inbound_anomaly_score=0',\
     setvar:'tx.detection_inbound_anomaly_score=0',\
@@ -300,6 +322,7 @@ SecRule TX:ENABLE_DEFAULT_COLLECTIONS "@eq 1" \
     phase:1,\
     pass,\
     nolog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     chain"
     SecRule REQUEST_HEADERS:User-Agent "@rx ^.*$" \
@@ -322,6 +345,7 @@ SecRule REQBODY_PROCESSOR "!@rx (?:URLENCODED|MULTIPART|XML|JSON)" \
     noauditlog,\
     msg:'Enabling body inspection',\
     ctl:forceRequestBodyVariable=On,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev'"
 
 # Force body processor URLENCODED
@@ -333,6 +357,7 @@ SecRule TX:enforce_bodyproc_urlencoded "@eq 1" \
     nolog,\
     noauditlog,\
     msg:'Enabling forced body inspection for ASCII content',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     chain"
     SecRule REQBODY_PROCESSOR "!@rx (?:URLENCODED|MULTIPART|XML|JSON)" \
@@ -372,6 +397,7 @@ SecRule TX:sampling_percentage "@eq 100" \
     phase:1,\
     pass,\
     nolog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     skipAfter:END-SAMPLING"
 
@@ -382,6 +408,7 @@ SecRule UNIQUE_ID "@rx ^[a-f]*([0-9])[a-f]*([0-9])" \
     capture,\
     t:sha1,t:hexEncode,\
     nolog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'TX.sampling_rnd100=%{TX.1}%{TX.2}'"
 
@@ -406,6 +433,7 @@ SecRule TX:sampling_rnd100 "!@lt %{tx.sampling_percentage}" \
     noauditlog,\
     msg:'Sampling: Disable the rule engine based on sampling_percentage %{TX.sampling_percentage} and random number %{TX.sampling_rnd100}',\
     ctl:ruleRemoveByTag=OWASP_CRS,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev'"
 
 SecMarker "END-SAMPLING"
@@ -424,4 +452,5 @@ SecRule TX:detection_paranoia_level "@lt %{tx.blocking_paranoia_level}" \
     t:none,\
     log,\
     msg:'Detection paranoia level configured is lower than the paranoia level itself. This is illegal. Blocking request. Aborting',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev'"

--- a/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
+++ b/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
@@ -24,6 +24,7 @@ SecRule REQUEST_LINE "@streq GET /" \
     tag:'language-multi',\
     tag:'platform-apache',\
     tag:'attack-generic',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     chain"
     SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
@@ -44,6 +45,7 @@ SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
     tag:'language-multi',\
     tag:'platform-apache',\
     tag:'attack-generic',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     chain"
     SecRule REQUEST_HEADERS:User-Agent "@endsWith (internal dummy connection)" \

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -61,8 +61,8 @@ SecRule REQUEST_FILENAME "!@validateByteRange 20, 45-47, 48-57, 65-90, 95, 97-12
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.0.1-dev',\
-    ctl:ruleRemoveTargetByTag=xss-perf-disable;REQUEST_FILENAME"
+    ctl:ruleRemoveTargetByTag=xss-perf-disable;REQUEST_FILENAME,\
+    ver:'OWASP_CRS/4.0.1-dev'"
 
 
 #

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -60,6 +60,8 @@ SecRule REQUEST_FILENAME "!@validateByteRange 20, 45-47, 48-57, 65-90, 95, 97-12
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     ctl:ruleRemoveTargetByTag=xss-perf-disable;REQUEST_FILENAME"
 
 

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1326,6 +1326,7 @@ SecRule ARGS_GET:fbclid "@rx [a-zA-Z0-9_-]{61,61}" \
     t:none,t:urlDecodeUni,\
     nolog,\
     ctl:ruleRemoveTargetById=942440;ARGS:fbclid,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev'"
 
 #
@@ -1340,6 +1341,7 @@ SecRule ARGS_GET:gclid "@rx [a-zA-Z0-9_-]{91,91}" \
     t:none,t:urlDecodeUni,\
     nolog,\
     ctl:ruleRemoveTargetById=942440;ARGS:gclid,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev'"
 
 #

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1326,8 +1326,8 @@ SecRule ARGS_GET:fbclid "@rx [a-zA-Z0-9_-]{61,61}" \
     t:none,t:urlDecodeUni,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.0.1-dev',\
-    ctl:ruleRemoveTargetById=942440;ARGS:fbclid"
+    ctl:ruleRemoveTargetById=942440;ARGS:fbclid,\
+    ver:'OWASP_CRS/4.0.1-dev'"
 
 #
 # -=[ Exclusion rule for 942440 ]=-
@@ -1341,8 +1341,8 @@ SecRule ARGS_GET:gclid "@rx [a-zA-Z0-9_-]{91,91}" \
     t:none,t:urlDecodeUni,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.0.1-dev',\
-    ctl:ruleRemoveTargetById=942440;ARGS:gclid"
+    ctl:ruleRemoveTargetById=942440;ARGS:gclid,\
+    ver:'OWASP_CRS/4.0.1-dev'"
 
 #
 # -=[ Detect SQL Comment Sequences ]=-

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1325,9 +1325,9 @@ SecRule ARGS_GET:fbclid "@rx [a-zA-Z0-9_-]{61,61}" \
     pass,\
     t:none,t:urlDecodeUni,\
     nolog,\
-    ctl:ruleRemoveTargetById=942440;ARGS:fbclid,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.0.1-dev'"
+    ver:'OWASP_CRS/4.0.1-dev',\
+    ctl:ruleRemoveTargetById=942440;ARGS:fbclid"
 
 #
 # -=[ Exclusion rule for 942440 ]=-
@@ -1340,9 +1340,9 @@ SecRule ARGS_GET:gclid "@rx [a-zA-Z0-9_-]{91,91}" \
     pass,\
     t:none,t:urlDecodeUni,\
     nolog,\
-    ctl:ruleRemoveTargetById=942440;ARGS:gclid,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.0.1-dev'"
+    ver:'OWASP_CRS/4.0.1-dev',\
+    ctl:ruleRemoveTargetById=942440;ARGS:gclid"
 
 #
 # -=[ Detect SQL Comment Sequences ]=-

--- a/rules/REQUEST-949-BLOCKING-EVALUATION.conf
+++ b/rules/REQUEST-949-BLOCKING-EVALUATION.conf
@@ -23,13 +23,18 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 1" \
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl1}'"
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 1" \
     "id:949152,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl1}'"
 
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
@@ -38,13 +43,18 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl2}'"
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 2" \
     "id:949153,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl2}'"
 
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
@@ -53,13 +63,18 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl3}'"
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 3" \
     "id:949154,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl3}'"
 
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
@@ -68,13 +83,18 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl4}'"
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
     "id:949155,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl4}'"
 
 # at start of phase 2, we reset the aggregate scores to 0 to prevent duplicate counting of per-PL scores
@@ -85,13 +105,18 @@ SecAction \
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.blocking_inbound_anomaly_score=0'"
+
 SecAction \
     "id:949159,\
     phase:2,\
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.detection_inbound_anomaly_score=0'"
 
 # Summing up the blocking and detection anomaly scores in phase 2
@@ -102,13 +127,18 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 1" \
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl1}'"
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 1" \
     "id:949160,\
     phase:2,\
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl1}'"
 
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
@@ -117,13 +147,18 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl2}'"
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 2" \
     "id:949161,\
     phase:2,\
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl2}'"
 
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
@@ -132,13 +167,18 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl3}'"
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 3" \
     "id:949162,\
     phase:2,\
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl3}'"
 
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
@@ -147,13 +187,18 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl4}'"
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
     "id:949163,\
     phase:2,\
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl4}'"
 
 
@@ -171,6 +216,7 @@ SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_thresh
     t:none,\
     msg:'Inbound Anomaly Score Exceeded in phase 1 (Total Score: %{TX.BLOCKING_INBOUND_ANOMALY_SCORE})',\
     tag:'anomaly-evaluation',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     chain"
     SecRule TX:EARLY_BLOCKING "@eq 1"
@@ -183,6 +229,7 @@ SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_thresh
     t:none,\
     msg:'Inbound Anomaly Score Exceeded (Total Score: %{TX.BLOCKING_INBOUND_ANOMALY_SCORE})',\
     tag:'anomaly-evaluation',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev'"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:949011,phase:1,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"

--- a/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
+++ b/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
@@ -34,13 +34,18 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 1" \
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl1}'"
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 1" \
     "id:959152,\
     phase:3,\
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl1}'"
 
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
@@ -49,13 +54,18 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl2}'"
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 2" \
     "id:959153,\
     phase:3,\
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl2}'"
 
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
@@ -64,13 +74,18 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl3}'"
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 3" \
     "id:959154,\
     phase:3,\
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl3}'"
 
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
@@ -79,13 +94,18 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl4}'"
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
     "id:959155,\
     phase:3,\
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl4}'"
 
 # at start of phase 4, we reset the aggregate scores to 0 to prevent duplicate counting of per-PL scores
@@ -96,13 +116,18 @@ SecAction \
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.blocking_outbound_anomaly_score=0'"
+
 SecAction \
     "id:959159,\
     phase:4,\
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.detection_outbound_anomaly_score=0'"
 
 SecMarker "EARLY_BLOCKING_ANOMALY_SCORING"
@@ -115,13 +140,18 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 1" \
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl1}'"
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 1" \
     "id:959160,\
     phase:4,\
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl1}'"
 
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
@@ -130,13 +160,18 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl2}'"
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 2" \
     "id:959161,\
     phase:4,\
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl2}'"
 
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
@@ -145,13 +180,18 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl3}'"
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 3" \
     "id:959162,\
     phase:4,\
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl3}'"
 
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
@@ -160,13 +200,18 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl4}'"
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
     "id:959163,\
     phase:4,\
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl4}'"
 
 #
@@ -181,6 +226,7 @@ SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_thre
     t:none,\
     msg:'Outbound Anomaly Score Exceeded in phase 3 (Total Score: %{tx.blocking_outbound_anomaly_score})',\
     tag:'anomaly-evaluation',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     chain"
     SecRule TX:EARLY_BLOCKING "@eq 1"
@@ -193,6 +239,7 @@ SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_thre
     t:none,\
     msg:'Outbound Anomaly Score Exceeded (Total Score: %{tx.blocking_outbound_anomaly_score})',\
     tag:'anomaly-evaluation',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev'"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:959011,phase:3,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -27,6 +27,7 @@ SecAction \
     t:none,\
     nolog,\
     noauditlog,\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
     setvar:'tx.blocking_anomaly_score=%{tx.blocking_inbound_anomaly_score}',\
     setvar:'tx.blocking_anomaly_score=+%{tx.blocking_outbound_anomaly_score}',\
@@ -93,6 +94,7 @@ SecAction \
 (Outbound Scores: blocking=%{tx.blocking_outbound_anomaly_score}, detection=%{tx.detection_outbound_anomaly_score}, per_pl=%{tx.outbound_anomaly_score_pl1}-%{tx.outbound_anomaly_score_pl2}-%{tx.outbound_anomaly_score_pl3}-%{tx.outbound_anomaly_score_pl4}, threshold=%{tx.outbound_anomaly_score_threshold}) - \
 (SQLI=%{tx.sql_injection_score}, XSS=%{tx.xss_score}, RFI=%{tx.rfi_score}, LFI=%{tx.lfi_score}, RCE=%{tx.rce_score}, PHPI=%{tx.php_injection_score}, HTTP=%{tx.http_violation_score}, SESS=%{tx.session_fixation_score}, COMBINED_SCORE=%{tx.anomaly_score})',\
     tag:'reporting',\
+    tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev'"
 
 SecMarker "END-REPORTING"


### PR DESCRIPTION
Adding missing tag `OWASP_CRS` to (almost) all rules so it's all disabled when using `ctl:ruleRemoveByTag=OWASP_CRS`.

Also adding missing `ver` action to (almost) all rules.

Not sure if tag `OWASP_CRS` should be added also to rules used for skipping paranoia levels and anomaly score reporting rules in `RESPONSE-980-CORRELATION.conf`.