### PR TITLE
fix: adding more missing tags and ver actions

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -180,6 +180,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    t:none,\
 #    nolog,\
+#    tag:'OWASP_CRS',\
+#    ver:'OWASP_CRS/4.0.1-dev',\
 #    setvar:tx.blocking_paranoia_level=1"
 
 
@@ -206,6 +208,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    t:none,\
 #    nolog,\
+#    tag:'OWASP_CRS',\
+#    ver:'OWASP_CRS/4.0.1-dev',\
 #    setvar:tx.detection_paranoia_level=1"
 
 
@@ -230,6 +234,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    t:none,\
 #    nolog,\
+#    tag:'OWASP_CRS',\
+#    ver:'OWASP_CRS/4.0.1-dev',\
 #    setvar:tx.enforce_bodyproc_urlencoded=1"
 
 
@@ -263,6 +269,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    t:none,\
 #    nolog,\
+#    tag:'OWASP_CRS',\
+#    ver:'OWASP_CRS/4.0.1-dev',\
 #    setvar:tx.critical_anomaly_score=5,\
 #    setvar:tx.error_anomaly_score=4,\
 #    setvar:tx.warning_anomaly_score=3,\
@@ -315,6 +323,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    t:none,\
 #    nolog,\
+#    tag:'OWASP_CRS',\
+#    ver:'OWASP_CRS/4.0.1-dev',\
 #    setvar:tx.inbound_anomaly_score_threshold=5,\
 #    setvar:tx.outbound_anomaly_score_threshold=4"
 
@@ -374,6 +384,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    t:none,\
 #    nolog,\
+#    tag:'OWASP_CRS',\
+#    ver:'OWASP_CRS/4.0.1-dev',\
 #    setvar:tx.reporting_level=4"
 
 
@@ -404,6 +416,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    t:none,\
 #    nolog,\
+#    tag:'OWASP_CRS',\
+#    ver:'OWASP_CRS/4.0.1-dev',\
 #    setvar:tx.early_blocking=1"
 
 
@@ -423,6 +437,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    t:none,\
 #    nolog,\
+#    tag:'OWASP_CRS',\
+#    ver:'OWASP_CRS/4.0.1-dev',\
 #    setvar:tx.enable_default_collections=1"
 
 
@@ -449,6 +465,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    t:none,\
 #    nolog,\
+#    tag:'OWASP_CRS',\
+#    ver:'OWASP_CRS/4.0.1-dev',\
 #    setvar:'tx.allowed_methods=GET HEAD POST OPTIONS'"
 
 # Content-Types that a client is allowed to send in a request.
@@ -476,7 +494,9 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    t:none,\
 #    nolog,\
+#    tag:'OWASP_CRS',\
 #    ctl:ruleRemoveById=920420,\
+#    ver:'OWASP_CRS/4.0.1-dev',\
 #    chain"
 #    SecRule REQUEST_URI "@rx ^/foo/bar" \
 #        "t:none"
@@ -489,6 +509,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    t:none,\
 #    nolog,\
+#    tag:'OWASP_CRS',\
+#    ver:'OWASP_CRS/4.0.1-dev',\
 #    setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |multipart/related| |text/xml| |application/xml| |application/soap+xml| |application/json| |application/cloudevents+json| |application/cloudevents-batch+json|'"
 
 # Allowed HTTP versions.
@@ -503,6 +525,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    t:none,\
 #    nolog,\
+#    tag:'OWASP_CRS',\
+#    ver:'OWASP_CRS/4.0.1-dev',\
 #    setvar:'tx.allowed_http_versions=HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0 HTTP/3 HTTP/3.0'"
 
 # Forbidden file extensions.
@@ -525,6 +549,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    t:none,\
 #    nolog,\
+#    tag:'OWASP_CRS',\
+#    ver:'OWASP_CRS/4.0.1-dev',\
 #    setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .rdb/ .resources/ .resx/ .sql/ .swp/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'"
 
 # Restricted request headers.
@@ -568,6 +594,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    t:none,\
 #    nolog,\
+#    tag:'OWASP_CRS',\
+#    ver:'OWASP_CRS/4.0.1-dev',\
 #    setvar:'tx.restricted_headers_basic=/content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/'"
 #
 # [ Extended ]
@@ -592,6 +620,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    t:none,\
 #    nolog,\
+#    tag:'OWASP_CRS',\
+#    ver:'OWASP_CRS/4.0.1-dev',\
 #    setvar:'tx.restricted_headers_extended=/accept-charset/'"
 
 # Content-Types charsets that a client is allowed to send in a request.
