### PR TITLE
fix: add visudo and cscli to unix-shell.data (932160 PL-1, 932161 PL-2)

### DIFF
--- a/rules/unix-shell.data
+++ b/rules/unix-shell.data
@@ -140,6 +140,7 @@ bin/cpulimit
 bin/crash
 bin/cron
 bin/crontab
+bin/cscli
 bin/csh
 bin/csplit
 bin/csvtool
@@ -583,6 +584,7 @@ bin/vim
 bin/vimdiff
 bin/vipw
 bin/virsh
+bin/visudo
 bin/volatility
 bin/w
 bin/w3m

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932160.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932160.yaml
@@ -197,3 +197,35 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "932160"
+  - test_title: 932160-13
+    desc: "Positive test: Match against bin/cscli"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: "localhost"
+              User-Agent: "OWASP CRS test agent"
+            method: GET
+            port: 80
+            uri: /get?a=bin/cscli
+            version: HTTP/1.0
+          output:
+            log_contains: id "932160"
+  - test_title: 932160-14
+    desc: "Positive test: Match against bin/visudo"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: "localhost"
+              User-Agent: "OWASP CRS test agent"
+            method: GET
+            port: 80
+            uri: /get?a=bin/visudo
+            version: HTTP/1.0
+          output:
+            log_contains: id "932160"


### PR DESCRIPTION
I was supposed to add cscli and visudo to ``unix-shell.data`` in https://github.com/coreruleset/coreruleset/pull/3649 but I forgot about it, this pr fixes that.