### PR TITLE
fix: add missing roundcube files (930120 PL-1, 930121 PL-2, 930130 PL-1, 932180 PL-1)

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -681,8 +681,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # that affect the behavior of the web server, possibly causing remote
 # code execution.
 #
-SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEADERS:X-File-Name \
-    "@pmFromFile restricted-upload.data" \
+SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEADERS:X-File-Name "@pmFromFile restricted-upload.data" \
     "id:932180,\
     phase:2,\
     block,\

--- a/rules/lfi-os-files.data
+++ b/rules/lfi-os-files.data
@@ -143,6 +143,7 @@ boot/grub/grub.cfg
 boot/grub/menu.lst
 config_dev.yml
 config_prod.yml
+config.sample.php
 config_test.yml
 config.inc.php
 config.php
@@ -154,6 +155,7 @@ configuration.php
 cpanel/logs
 data/elasticsearch
 data/kafka
+defaults.inc.php
 etc/.java
 etc/acpi
 etc/adduser.conf

--- a/rules/restricted-files.data
+++ b/rules/restricted-files.data
@@ -176,6 +176,10 @@ WEB-INF/
 sslvpn_websession
 # BlockCypher log file used in code examples
 BlockCypher.log
+# Roundcube Webmail
+config.inc.php
+config.sample.php
+defaults.inc.php
 
 # /proc entries (keep in sync with lfi-os-files.data)
 # grep -E "^proc/" lfi-os-files.data

--- a/rules/restricted-upload.data
+++ b/rules/restricted-upload.data
@@ -94,13 +94,16 @@ cmdline
 composer.json
 composer.lock
 config.gz
+config.inc.php
 config.php
+config.sample.php
 config.yml
 config_dev.yml
 config_prod.yml
 config_test.yml
 cpuinfo
 database.yml
+defaults.inc.php
 default.settings.php
 diskstats
 dynamic_debug


### PR DESCRIPTION
``lfi-os-data`` already included Roundcube's ``config.inc.php`` but it was missing from other data files as well as ``config.sample.php`` and ``defaults.inc.php``. I've added Roundcube's example config files as well just in case someone left a database password in there.