### PR TITLE
feat: commenting out unneeded PL skipping rules to gain performance

### DIFF
--- a/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
+++ b/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
@@ -46,24 +46,24 @@ SecRule REQUEST_METHOD "!@within %{tx.allowed_methods}" \
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:911013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:911014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:911013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:911014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:911015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:911016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:911015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:911016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:911017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:911018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:911017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:911018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-913-SCANNER-DETECTION.conf
+++ b/rules/REQUEST-913-SCANNER-DETECTION.conf
@@ -56,24 +56,24 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scanners-user-agents.data" \
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:913013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:913014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:913013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:913014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:913015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:913016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:913015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:913016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:913017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:913018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:913017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:913018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -181,16 +181,16 @@ SecRule REQUEST_HEADERS:Referer|REQUEST_HEADERS:User-Agent "@pmFromFile lfi-os-f
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:930015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:930016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:930015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:930016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:930017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:930018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:930017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:930018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
+++ b/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
@@ -167,16 +167,16 @@ SecRule REQUEST_FILENAME "@rx (?i)(?:(?:url|jar):)?(?:a(?:cap|f[ps]|ttachment)|b
         setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:931015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:931016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:931015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:931016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:931017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:931018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:931017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:931018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -1814,8 +1814,8 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:932017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:932018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:932017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:932018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -754,8 +754,8 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:933017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:933018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:933017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:933018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
+++ b/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
@@ -346,14 +346,14 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:934015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:934016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:934015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:934016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:934017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:934018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:934017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:934018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -1050,16 +1050,16 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:941015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:941016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:941015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:941016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:941017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:941018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:941017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:941018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
+++ b/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
@@ -102,24 +102,24 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:943013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:943014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:943013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:943014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:943015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:943016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:943015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:943016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:943017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:943018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:943017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:943018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-949-BLOCKING-EVALUATION.conf
+++ b/rules/REQUEST-949-BLOCKING-EVALUATION.conf
@@ -232,32 +232,32 @@ SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_thresh
     tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev'"
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:949011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:949012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:949011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:949012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:949013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:949014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:949013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:949014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:949015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:949016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:949015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:949016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:949017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:949018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:949017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:949018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -116,16 +116,16 @@ SecRule RESPONSE_STATUS "@rx ^5\d{2}$" \
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:950015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:950016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:950015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:950016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:950017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:950018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:950017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:950018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -374,24 +374,24 @@ SecRule RESPONSE_BODY "@rx (?i)(?:Sybase message:|Warning.{2,20}sybase|Sybase.*S
 SecMarker "END-SQL-ERROR-MATCH-PL1"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:951013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:951014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:951013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:951014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:951015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:951016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:951015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:951016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:951017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:951018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:951017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:951018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
+++ b/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
@@ -70,24 +70,24 @@ SecRule RESPONSE_BODY "@pmFromFile java-errors.data" \
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:952013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:952014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:952013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:952014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:952015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:952016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:952015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:952016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:952017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:952018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:952017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:952018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -128,16 +128,16 @@ SecRule RESPONSE_BODY "@pmFromFile php-errors-pl2.data" \
     setvar:'tx.outbound_anomaly_score_pl2=+%{tx.error_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:953015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:953016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:953015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:953016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:953017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:953018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:953017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:953018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+++ b/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
@@ -114,24 +114,24 @@ SecRule RESPONSE_STATUS "!@rx ^404$" \
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:954013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:954014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:954013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:954014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:954015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:954016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:954015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:954016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:954017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:954018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:954017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:954018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-955-WEB-SHELLS.conf
+++ b/rules/RESPONSE-955-WEB-SHELLS.conf
@@ -526,16 +526,16 @@ SecRule RESPONSE_BODY "@contains <h1 style=\"margin-bottom: 0\">webadmin.php</h1
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:955015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:955016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:955015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:955016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:955017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:955018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:955017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:955018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
+++ b/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
@@ -242,32 +242,32 @@ SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_thre
     tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev'"
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:959011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:959012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:959011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:959012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:959013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:959014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:959013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:959014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:959015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:959016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:959015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:959016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:959017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:959018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:959017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:959018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -100,32 +100,32 @@ SecAction \
 SecMarker "END-REPORTING"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:980011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-980-CORRELATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:980012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-980-CORRELATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:980011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-980-CORRELATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:980012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-980-CORRELATION"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:980013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-980-CORRELATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:980014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-980-CORRELATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:980013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-980-CORRELATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:980014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-980-CORRELATION"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:980015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-980-CORRELATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:980016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-980-CORRELATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:980015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-980-CORRELATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:980016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-980-CORRELATION"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:980017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-980-CORRELATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:980018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-980-CORRELATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:980017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-980-CORRELATION"
+#SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:980018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-980-CORRELATION"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #


### PR DESCRIPTION
We can gain some performance by commenting out currently unneeded paranoia level skipping rules - those where are no rules for that paranoia level. We have 92 (!) such PL skipping rules.

It is possible to remove additional 26 PL skipping rules if we comment them out also based on phase (for example, there are no rules in phase 2 for PL1 in file `REQUEST-911-METHOD-ENFORCEMENT.conf` so PL1 skipping rule for phase 2 can be commented out). This is currently NOT part of this PR.
