### PR TITLE
fix: run nightly workflows at separate times

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,6 +9,12 @@ jobs:
     name: Nightly Release
     runs-on: ubuntu-latest
     steps:
+      - name: Check GH API rate limits
+        run: |
+          gh api -i repos/coreruleset/coreruleset/releases/latest | grep -i "x-ratelimit"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: "Checkout repo"
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
 
@@ -57,5 +63,11 @@ jobs:
             --prerelease \
             --draft=false \
             nightly
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check GH API rate limits
+        run: |
+          gh api -i repos/coreruleset/coreruleset/releases/latest | grep -i "x-ratelimit"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -5,7 +5,7 @@ permissions: {}
 
 on:
   schedule:
-    - cron: '0 2 * * *' # run at 2 AM UTC
+    - cron: '0 4 * * *' # run at 4 AM UTC
 
 jobs:
   create-changelog-prs:
@@ -22,8 +22,20 @@ jobs:
         with:
           python-version: 3.12
 
+      - name: Check GH API rate limits
+        run: |
+          gh api -i repos/coreruleset/coreruleset/releases/latest | grep -i "x-ratelimit"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: "Run script"
         run: ".github/create-changelog-prs.py"
         env:
           # Required for the use of the gh CLI in the script
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check GH API rate limits
+        run: |
+          gh api -i repos/coreruleset/coreruleset/releases/latest | grep -i "x-ratelimit"
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Running workflows that use the GH API at the same time is a bad idea because it's easy to run into API rate limits that way.