@@ -604,6 +634,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    t:none,\
 #    nolog,\
+#    tag:'OWASP_CRS',\
+#    ver:'OWASP_CRS/4.0.1-dev',\
 #    setvar:'tx.allowed_request_content_type_charset=|utf-8| |iso-8859-1| |iso-8859-15| |windows-1252|'"
 
 #
@@ -628,6 +660,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    t:none,\
 #    nolog,\
+#    tag:'OWASP_CRS',\
+#    ver:'OWASP_CRS/4.0.1-dev',\
 #    setvar:tx.max_num_args=255"
 
 # Block request if the length of any argument name is too high
@@ -640,6 +674,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    t:none,\
 #    nolog,\
+#    tag:'OWASP_CRS',\
+#    ver:'OWASP_CRS/4.0.1-dev',\
 #    setvar:tx.arg_name_length=100"
 
 # Block request if the length of any argument value is too high
@@ -652,6 +688,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    t:none,\
 #    nolog,\
+#    tag:'OWASP_CRS',\
+#    ver:'OWASP_CRS/4.0.1-dev',\
 #    setvar:tx.arg_length=400"
 
 # Block request if the total length of all combined arguments is too high
@@ -664,6 +702,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    t:none,\
 #    nolog,\
+#    tag:'OWASP_CRS',\
+#    ver:'OWASP_CRS/4.0.1-dev',\
 #    setvar:tx.total_arg_length=64000"
 
 # Block request if the file size of any individual uploaded file is too high
@@ -676,6 +716,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    t:none,\
 #    nolog,\
+#    tag:'OWASP_CRS',\
+#    ver:'OWASP_CRS/4.0.1-dev',\
 #    setvar:tx.max_file_size=1048576"
 
 # Block request if the total size of all combined uploaded files is too high
@@ -688,6 +730,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    t:none,\
 #    nolog,\
+#    tag:'OWASP_CRS',\
+#    ver:'OWASP_CRS/4.0.1-dev',\
 #    setvar:tx.combined_file_sizes=1048576"
 
 
@@ -726,6 +770,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    phase:1,\
 #    pass,\
 #    nolog,\
+#    tag:'OWASP_CRS',\
+#    ver:'OWASP_CRS/4.0.1-dev',\
 #    setvar:tx.sampling_percentage=100"
 
 
@@ -745,6 +791,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    t:none,\
 #    nolog,\
+#    tag:'OWASP_CRS',\
+#    ver:'OWASP_CRS/4.0.1-dev',\
 #    setvar:tx.crs_validate_utf8_encoding=1"
 
 
@@ -765,4 +813,6 @@ SecAction \
     pass,\
     t:none,\
     nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev',\
     setvar:tx.crs_setup_version=401"

--- a/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
+++ b/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:911011,phase:1,pass,nolog,skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:911012,phase:2,pass,nolog,skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:911011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:911012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -46,24 +46,24 @@ SecRule REQUEST_METHOD "!@within %{tx.allowed_methods}" \
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:911013,phase:1,pass,nolog,skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:911014,phase:2,pass,nolog,skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:911013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:911014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:911015,phase:1,pass,nolog,skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:911016,phase:2,pass,nolog,skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:911015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:911016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:911017,phase:1,pass,nolog,skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:911018,phase:2,pass,nolog,skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:911017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:911018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-913-SCANNER-DETECTION.conf
+++ b/rules/REQUEST-913-SCANNER-DETECTION.conf
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:913011,phase:1,pass,nolog,skipAfter:END-REQUEST-913-SCANNER-DETECTION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:913012,phase:2,pass,nolog,skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:913011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:913012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -56,24 +56,24 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scanners-user-agents.data" \
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:913013,phase:1,pass,nolog,skipAfter:END-REQUEST-913-SCANNER-DETECTION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:913014,phase:2,pass,nolog,skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:913013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:913014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:913015,phase:1,pass,nolog,skipAfter:END-REQUEST-913-SCANNER-DETECTION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:913016,phase:2,pass,nolog,skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:913015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:913016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:913017,phase:1,pass,nolog,skipAfter:END-REQUEST-913-SCANNER-DETECTION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:913018,phase:2,pass,nolog,skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:913017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:913018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -23,8 +23,8 @@
 #
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:920011,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:920012,phase:2,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:920011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:920012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -1335,8 +1335,8 @@ SecRule &REQUEST_HEADERS:Content-Type "@gt 1" \
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:920013,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:920014,phase:2,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:920013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:920014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -1372,9 +1372,9 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'WARNING',\
     chain"
