### PR TITLE
fix: Remove t:lowercase from rules what use '(?i) modifier in their regex

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -112,7 +112,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     phase:2,\
     block,\
     capture,\
-    t:none,t:urlDecodeUni,t:lowercase,\
+    t:none,t:urlDecodeUni,\
     msg:'SQL Injection Attack: SQL function name detected',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
@@ -761,7 +761,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     phase:2,\
     block,\
     capture,\
-    t:none,t:urlDecodeUni,t:lowercase,\
+    t:none,t:urlDecodeUni,\
     msg:'SQL Injection Attack: SQL function name detected',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
@@ -1621,7 +1621,7 @@ SecRule REQUEST_HEADERS:Referer|REQUEST_HEADERS:User-Agent "@rx (?i)\b(?:a(?:dd(
     phase:1,\
     block,\
     capture,\
-    t:none,t:urlDecodeUni,t:lowercase,\
+    t:none,t:urlDecodeUni,\
     msg:'SQL Injection Attack: SQL function name detected',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\


### PR DESCRIPTION
This PR removes the `t:lowercase` transformation from rules where the `@rx` operator uses `(?i)` modifier.

This needs to merge before #3584 will merged.