### PR TITLE
fix: fix permissions of log files for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
           FTW_LOGFILE: './tests/logs/${{ matrix.modsec_version }}/error.log'
         run: |
           mkdir -p "tests/logs/${{ matrix.modsec_version }}/{nginx,apache2}"
+          chmod -R o+rw "tests/logs"
           docker-compose -f ./tests/docker-compose.yml up -d "${{ matrix.modsec_version }}"
           docker-compose -f ./tests/docker-compose.yml logs
           [ "$(docker inspect ${{ matrix.modsec_version }} --format='{{.State.Running}}')" = "true" ]


### PR DESCRIPTION
The httpd container runs with a UID that differs from the host and is no longer root. On the GH runner, this apparently prevents files from being created in the logs directory.