@@ -1396,9 +1396,9 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'WARNING',\
     chain"
@@ -1417,9 +1417,9 @@ SecRule ARGS "@rx %[0-9a-fA-F]{2}" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/267/120',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.warning_anomaly_score}'"
@@ -1439,9 +1439,9 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 9,10,13,
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1465,10 +1465,10 @@ SecRule &REQUEST_HEADERS:User-Agent "@eq 0" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'PCI/6.5.10',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'NOTICE',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.notice_anomaly_score}'"
@@ -1488,9 +1488,9 @@ SecRule FILES_NAMES|FILES "@rx ['\";=]" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1578,8 +1578,8 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)application/x-www-form-urlencoded
         SecRule REQUEST_BODY "@validateUrlEncoding" \
             "setvar:'tx.inbound_anomaly_score_pl2=+%{tx.warning_anomaly_score}'"
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:920015,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:920016,phase:2,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:920015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:920016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
@@ -1601,9 +1601,9 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteR
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    tag:'paranoia-level/3',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -1634,10 +1634,10 @@ SecRule &REQUEST_HEADERS:Accept "@eq 0" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'PCI/6.5.10',\
-    tag:'paranoia-level/3',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'NOTICE',\
     chain"
@@ -1668,9 +1668,9 @@ SecRule &REQUEST_HEADERS:x-up-devcap-post-charset "@ge 1" \
     tag:'language-aspnet',\
     tag:'platform-windows',\
     tag:'attack-protocol',\
+    tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    tag:'paranoia-level/3',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     chain"
@@ -1759,8 +1759,8 @@ SecRule REQUEST_HEADERS:Accept-Encoding "!@rx br|compress|deflate|(?:pack200-)?g
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:920017,phase:1,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:920018,phase:2,pass,nolog,skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:920017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:920018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
@@ -1780,9 +1780,9 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'paranoia-level/4',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    tag:'paranoia-level/4',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'WARNING',\
     chain"
