### PR TITLE
fix: increase length of Accept-Encoding header from 50 to 100 (920520 PL1)

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1196,15 +1196,17 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
 
 #
 # Rule against CVE-2022-21907
-# This rule blocks Accept-Encoding headers longer than 50 characters.
-# The length of 50 is a heuristic based on the length of values from
+# This rule blocks Accept-Encoding headers longer than 100 characters.
+# The length of 100 is a heuristic based on the length of values from
 # the RFC (https://datatracker.ietf.org/doc/rfc9110/)
 # and the respective values assigned by IANA
 # (https://www.iana.org/assignments/http-parameters/http-parameters.xml#content-coding).
+# Concatenating all valid values for Accept-Encoding (without q=0.5) resulted in a value of 93:
+# aes128gcm, br, compress, deflate, exi, gzip, identity, pack200-gzip, x-compress, x-gzip, zstd
 #
 # This rule has a stricter sibling: 920521
 #
-SecRule REQUEST_HEADERS:Accept-Encoding "@gt 50" \
+SecRule REQUEST_HEADERS:Accept-Encoding "@gt 100" \
     "id:920520,\
     phase:1,\
     block,\

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920520.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920520.yaml
@@ -149,3 +149,21 @@ tests:
             version: "HTTP/1.1"
           output:
             no_log_contains: "id \"920520\""
+  - test_title: 920520-9
+    desc: "False positive test for long Accept-Encoding of length 99"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: "OWASP CRS test agent"
+              Accept: "*/*"
+              Host: "localhost"
+              Accept-Encoding: "aes128gcm, br, compress, deflate, exi, identity, pack200-gzip, x-compress, x-gzip, zstd, gzip;q=1.0"
+            protocol: "http"
+            uri: "/"
+            version: "HTTP/1.1"
+          output:
+            no_log_contains: "id \"920520\""

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920520.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920520.yaml
@@ -131,3 +131,21 @@ tests:
             version: "HTTP/1.1"
           output:
             log_contains: "id \"920520\""
+  - test_title: 920520-8
+    desc: "False positive test for long Accept-Encoding headers from internet.nl"
+    stages:
+      - stage:
+          input:
+            dest_addr: "127.0.0.1"
+            method: "GET"
+            port: 80
+            headers:
+              User-Agent: "OWASP CRS test agent"
+              Accept: "*/*"
+              Host: "localhost"
+              Accept-Encoding: "compress, deflate, exi, gzip, pack200-gzip, x-compress, x-gzip"
+            protocol: "http"
+            uri: "/"
+            version: "HTTP/1.1"
+          output:
+            no_log_contains: "id \"920520\""


### PR DESCRIPTION
This PR resolves #3623 by increasing the length of accepted Accept-Encoding headers from 50 to 100 (according to decision in [monthly chat meeting in April](https://github.com/coreruleset/coreruleset/issues/3636#issuecomment-2031698769)).
This PR also adds a test to ensure that internet.nl values no longer trigger FP.
Please also note that regression test 920520-7 still works.