### PR TITLE
chore: consolidate CONTRIBUTORS.md after 4.0

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,27 +3,30 @@
 ## Project Co-Leads:
 
 - [Christian Folini](https://github.com/dune73)
-- [Walter Hop](https://github.com/lifeforms)
 - [Felipe Zipitría](https://github.com/fzipi)
 
 ## Developers:
 
-- [Paul Beckett](https://github.com/53cur3M3)
 - [Franziska Bühler](https://github.com/franbuehler)
 - [Esad Cetiner](https://github.com/esadcetiner)
-- [Christoph Hansen](https://github.com/emphazer)
 - [Ervin Hegedus](https://github.com/airween)
 - [Andrew Howe](https://github.com/RedXanadu)
 - [Karel Knibbe](https://github.com/karelorigin)
 - [Max Leske](https://github.com/theseion)
-- [Andrea Menin](https://github.com/theMiddleBlue)
 - [Matteo Pace](https://github.com/M4tteoP)
 - [Jitendra Patro](https://github.com/Xhoenix)
+- [Jozef Sudolský](https://github.com/azurit)
+
+## Former and Inactive Developers
+
+- [Paul Beckett](https://github.com/53cur3M3)
+- [Christoph Hansen](https://github.com/emphazer)
+- [Walter Hop](https://github.com/lifeforms) †
+- [Manuel Leos Rivas](https://github.com/spartantri)
+- [Andrea Menin](https://github.com/theMiddleBlue)
 - [Chaim Sanders](https://github.com/csanders-git)
 - [Federico G. Schwindt](https://github.com/fgsch)
-- [Manuel Leos Rivas](https://github.com/spartantri)
 - [Simon Studer](https://github.com/studersi)
-- [Jozef Sudolský](https://github.com/azurit)
 
 ## Contributors:
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -17,7 +17,7 @@
 - [Jitendra Patro](https://github.com/Xhoenix)
 - [Jozef Sudolský](https://github.com/azurit)
 
-## Former and Inactive Developers
+## Former and Inactive Developers:
 
 - [Paul Beckett](https://github.com/53cur3M3)
 - [Christoph Hansen](https://github.com/emphazer)


### PR DESCRIPTION
CC @53cur3M3, @emphazer, @spartantri, @theMiddleBlue, @csanders-git, @fgsch, @studersi

We discussed this internally and talked to some of you already. This is now the step that reduces the CONTRIBUTORS.md file to the currently actively contributing developers. That means we kept everybody in the file for 4.0, but now we move forward with the consolidated team.

If you pick up contributing to the project again, then you'll move to the developers section of course.
