### PR TITLE
fix: typos in 920330 and 942280 tests

### DIFF
--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920330.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920330.yaml
@@ -2,7 +2,7 @@
 meta:
   author: "csanders-git"
   enabled: true
-  name: "920320.yaml"
+  name: "920330.yaml"
   description: "Description"
 tests:
   - test_title: 920330-1

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942280.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942280.yaml
@@ -37,4 +37,4 @@ tests:
             data: "var=\"tester@coreruleset.org\"' waitfor delay'0:0:20'--"
             version: HTTP/1.0
           output:
-            log_contains: id "942280
+            log_contains: id "942280"


### PR DESCRIPTION
In https://github.com/coreruleset/coreruleset/blob/31ee4883c74e098e22ca69acd1c15a8a63ad94c4/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920330.yaml#L5 the value of name is `920320.yaml`, as opposed to the actual filename of `920330.yaml`
In https://github.com/coreruleset/coreruleset/blob/31ee4883c74e098e22ca69acd1c15a8a63ad94c4/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942280.yaml#L40 there is a missing trailing double quote in the `log_contains` field