### PR TITLE
test: change pl-1 to pl1 to be inline with others

### DIFF
--- a/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
+++ b/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
@@ -86,7 +86,7 @@ tests:
           output:
             no_log_contains: id "953100"
   - test_title: 953100-5
-    desc: "'cannot be empty is too common for PL-1 GH isue #3399"
+    desc: "'cannot be empty is too common for PL1 GH isue #3399"
     stages:
       - stage:
           input:

--- a/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953101.yaml
+++ b/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953101.yaml
@@ -86,7 +86,7 @@ tests:
           output:
             log_contains: id "953101"
   - test_title: 953101-5
-    desc: "'cannot be empty is too common for PL-1, it should match at PL-2 GH isue #3399"
+    desc: "'cannot be empty is too common for PL1, it should match at PL2 GH isue #3399"
     stages:
       - stage:
           input:


### PR DESCRIPTION
In most instances (within tests at least) priority level 1 and 2 are referred to as `PL1` and `PL2`. 
In a couple of instances they are referred to as `PL-1` and `PL-2`; breaking the common terms used. 