### PR TITLE
fix: pin tool versions in gha

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,6 +2,11 @@ name: Lint
 
 on: [push, pull_request, merge_group]
 
+# Pin versions to not disrupt test pipelines
+env:
+  CRS_TOOLCHAIN_VERSION: '2.1.0'
+  SECRULES_PARSING_VERSION: '0.2.7'
+
 jobs:
   check-syntax:
     runs-on: ubuntu-latest
@@ -28,7 +33,7 @@ jobs:
       - name: "Check CRS syntax"
         run: |
           pip install --upgrade setuptools
-          pip install secrules-parsing
+          pip install secrules-parsing==${{ env.SECRULES_PARSING_VERSION }}
           secrules-parser -c --output-type github -f rules/*.conf
 
       - name: "Check CRS formatting"
@@ -43,14 +48,12 @@ jobs:
           pip install -r ./util/find-rules-without-test/requirements.txt
           ./util/find-rules-without-test/find-rules-without-test.py --output=github .
 
-      - name: "Install crs-toolchain"
+      - name: "Install crs-toolchain ${{ env.CRS_TOOLCHAIN_VERSION }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release download -R coreruleset/crs-toolchain -p '*_linux_amd64.tar.gz'
-          ls crs-toolchain*
-          tar xzf crs-toolchain*_linux_amd64.tar.gz
-          rm crs-toolchain*_linux_amd64.tar.gz
+          gh release download -R coreruleset/crs-toolchain "v${{ env.CRS_TOOLCHAIN_VERSION }}" \
+            -p "crs-toolchain_${{ env.CRS_TOOLCHAIN_VERSION }}_linux_amd64.tar.gz" -O - | tar -xzvf - crs-toolchain
 
       - name: "Check that all assembly files are properly formatted"
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,10 @@ on:
       - '.github/**'
   merge_group:
 
+# Pin tool versions to prevent problems
+env:
+  GO_FTW_VERSION: '0.6.4'
+
 jobs:
   regression:
     runs-on: ubuntu-latest
@@ -27,20 +31,20 @@ jobs:
       - name: "Install dependencies"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GO_FTW_VERSION: '0.6.4'
         run: |
-          gh release download -R coreruleset/go-ftw v${GO_FTW_VERSION} -p "ftw_${GO_FTW_VERSION}_linux_amd64.tar.gz" -O - | tar -xzvf - ftw
+          gh release download -R coreruleset/go-ftw "v${{ env.GO_FTW_VERSION }}" \
+            -p "ftw_${{ env.GO_FTW_VERSION }}_linux_amd64.tar.gz" -O - | tar -xzvf - ftw
 
       - name: "Run tests for ${{ matrix.modsec_version }}"
-        run: |
-          mkdir -p tests/logs/${{ matrix.modsec_version }}/{nginx,apache2}
-          docker-compose -f ./tests/docker-compose.yml up -d "${{ matrix.modsec_version }}"
-          docker-compose -f ./tests/docker-compose.yml logs
-          [ $(docker inspect ${{ matrix.modsec_version }} --format='{{.State.Running}}') = 'true' ]
-          ./ftw check -d tests/regression/tests
-          ./ftw run -d tests/regression/tests --show-failures-only
         env:
           FTW_LOGFILE: './tests/logs/${{ matrix.modsec_version }}/error.log'
+        run: |
+          mkdir -p "tests/logs/${{ matrix.modsec_version }}/{nginx,apache2}"
+          docker-compose -f ./tests/docker-compose.yml up -d "${{ matrix.modsec_version }}"
+          docker-compose -f ./tests/docker-compose.yml logs
+          [ "$(docker inspect ${{ matrix.modsec_version }} --format='{{.State.Running}}')" = "true" ]
+          ./ftw check -d tests/regression/tests
+          ./ftw run -d tests/regression/tests --show-failures-only
 
       - name: "Change permissions if failed"
         if: failure()


### PR DESCRIPTION
To prevent unexpected results when running pipelines, pinning versions in our tools will allow us to make controlled deployments.