### PR TITLE
feat: accidental firewall disability prevention

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -285,6 +285,10 @@ SecAction \
     nolog,\
     tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
+    setvar:'tx.inbound_early_blocking_evaluated=0',\
+    setvar:'tx.inbound_blocking_evaluated=0',\
+    setvar:'tx.outbound_early_blocking_evaluated=0',\
+    setvar:'tx.outbound_blocking_evaluated=0',\
     setvar:'tx.blocking_inbound_anomaly_score=0',\
     setvar:'tx.detection_inbound_anomaly_score=0',\
     setvar:'tx.inbound_anomaly_score_pl1=0',\

--- a/rules/REQUEST-949-BLOCKING-EVALUATION.conf
+++ b/rules/REQUEST-949-BLOCKING-EVALUATION.conf
@@ -209,7 +209,7 @@ SecMarker "BEGIN-REQUEST-BLOCKING-EVAL"
 #
 
 # if early blocking is active, check threshold in phase 1
-SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
+SecAction \
     "id:949111,\
     phase:1,\
     deny,\
@@ -218,11 +218,14 @@ SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_thresh
     tag:'anomaly-evaluation',\
     tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
+    setvar:'tx.inbound_early_blocking_evaluated=1',\
     chain"
-    SecRule TX:EARLY_BLOCKING "@eq 1"
+    SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
+        "chain"
+        SecRule TX:EARLY_BLOCKING "@eq 1" "setvar:'tx.inbound_blocking_evaluated=1',setvar:'tx.outbound_early_blocking_evaluated=1',setvar:'tx.outbound_blocking_evaluated=1'"
 
 # always check threshold in phase 2
-SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
+SecAction \
     "id:949110,\
     phase:2,\
     deny,\
@@ -230,7 +233,10 @@ SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_thresh
     msg:'Inbound Anomaly Score Exceeded (Total Score: %{TX.BLOCKING_INBOUND_ANOMALY_SCORE})',\
     tag:'anomaly-evaluation',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.0.1-dev'"
+    ver:'OWASP_CRS/4.0.1-dev',\
+    setvar:'tx.inbound_blocking_evaluated=1',\
+    chain"
+    SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" "setvar:'tx.outbound_early_blocking_evaluated=1',setvar:'tx.outbound_blocking_evaluated=1'"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:949011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:949012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"

--- a/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
+++ b/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
@@ -219,7 +219,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
 #
 
 # if early blocking is active, check threshold in phase 3
-SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
+SecAction \
     "id:959101,\
     phase:3,\
     deny,\
@@ -228,11 +228,14 @@ SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_thre
     tag:'anomaly-evaluation',\
     tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.0.1-dev',\
+    setvar:'tx.outbound_early_blocking_evaluated=1',\
     chain"
-    SecRule TX:EARLY_BLOCKING "@eq 1"
+    SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
+        "chain"
+        SecRule TX:EARLY_BLOCKING "@eq 1" "setvar:'tx.outbound_blocking_evaluated=1'"
 
 # always check threshold in phase 4
-SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
+SecAction \
     "id:959100,\
     phase:4,\
     deny,\
@@ -240,7 +243,10 @@ SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_thre
     msg:'Outbound Anomaly Score Exceeded (Total Score: %{tx.blocking_outbound_anomaly_score})',\
     tag:'anomaly-evaluation',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.0.1-dev'"
+    ver:'OWASP_CRS/4.0.1-dev',\
+    setvar:'tx.outbound_blocking_evaluated=1',\
+    chain"
+    SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:959011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:959012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.0.1-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -19,6 +19,15 @@
 # -= Paranoia Level 0 (empty) =- (apply unconditionally)
 #
 
+SecRule TX:inbound_early_blocking_evaluated|TX:inbound_blocking_evaluated|TX:outbound_early_blocking_evaluated|TX:outbound_blocking_evaluated "@eq 0" \
+    "id:980098,\
+    phase:5,\
+    pass,\
+    t:none,\
+    msg:'ATTENTION, FIREWALL IS DISABLED!!! At least one of the blocking evaluation rules was not executed (Inbound early blocking evaluated: %{tx.inbound_early_blocking_evaluated}, inbound blocking evaluated: %{tx.inbound_blocking_evaluated}, outbound early blocking evaluated: %{tx.outbound_early_blocking_evaluated}, outbound blocking evaluated: %{tx.outbound_blocking_evaluated})',\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.0.1-dev'"
+
 # Combine inbound and outbound scores
 SecAction \
     "id:980099,\


### PR DESCRIPTION
This is only a proof-of-concept, probably not the best one.

Everyone of our users, who is new to rule exclusions and is trying to write his/her own exclusion rules, is disabling also one or both of the rules `949110` and `959100`. What is worse, in most cases, users see that it helped to resolve the problem and doesn't know that the whole firewall was disabled. Such cases are discovered probably only by accident, because users are having more problems they are unable to resolve and are asking for help where they show us currently used exclusion rule. How many installations of CRS are there with rules `949110/959100` disabled?

This PR is showing how it is possible to partially prevent this and, at least, log a huge warning for a user.

Any ideas how to do this better are welcomed.