### PR TITLE
refactor: Replace cnn.com with coreruleset.org

### DIFF
--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920100.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920100.yaml
@@ -87,7 +87,7 @@ tests:
               Host: "localhost"
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             protocol: "http"
-            uri: "www.cnn.com"
+            uri: "www.coreruleset.org"
             version: "HTTP/1.1"
           output:
             status: [400]
@@ -104,7 +104,7 @@ tests:
               Host: "localhost"
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             protocol: "http"
-            uri: "www.cnn.com:80"
+            uri: "www.coreruleset.org:80"
             version: "HTTP/1.1"
           output:
             no_log_contains: "id \"920100\""

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920300.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920300.yaml
@@ -54,7 +54,7 @@ tests:
               Proxy-Connection: "Keep-Alive"
               # Test needs a missing 'Accept' header
             method: "CONNECT"
-            uri: "www.cnn.com:80"
+            uri: "www.coreruleset.org:80"
             version: "HTTP/1.1"
           output:
             no_log_contains: "id \"920300\""

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941100.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941100.yaml
@@ -61,7 +61,7 @@ tests:
             uri: /
             headers:
               User-Agent: "OWASP CRS test agent"
-              Referer: http://www.cnn.com
+              Referer: http://www.coreruleset.org
               Host: localhost
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
           output:

--- a/tests/regression/tests/REQUEST-949-BLOCKING-EVALUATION/949110.yaml
+++ b/tests/regression/tests/REQUEST-949-BLOCKING-EVALUATION/949110.yaml
@@ -35,7 +35,7 @@ tests:
             uri: /
             headers:
               User-Agent: "OWASP CRS test agent"
-              Referer: http://www.cnn.com
+              Referer: http://www.coreruleset.org
               Host: localhost
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
           output:


### PR DESCRIPTION
As discussed on slack, replace cnn.com with coreruleset.org to make tests neutral