### PR TITLE
fix(test): 932260-28 http method uppercase

### DIFF
--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932260.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932260.yaml
@@ -458,7 +458,7 @@ tests:
               User-Agent: "OWASP CRS test agent"
               Host: localhost
               Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
-            method: get
+            method: GET
             port: 80
             uri: /get/?a=whoami;0'0'"
             version: HTTP/1.1


### PR DESCRIPTION
As per [rfc9110](https://httpwg.org/specs/rfc9110.html#method.overview), `method` is case sensitive. Because of this, `932260-28` is failing against Envoy that is returning `400` and go-httpbin that returns `405 Method Not Allowed`.