### PR TITLE
fix(security): remove double URL decode (921151 PL2, 932190 PL3, 942441 PL2, 942442 PL2, 942460 PL3)

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -323,7 +323,7 @@ SecRule ARGS_GET "@rx [\n\r]" \
     phase:1,\
     block,\
     capture,\
-    t:none,t:urlDecodeUni,t:htmlEntityDecode,\
+    t:none,t:htmlEntityDecode,\
     msg:'HTTP Header Injection Attack via payload (CR/LF detected)',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -1670,7 +1670,7 @@ SecRule ARGS "@rx /(?:[?*]+[a-z/]+|[a-z/]+[?*]+)" \
     phase:2,\
     block,\
     capture,\
-    t:none,t:urlDecodeUni,t:normalizePath,t:cmdLine,\
+    t:none,t:normalizePath,t:cmdLine,\
     msg:'Remote Command Execution: Wildcard bypass technique attempt',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1323,7 +1323,7 @@ SecRule ARGS_GET:fbclid "@rx [a-zA-Z0-9_-]{61,61}" \
     "id:942441,\
     phase:2,\
     pass,\
-    t:none,t:urlDecodeUni,\
+    t:none,\
     nolog,\
     tag:'OWASP_CRS',\
     ctl:ruleRemoveTargetById=942440;ARGS:fbclid,\
@@ -1338,7 +1338,7 @@ SecRule ARGS_GET:gclid "@rx [a-zA-Z0-9_-]{91,91}" \
     "id:942442,\
     phase:2,\
     pass,\
-    t:none,t:urlDecodeUni,\
+    t:none,\
     nolog,\
     tag:'OWASP_CRS',\
     ctl:ruleRemoveTargetById=942440;ARGS:gclid,\
@@ -1814,7 +1814,7 @@ SecRule ARGS "@rx \W{4}" \
     phase:2,\
     block,\
     capture,\
-    t:none,t:urlDecodeUni,\
+    t:none,\
     msg:'Meta-Character Anomaly Detection Alert - Repetitive Non-Word Characters',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\


### PR DESCRIPTION
As these rules are matching only against ARGS* variables, double URL decode can be removed immediately and without handling other related problems.

Partial fix for R9V-240531.