@@ -1807,9 +1807,9 @@ SecRule ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteRange 38,44-46,48-58,61,65-90
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'paranoia-level/4',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    tag:'paranoia-level/4',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
@@ -1828,9 +1828,9 @@ SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!RE
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'paranoia-level/4',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    tag:'paranoia-level/4',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
@@ -1854,9 +1854,9 @@ SecRule REQUEST_HEADERS:Sec-Fetch-User|REQUEST_HEADERS:Sec-CH-UA-Mobile "!@rx ^(
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'paranoia-level/4',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    tag:'paranoia-level/4',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl4=+%{tx.critical_anomaly_score}'"

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:921011,phase:1,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:921012,phase:2,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:921011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:921012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -305,8 +305,8 @@ SecRule REQUEST_URI "@rx unix:[^|]*\|" \
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:921013,phase:1,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:921014,phase:2,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:921013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:921014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -374,8 +374,8 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^\s\v,;]+[\s\v,;].*?\b(?:((?:tex|mul
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:921015,phase:1,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:921016,phase:2,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:921015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:921016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
@@ -437,6 +437,7 @@ SecRule ARGS_NAMES "@rx ." \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/137/15/460',\
     ver:'OWASP_CRS/4.0.1-dev',\
@@ -452,9 +453,9 @@ SecRule TX:/paramcounter_.*/ "@gt 1" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/137/15/460',\
-    tag:'paranoia-level/3',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     chain"
@@ -497,9 +498,9 @@ SecRule ARGS_NAMES "@rx (][^\]]+$|][^\]]+\[)" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/137/15/460',\
-    tag:'paranoia-level/3',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
@@ -507,8 +508,8 @@ SecRule ARGS_NAMES "@rx (][^\]]+$|][^\]]+\[)" \
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:921017,phase:1,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:921018,phase:2,pass,nolog,skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:921017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:921018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
@@ -545,9 +546,9 @@ SecRule ARGS_NAMES "@rx \[" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'paranoia-level/4',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/137/15/460',\
-    tag:'paranoia-level/4',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -437,7 +437,6 @@ SecRule ARGS_NAMES "@rx ." \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
-    tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/137/15/460',\
     ver:'OWASP_CRS/4.0.1-dev',\

--- a/rules/REQUEST-922-MULTIPART-ATTACK.conf
+++ b/rules/REQUEST-922-MULTIPART-ATTACK.conf
@@ -35,9 +35,9 @@ SecRule &MULTIPART_PART_HEADERS:_charset_ "!@eq 0" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-multipart-header',\
+    tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153',\
-    tag:'paranoia-level/1',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.922100_charset=|%{ARGS._charset_}|',\
@@ -66,9 +66,9 @@ SecRule MULTIPART_PART_HEADERS "@rx ^content-type\s*:\s*(.*)$" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-protocol',\
+    tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/272/220',\
-    tag:'paranoia-level/1',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     chain"
@@ -89,9 +89,9 @@ SecRule MULTIPART_PART_HEADERS "@rx content-transfer-encoding:(.*)" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-deprecated-header',\
+    tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/272/220',\
-    tag:'paranoia-level/1',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:930011,phase:1,pass,nolog,skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:930012,phase:2,pass,nolog,skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:930011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:930012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -144,8 +144,8 @@ SecRule REQUEST_FILENAME "@pmFromFile restricted-files.data" \
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:930013,phase:1,pass,nolog,skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:930014,phase:2,pass,nolog,skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:930013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:930014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -181,16 +181,16 @@ SecRule REQUEST_HEADERS:Referer|REQUEST_HEADERS:User-Agent "@pmFromFile lfi-os-f
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:930015,phase:1,pass,nolog,skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:930016,phase:2,pass,nolog,skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:930015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:930016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:930017,phase:1,pass,nolog,skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:930018,phase:2,pass,nolog,skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:930017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:930018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
+++ b/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
@@ -17,8 +17,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:931011,phase:1,pass,nolog,skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:931012,phase:2,pass,nolog,skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:931011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:931012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -96,8 +96,8 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?).*?\?+$" \
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:931013,phase:1,pass,nolog,skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:931014,phase:2,pass,nolog,skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:931013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:931014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -125,9 +125,9 @@ SecRule ARGS "@rx (?i)(?:(?:url|jar):)?(?:a(?:cap|f[ps]|ttachment)|b(?:eshare|it
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-rfi',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/175/253',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_parameter_%{MATCHED_VAR_NAME}=.%{tx.1}',\
@@ -155,9 +155,9 @@ SecRule REQUEST_FILENAME "@rx (?i)(?:(?:url|jar):)?(?:a(?:cap|f[ps]|ttachment)|b
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-rfi',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/175/253',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_parameter_%{MATCHED_VAR_NAME}=.%{tx.1}',\
@@ -167,16 +167,16 @@ SecRule REQUEST_FILENAME "@rx (?i)(?:(?:url|jar):)?(?:a(?:cap|f[ps]|ttachment)|b
         setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:931015,phase:1,pass,nolog,skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:931016,phase:2,pass,nolog,skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:931015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:931016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:931017,phase:1,pass,nolog,skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:931018,phase:2,pass,nolog,skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:931017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:931018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:932011,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:932012,phase:2,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:932011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:932012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -835,8 +835,8 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:932013,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:932014,phase:2,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:932013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:932014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -1465,8 +1465,8 @@ SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer "@pmFromFile unix-she
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:932015,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:932016,phase:2,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:932015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:932016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
@@ -1521,10 +1521,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-shell',\
     tag:'platform-unix',\
     tag:'attack-rce',\
+    tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/3',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
@@ -1671,10 +1671,10 @@ SecRule ARGS "@rx /(?:[?*]+[a-z/]+|[a-z/]+[?*]+)" \
     tag:'language-shell',\
     tag:'platform-unix',\
     tag:'attack-rce',\
+    tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/3',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
@@ -1814,8 +1814,8 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:932017,phase:1,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:932018,phase:2,pass,nolog,skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:932017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:932018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:933011,phase:1,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:933012,phase:2,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:933011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:933012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -505,8 +505,8 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:933013,phase:1,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:933014,phase:2,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:933013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:933014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -540,9 +540,9 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.933151_tx_0=%{tx.0}',\
@@ -555,8 +555,8 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:933015,phase:1,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:933016,phase:2,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:933015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:933016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
@@ -595,9 +595,9 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    tag:'paranoia-level/3',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
@@ -639,9 +639,9 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    tag:'paranoia-level/3',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
@@ -681,9 +681,9 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    tag:'paranoia-level/3',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
@@ -710,9 +710,9 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-php',\
     tag:'platform-multi',\
     tag:'attack-injection-php',\
+    tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    tag:'paranoia-level/3',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
@@ -754,8 +754,8 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:933017,phase:1,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:933018,phase:2,pass,nolog,skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:933017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:933018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
+++ b/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:934011,phase:1,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:934012,phase:2,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:934011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:934012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -233,8 +233,8 @@ SecRule REQUEST_FILENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIE
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:934013,phase:1,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:934014,phase:2,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:934013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:934014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -346,14 +346,14 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:934015,phase:1,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:934016,phase:2,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:934015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:934016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:934017,phase:1,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:934018,phase:2,pass,nolog,skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:934017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:934018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:941011,phase:1,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:941012,phase:2,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:941011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:941012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -762,8 +762,8 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:941013,phase:1,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:941014,phase:2,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:941013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:941014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -784,9 +784,9 @@ SecRule REQUEST_FILENAME|REQUEST_HEADERS:Referer "@detectXSS" \
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'xss-perf-disable',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
@@ -844,9 +844,9 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'xss-perf-disable',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
@@ -959,10 +959,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'xss-perf-disable',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242/63',\
     tag:'PCI/6.5.1',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
@@ -981,10 +981,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'xss-perf-disable',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     tag:'PCI/6.5.1',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
@@ -1006,10 +1006,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'platform-multi',\
     tag:'attack-xss',\
     tag:'xss-perf-disable',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     tag:'PCI/6.5.1',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
@@ -1040,9 +1040,9 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'attack-xss',\
     tag:'xss-perf-disable',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242/63',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
@@ -1050,16 +1050,16 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:941015,phase:1,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:941016,phase:2,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:941015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:941016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:941017,phase:1,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:941018,phase:2,pass,nolog,skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:941017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:941018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:942011,phase:1,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:942012,phase:2,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:942011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:942012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -119,10 +119,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/1',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -557,9 +557,9 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'platform-multi',\
     tag:'attack-sqli',\
     tag:'OWASP_CRS',\
+    tag:'paranoia-level/1',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/1',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -585,10 +585,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/1',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -614,18 +614,18 @@ SecRule REQUEST_FILENAME|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIE
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/1',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:942013,phase:1,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:942014,phase:2,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:942013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:942014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -654,10 +654,10 @@ SecRule ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@rx (?i)!=|&&|\|\||>[=>]|<(?:<|
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -695,10 +695,10 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\v\"'-\)`]*?\b([0-9A-Z_a-z]+)\b[\s\v\
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.942130_matched_var_name=%{matched_var_name}',\
@@ -731,10 +731,10 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\v\"'-\)`]*?\b([0-9A-Z_a-z]+)\b[\s\v\
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     multiMatch,\
@@ -768,10 +768,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -811,10 +811,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -840,10 +840,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -869,10 +869,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -895,10 +895,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -921,10 +921,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -947,10 +947,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -981,10 +981,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -1010,10 +1010,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -1035,10 +1035,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -1097,10 +1097,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -1123,10 +1123,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -1149,10 +1149,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -1175,10 +1175,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -1206,10 +1206,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -1235,10 +1235,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -1264,10 +1264,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -1305,10 +1305,10 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.warning_anomaly_score}',\
@@ -1325,6 +1325,7 @@ SecRule ARGS_GET:fbclid "@rx [a-zA-Z0-9_-]{61,61}" \
     pass,\
     t:none,t:urlDecodeUni,\
     nolog,\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     ctl:ruleRemoveTargetById=942440;ARGS:fbclid,\
     ver:'OWASP_CRS/4.0.1-dev'"
@@ -1340,6 +1341,7 @@ SecRule ARGS_GET:gclid "@rx [a-zA-Z0-9_-]{91,91}" \
     pass,\
     t:none,t:urlDecodeUni,\
     nolog,\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     ctl:ruleRemoveTargetById=942440;ARGS:gclid,\
     ver:'OWASP_CRS/4.0.1-dev'"
@@ -1392,10 +1394,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     chain"
@@ -1423,10 +1425,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -1472,10 +1474,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -1499,10 +1501,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -1532,10 +1534,10 @@ SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.942521_matched_var_name=%{matched_var_name}',\
@@ -1560,10 +1562,10 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ^.*?\x5c['\"`](?:.*?['\"`])?\s*(?:and|or)\b"
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -1598,10 +1600,10 @@ SecRule REQUEST_BASENAME|REQUEST_FILENAME "@detectSQLi" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -1630,10 +1632,10 @@ SecRule REQUEST_HEADERS:Referer|REQUEST_HEADERS:User-Agent "@rx (?i)\b(?:a(?:dd(
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -1671,8 +1673,8 @@ SecRule REQUEST_HEADERS:Referer|REQUEST_HEADERS:User-Agent "@rx (?i)create[\s\v]
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:942015,phase:1,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:942016,phase:2,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:942015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:942016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
@@ -1700,10 +1702,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/3',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -1724,10 +1726,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/3',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -1764,10 +1766,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/3',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.warning_anomaly_score}',\
@@ -1793,10 +1795,10 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/3',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.warning_anomaly_score}',\
@@ -1823,10 +1825,10 @@ SecRule ARGS "@rx \W{4}" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/3',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'WARNING',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}',\
@@ -1873,10 +1875,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/3',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -1902,18 +1904,18 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/3',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:942017,phase:1,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:942018,phase:2,pass,nolog,skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:942017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:942018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
@@ -1936,10 +1938,10 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/4',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/4',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl4=+%{tx.warning_anomaly_score}',\
@@ -1965,10 +1967,10 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-sqli',\
+    tag:'paranoia-level/4',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/4',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl4=+%{tx.warning_anomaly_score}',\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1325,7 +1325,6 @@ SecRule ARGS_GET:fbclid "@rx [a-zA-Z0-9_-]{61,61}" \
     pass,\
     t:none,t:urlDecodeUni,\
     nolog,\
-    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     ctl:ruleRemoveTargetById=942440;ARGS:fbclid,\
     ver:'OWASP_CRS/4.0.1-dev'"
@@ -1341,7 +1340,6 @@ SecRule ARGS_GET:gclid "@rx [a-zA-Z0-9_-]{91,91}" \
     pass,\
     t:none,t:urlDecodeUni,\
     nolog,\
-    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     ctl:ruleRemoveTargetById=942440;ARGS:gclid,\
     ver:'OWASP_CRS/4.0.1-dev'"

--- a/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
+++ b/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:943011,phase:1,pass,nolog,skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:943012,phase:2,pass,nolog,skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:943011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:943012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -102,24 +102,24 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:943013,phase:1,pass,nolog,skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:943014,phase:2,pass,nolog,skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:943013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:943014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:943015,phase:1,pass,nolog,skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:943016,phase:2,pass,nolog,skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:943015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:943016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:943017,phase:1,pass,nolog,skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:943018,phase:2,pass,nolog,skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:943017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:943018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -13,8 +13,8 @@
 #
 # Many rules check request bodies, use "SecRequestBodyAccess On" to enable it on main modsecurity configuration file.
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:944011,phase:1,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:944012,phase:2,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:944011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:944012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -42,10 +42,10 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/137/6',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/1',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
@@ -75,10 +75,10 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/1',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     chain"
@@ -100,10 +100,10 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/1',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     chain"
@@ -132,10 +132,10 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/1',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
@@ -218,18 +218,18 @@ SecRule REQUEST_LINE|ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUE
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/137/6',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/1',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:944013,phase:1,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:944014,phase:2,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:944013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:944014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -256,10 +256,10 @@ SecRule REQUEST_LINE|ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUE
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/137/6',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
@@ -288,10 +288,10 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
@@ -309,10 +309,10 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
@@ -330,10 +330,10 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
@@ -354,10 +354,10 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
@@ -379,18 +379,18 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/2',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:944015,phase:1,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:944016,phase:2,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:944015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:944016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
@@ -413,18 +413,18 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/3',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:944017,phase:1,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:944018,phase:2,pass,nolog,skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:944017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:944018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
@@ -449,10 +449,10 @@ SecRule REQUEST_LINE|ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUE
     tag:'language-java',\
     tag:'platform-multi',\
     tag:'attack-rce',\
+    tag:'paranoia-level/4',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/137/6',\
     tag:'PCI/6.5.2',\
-    tag:'paranoia-level/4',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\

--- a/rules/REQUEST-949-BLOCKING-EVALUATION.conf
+++ b/rules/REQUEST-949-BLOCKING-EVALUATION.conf
@@ -232,32 +232,32 @@ SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_thresh
     tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev'"
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:949011,phase:1,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:949012,phase:2,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:949011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:949012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:949013,phase:1,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:949014,phase:2,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:949013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:949014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:949015,phase:1,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:949016,phase:2,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:949015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:949016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:949017,phase:1,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:949018,phase:2,pass,nolog,skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:949017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:949018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -23,8 +23,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:950011,phase:3,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:950012,phase:4,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:950011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:950012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -85,8 +85,8 @@ SecRule RESPONSE_BODY "@rx ^#\!\s?/" \
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:950013,phase:3,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:950014,phase:4,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:950013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:950014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -106,26 +106,26 @@ SecRule RESPONSE_STATUS "@rx ^5\d{2}$" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-disclosure',\
-    tag:'PCI/6.5.6',\
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152',\
+    tag:'PCI/6.5.6',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl2=+%{tx.error_anomaly_score}'"
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:950015,phase:3,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:950016,phase:4,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:950015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:950016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:950017,phase:3,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:950018,phase:4,pass,nolog,skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:950017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:950018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:951011,phase:3,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:951012,phase:4,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:951011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:951012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -36,6 +36,7 @@ SecRule RESPONSE_BODY "!@pmFromFile sql-errors.data" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-disclosure',\
+    tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
     ver:'OWASP_CRS/4.0.1-dev',\
@@ -374,24 +375,24 @@ SecRule RESPONSE_BODY "@rx (?i)(?:Sybase message:|Warning.{2,20}sybase|Sybase.*S
 SecMarker "END-SQL-ERROR-MATCH-PL1"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:951013,phase:3,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:951014,phase:4,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:951013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:951014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:951015,phase:3,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:951016,phase:4,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:951015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:951016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:951017,phase:3,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:951018,phase:4,pass,nolog,skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:951017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:951018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -36,7 +36,6 @@ SecRule RESPONSE_BODY "!@pmFromFile sql-errors.data" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-disclosure',\
-    tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
     ver:'OWASP_CRS/4.0.1-dev',\

--- a/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
+++ b/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:952011,phase:3,pass,nolog,skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:952012,phase:4,pass,nolog,skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:952011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:952012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -70,24 +70,24 @@ SecRule RESPONSE_BODY "@pmFromFile java-errors.data" \
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:952013,phase:3,pass,nolog,skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:952014,phase:4,pass,nolog,skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:952013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:952014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:952015,phase:3,pass,nolog,skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:952016,phase:4,pass,nolog,skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:952015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:952016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:952017,phase:3,pass,nolog,skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:952018,phase:4,pass,nolog,skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:952017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:952018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:953011,phase:3,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:953012,phase:4,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:953011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:953012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -95,8 +95,8 @@ SecRule RESPONSE_BODY "@rx (?i)<\?(?:=|php)?\s+" \
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:953013,phase:3,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:953014,phase:4,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:953013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:953014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -128,16 +128,16 @@ SecRule RESPONSE_BODY "@pmFromFile php-errors-pl2.data" \
     setvar:'tx.outbound_anomaly_score_pl2=+%{tx.error_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:953015,phase:3,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:953016,phase:4,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:953015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:953016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:953017,phase:3,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:953018,phase:4,pass,nolog,skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:953017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:953018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+++ b/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:954011,phase:3,pass,nolog,skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:954012,phase:4,pass,nolog,skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:954011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:954012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -55,9 +55,9 @@ SecRule RESPONSE_BODY "@rx (?:Microsoft OLE DB Provider for SQL Server(?:</font>
     tag:'platform-windows',\
     tag:'attack-disclosure',\
     tag:'paranoia-level/1',\
-    tag:'PCI/6.5.6',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116',\
+    tag:'PCI/6.5.6',\
     ver:'OWASP_CRS/4.0.1-dev',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
@@ -114,24 +114,24 @@ SecRule RESPONSE_STATUS "!@rx ^404$" \
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:954013,phase:3,pass,nolog,skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:954014,phase:4,pass,nolog,skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:954013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:954014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:954015,phase:3,pass,nolog,skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:954016,phase:4,pass,nolog,skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:954015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:954016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:954017,phase:3,pass,nolog,skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:954018,phase:4,pass,nolog,skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:954017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:954018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-955-WEB-SHELLS.conf
+++ b/rules/RESPONSE-955-WEB-SHELLS.conf
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:955011,phase:3,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:955012,phase:4,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:955011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:955012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -500,8 +500,8 @@ SecRule RESPONSE_BODY "@rx ^ <html><head><title>:: b374k m1n1 [0-9.]+ ::</title>
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:955013,phase:3,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:955014,phase:4,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:955013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:955014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -526,16 +526,16 @@ SecRule RESPONSE_BODY "@contains <h1 style=\"margin-bottom: 0\">webadmin.php</h1
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:955015,phase:3,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:955016,phase:4,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:955015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:955016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:955017,phase:3,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:955018,phase:4,pass,nolog,skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:955017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:955018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
+++ b/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
@@ -242,32 +242,32 @@ SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_thre
     tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev'"
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:959011,phase:3,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:959012,phase:4,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:959011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:959012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:959013,phase:3,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:959014,phase:4,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:959013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:959014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:959015,phase:3,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:959016,phase:4,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:959015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:959016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:959017,phase:3,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:959018,phase:4,pass,nolog,skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:959017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:959018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -41,33 +41,33 @@ SecAction \
 #
 
 # -= Reporting Level 0 =- (Skip over reporting when tx.reporting_level is 0)
-SecRule TX:REPORTING_LEVEL "@eq 0" "id:980041,phase:5,pass,nolog,skipAfter:END-REPORTING"
+SecRule TX:REPORTING_LEVEL "@eq 0" "id:980041,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REPORTING"
 
 # -= Reporting Level 5 =- (Jump to reporting rule immediately when tx.reporting_level is 5 or greater)
-SecRule TX:REPORTING_LEVEL "@ge 5" "id:980042,phase:5,pass,nolog,skipAfter:LOG-REPORTING"
+SecRule TX:REPORTING_LEVEL "@ge 5" "id:980042,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:LOG-REPORTING"
 
 # -= Zero detection score =- (Skip over reporting when sum of inbound and outbound detection score is equal to 0)
-SecRule TX:DETECTION_ANOMALY_SCORE "@eq 0" "id:980043,phase:5,pass,nolog,skipAfter:END-REPORTING"
+SecRule TX:DETECTION_ANOMALY_SCORE "@eq 0" "id:980043,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REPORTING"
 
 # -= Blocking score exceeds threshold =- (Jump to reporting rule immediately if a blocking score exceeds a threshold)
-SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" "id:980044,phase:5,pass,nolog,skipAfter:LOG-REPORTING"
-SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" "id:980045,phase:5,pass,nolog,skipAfter:LOG-REPORTING"
+SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" "id:980044,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:LOG-REPORTING"
+SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" "id:980045,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:LOG-REPORTING"
 
 # -= Reporting Level 2 =- (Skip over reporting when tx.reporting_level is less than 2)
-SecRule TX:REPORTING_LEVEL "@lt 2" "id:980046,phase:5,pass,nolog,skipAfter:END-REPORTING"
+SecRule TX:REPORTING_LEVEL "@lt 2" "id:980046,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REPORTING"
 
 # -= Detection score exceeds threshold =- (Jump to reporting rule immediately if a detection score exceeds a threshold)
-SecRule TX:DETECTION_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" "id:980047,phase:5,pass,nolog,skipAfter:LOG-REPORTING"
-SecRule TX:DETECTION_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" "id:980048,phase:5,pass,nolog,skipAfter:LOG-REPORTING"
+SecRule TX:DETECTION_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" "id:980047,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:LOG-REPORTING"
+SecRule TX:DETECTION_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" "id:980048,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:LOG-REPORTING"
 
 # -= Reporting Level 3 =- (Skip over reporting when tx.reporting_level is less than 3)
-SecRule TX:REPORTING_LEVEL "@lt 3" "id:980049,phase:5,pass,nolog,skipAfter:END-REPORTING"
+SecRule TX:REPORTING_LEVEL "@lt 3" "id:980049,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REPORTING"
 
 # -= Blocking score greater than zero =- (Jump to reporting rule immediately when sum of inbound and outbound blocking score is greater than zero)
-SecRule TX:BLOCKING_ANOMALY_SCORE "@gt 0" "id:980050,phase:5,pass,nolog,skipAfter:LOG-REPORTING"
+SecRule TX:BLOCKING_ANOMALY_SCORE "@gt 0" "id:980050,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:LOG-REPORTING"
 
 # -= Reporting Level 4 =- (Skip over reporting when tx.reporting_level is less than 4)
-SecRule TX:REPORTING_LEVEL "@lt 4" "id:980051,phase:5,pass,nolog,skipAfter:END-REPORTING"
+SecRule TX:REPORTING_LEVEL "@lt 4" "id:980051,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REPORTING"
 
 # At this point, the reporting level is 4 and there's a non-zero detection
 # score (already established by rule 980043) so fall through to the reporting
@@ -100,32 +100,32 @@ SecAction \
 SecMarker "END-REPORTING"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:980011,phase:1,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:980012,phase:2,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:980011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:980012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-980-CORRELATION"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:980013,phase:1,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:980014,phase:2,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:980013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:980014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-980-CORRELATION"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:980015,phase:1,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:980016,phase:2,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:980015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:980016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-980-CORRELATION"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:980017,phase:1,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:980018,phase:2,pass,nolog,skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:980017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:980018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-980-CORRELATION"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #


### PR DESCRIPTION
 - Adding missing tag `OWASP_CRS` to everywhere.
 - Adding missing `ver` action to everywhere.
 - Reordering tags in some rules to unify tag order.