### PR TITLE
feat: catch Java PostgreSQL errors (951240 PL1)

### DIFF
--- a/regex-assembly/951240.ra
+++ b/regex-assembly/951240.ra
@@ -15,3 +15,4 @@ PG::[a-z]*Error
 Supplied argument is not a valid PostgreSQL .*? resource
 Unable to connect to PostgreSQL server
 invalid input syntax for integer
+org\.postgresql\.util\.PSQLException:

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -311,7 +311,7 @@ SecRule RESPONSE_BODY "@rx (?i)(?:supplied argument is not a valid |SQL syntax.*
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 951240
 #
-SecRule RESPONSE_BODY "@rx (?i)P(?:ostgreSQL(?: query failed:|.{1,20}ERROR)|G::[a-z]*Error)|pg_(?:query|exec)\(\) \[:|Warning.{1,20}\bpg_.*|valid PostgreSQL result|Npgsql\.|Supplied argument is not a valid PostgreSQL .*? resource|(?:Unable to connect to PostgreSQL serv|invalid input syntax for integ)er" \
+SecRule RESPONSE_BODY "@rx (?i)P(?:ostgreSQL(?: query failed:|.{1,20}ERROR)|G::[a-z]*Error)|(?:pg_(?:query|exec)\(\) \[|org\.postgresql\.util\.PSQLException):|Warning.{1,20}\bpg_.*|valid PostgreSQL result|Npgsql\.|Supplied argument is not a valid PostgreSQL .*? resource|(?:Unable to connect to PostgreSQL serv|invalid input syntax for integ)er" \
     "id:951240,\
     phase:4,\
     block,\


### PR DESCRIPTION
Catch Java error messages similar to this:
`org.postgresql.util.PSQLException: ERROR: duplicate key value violates unique constraint "uk_1t68827l97cwyxo9r1u6t4p7d"
`