### PR TITLE
fix: Oracle SQL database data leakage FP (951120 PL1)

### DIFF
--- a/regex-assembly/951120.ra
+++ b/regex-assembly/951120.ra
@@ -1,0 +1,15 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##!+ i
+
+##! ORA-04021: timeout occurred while waiting to lock object SYS.<package like UTL_FILE
+\bORA-[0-9][0-9][0-9][0-9][0-9]:
+java\.sql\.SQLException
+Oracle error
+##! Cannot initiate JDBC driver with class name oracle jdbc Oracle Driver
+##! [informatica][Oracle JDBC Driver][Oracle]Connection refused
+##! JDBC Driver class not found: oracle.jdbc.OracleDriver
+Oracle.{0,20}Driver
+Warning.*oci_.*
+Warning.*ora_.*

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -61,11 +61,12 @@ SecRule RESPONSE_BODY "@rx (?i:JET Database Engine|Access Database Engine|\[Micr
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
-# Examples of error messages:
-# Cannot initiate JDBC driver with class name oracle jdbc Oracle Driver
-# [informatica][Oracle JDBC Driver][Oracle]Connection refused
-# JDBC Driver class not found: oracle.jdbc.OracleDriver
-SecRule RESPONSE_BODY "@rx (?i:ORA-[0-9][0-9][0-9][0-9]|java\.sql\.SQLException|Oracle error|Oracle.{0,20}Driver|Warning.*oci_.*|Warning.*ora_.*)" \
+# Regular expression generated from regex-assembly/951120.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 951120
+#
+SecRule RESPONSE_BODY "@rx (?i)\bORA-[0-9][0-9][0-9][0-9][0-9]:|java\.sql\.SQLException|Oracle(?: erro|.{0,20}Drive)r|Warning.*o(?:ci|ra)_.*" \
     "id:951120,\
     phase:4,\
     block,\

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -61,7 +61,11 @@ SecRule RESPONSE_BODY "@rx (?i:JET Database Engine|Access Database Engine|\[Micr
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
-SecRule RESPONSE_BODY "@rx (?i:ORA-[0-9][0-9][0-9][0-9]|java\.sql\.SQLException|Oracle error|Oracle.*Driver|Warning.*oci_.*|Warning.*ora_.*)" \
+# Examples of error messages:
+# Cannot initiate JDBC driver with class name oracle jdbc Oracle Driver
+# [informatica][Oracle JDBC Driver][Oracle]Connection refused
+# JDBC Driver class not found: oracle.jdbc.OracleDriver
+SecRule RESPONSE_BODY "@rx (?i:ORA-[0-9][0-9][0-9][0-9]|java\.sql\.SQLException|Oracle error|Oracle.{0,20}Driver|Warning.*oci_.*|Warning.*ora_.*)" \
     "id:951120,\
     phase:4,\
     block,\


### PR DESCRIPTION
I'm getting FPs with this part of regex matching Oracle SQL error messages:
`Oracle.*Driver`

Was trying to find what kind of error messages is this regex supposed to match and was able to found only these:
```
Cannot initiate JDBC driver with class name oracle jdbc Oracle Driver
[informatica][Oracle JDBC Driver][Oracle]Connection refused
JDBC Driver class not found: oracle.jdbc.OracleDriver
```
My fix expects that the last one may be in the form of `oracle.jdbc.Oracle<something>Driver` (but i haven't found any on the web) and for this case the 20 characters limit seems to be sufficient.

Also, this PR fixes other FPs, for example:
```
<URL>https://www.example.com/rainbow-loom-gumicky-trikolora-20721/</URL>
41-npr-devinska-kobyla-_-florora-693027.jpg
```

All Oracle error codes which i was able to find has 5 digits suffixed with a colon.