### PR TITLE
fix: add detection for php evasion attempt (933100 PL1)

### DIFF
--- a/regex-assembly/933100.ra
+++ b/regex-assembly/933100.ra
@@ -11,6 +11,7 @@
     x[^m]
     xm[^l]
     xml[^\s]
+    ##! With [^a-z] we are looking for `:` as in `<?xml :echo 1;`
     xml\s+[^a-z]
     xml$
     $

--- a/regex-assembly/933100.ra
+++ b/regex-assembly/933100.ra
@@ -11,7 +11,7 @@
     x[^m]
     xm[^l]
     xml[^\s]
-    xml\s*[^a-z]
+    xml\s+[^a-z]
     xml$
     $
     php

--- a/regex-assembly/933100.ra
+++ b/regex-assembly/933100.ra
@@ -11,6 +11,7 @@
     x[^m]
     xm[^l]
     xml[^\s]
+    xml\s*[^a-z]
     xml$
     $
     php

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -44,7 +44,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:933012,phase:2,pass,nolog,tag:'O
 # Therefore, that pattern is now checked by rule 933190 in paranoia levels
 # 3 or higher.
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)<\?(?:[^x]|x(?:[^m]|m(?:[^l]|l(?:[^\s\x0b]|$)))|$|php)|\[[/\x5c]?php\]" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)<\?(?:[^x]|x(?:[^m]|m(?:[^l]|l(?:[^\s\x0b]|[\s\x0b]*[^a-z]|$)))|$|php)|\[[/\x5c]?php\]" \
     "id:933100,\
     phase:2,\
     block,\

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -44,7 +44,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:933012,phase:2,pass,nolog,tag:'O
 # Therefore, that pattern is now checked by rule 933190 in paranoia levels
 # 3 or higher.
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)<\?(?:[^x]|x(?:[^m]|m(?:[^l]|l(?:[^\s\x0b]|[\s\x0b]*[^a-z]|$)))|$|php)|\[[/\x5c]?php\]" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)<\?(?:[^x]|x(?:[^m]|m(?:[^l]|l(?:[^\s\x0b]|[\s\x0b]+[^a-z]|$)))|$|php)|\[[/\x5c]?php\]" \
     "id:933100,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933100.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933100.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: csanders-git
+  author: "csanders-git, Franziska Bühler"
   description: None
   enabled: true
   name: 933100.yaml
@@ -74,6 +74,78 @@ tests:
             method: GET
             port: 80
             uri: /?foo=somePhpWouldGoHere%5B%5Cphp%5D
+            version: HTTP/1.0
+          output:
+            log_contains: id "933100"
+  - test_title: 933100-5
+    desc: |
+      xml/php polyglot payload, using a PHP
+      decoded payload: <?xml :echo 1;'
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "*/*"
+              Host: "localhost"
+              User-Agent: "OWASP CRS test agent"
+            method: GET
+            port: 80
+            uri: /?foo=%3C%3Fxml%20%3Aecho%201%3B
+            version: HTTP/1.0
+          output:
+            log_contains: id "933100"
+  - test_title: 933100-6
+    desc: |
+      xml/php polyglot payload, using a PHP, uppercase test
+      decoded payload: <?XML :echo 1;'
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "*/*"
+              Host: "localhost"
+              User-Agent: "OWASP CRS test agent"
+            method: GET
+            port: 80
+            uri: /?foo=%3C%3Fxml%20%3Aecho%201%3B
+            version: HTTP/1.0
+          output:
+            log_contains: id "933100"
+  - test_title: 933100-7
+    desc: |
+      xml/php polyglot payload, using a PHP
+      decoded payload: <?xml :fputCSV($alreadyOpenFile, array("foo", "bar", "hello", "world"));'
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "*/*"
+              Host: "localhost"
+              User-Agent: "OWASP CRS test agent"
+            method: GET
+            port: 80
+            uri: /?foo=%3C%3Fxml%20%3AfputCSV%28%24alreadyOpenFile%2C%20array%28%22foo%22%2C%20%22bar%22%2C%20%22hello%22%2C%20%22world%22%29%29%3B
+            version: HTTP/1.0
+          output:
+            log_contains: id "933100"
+  - test_title: 933100-8
+    desc: |
+      xml/php polyglot payload, using a PHP
+      decoded payload: <?xml   						 ();echo 1;
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "*/*"
+              Host: "localhost"
+              User-Agent: "OWASP CRS test agent"
+            method: GET
+            port: 80
+            uri: /?foo=%3C%3Fxml%20%20%20%09%09%09%09%09%09%20%28%29%3Becho%201%3B
             version: HTTP/1.0
           output:
             log_contains: id "933100"


### PR DESCRIPTION
This PR is the second PR that should resolve #3616.
It adds a new detection for `xml\s*[^a-z]` (ignore case). 
Thank you @floyd-fuh for the false negative report and for providing a detection regex.
This PR also adds some tests: false negative test and uppercase test