### PR TITLE
chore: remove references to nonexistant 942110 rule

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1454,8 +1454,6 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
 #
 # The minimal string that triggers this regexp is: `if`
 #
-# The rule 942510 is related to 942110 which catches a single ' or `
-#
 # The rule 942511 is similar to this rule, but triggers on normal quotes
 # ('if'). That rule runs in paranoia level 3 or higher since it is prone to
 # false positives in natural text.
@@ -1853,8 +1851,6 @@ SecRule ARGS "@rx \W{4}" \
 # )?
 #
 # The minimal string that triggers this regexp is: 'if'
-#
-# The rule 942511 is related to 942110 which catches a single ' or `
 #
 # The rule 942510 is similar to this rule, but triggers on backticks
 # (`if`). That rule runs in paranoia level 2 or higher since the risk of


### PR DESCRIPTION
It was agreed to remove 942110 due to causing many false alarms without providing much value, however some traces of the rule remains in the code comments. https://github.com/coreruleset/coreruleset/issues/3466#issuecomment-1904742398