### PR TITLE
feat: skip response rules if data are compressed

### DIFF
--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -21,7 +21,15 @@
 # -= Paranoia Level 0 (empty) =- (apply unconditionally)
 #
 
-
+# Skip all rules if RESPONSE_BODY is compressed.
+SecRule RESPONSE_HEADERS:Content-Encoding "@pm gzip compress deflate br zstd" \
+    "id:950010,\
+    phase:4,\
+    pass,\
+    nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.4.0-dev',\
+    skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:950011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.4.0-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:950012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.4.0-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -12,7 +12,15 @@
 # -= Paranoia Level 0 (empty) =- (apply unconditionally)
 #
 
-
+# Skip all rules if RESPONSE_BODY is compressed.
+SecRule RESPONSE_HEADERS:Content-Encoding "@pm gzip compress deflate br zstd" \
+    "id:951010,\
+    phase:4,\
+    pass,\
+    nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.4.0-dev',\
+    skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:951011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.4.0-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:951012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.4.0-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"

--- a/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
+++ b/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
@@ -12,7 +12,15 @@
 # -= Paranoia Level 0 (empty) =- (apply unconditionally)
 #
 
-
+# Skip all rules if RESPONSE_BODY is compressed.
+SecRule RESPONSE_HEADERS:Content-Encoding "@pm gzip compress deflate br zstd" \
+    "id:952010,\
+    phase:4,\
+    pass,\
+    nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.4.0-dev',\
+    skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:952011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.4.0-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:952012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.4.0-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"

--- a/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -19,7 +19,7 @@ SecRule RESPONSE_HEADERS:Content-Encoding "@pm gzip compress deflate br zstd" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.3.0-dev',\
+    ver:'OWASP_CRS/4.4.0-dev',\
     skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:953011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.4.0-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"

--- a/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+++ b/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
@@ -12,7 +12,15 @@
 # -= Paranoia Level 0 (empty) =- (apply unconditionally)
 #
 
-
+# Skip all rules if RESPONSE_BODY is compressed.
+SecRule RESPONSE_HEADERS:Content-Encoding "@pm gzip compress deflate br zstd" \
+    "id:954010,\
+    phase:4,\
+    pass,\
+    nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.4.0-dev',\
+    skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:954011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.4.0-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:954012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.4.0-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"

--- a/rules/RESPONSE-955-WEB-SHELLS.conf
+++ b/rules/RESPONSE-955-WEB-SHELLS.conf
@@ -12,7 +12,15 @@
 # -= Paranoia Level 0 (empty) =- (apply unconditionally)
 #
 
-
+# Skip all rules if RESPONSE_BODY is compressed.
+SecRule RESPONSE_HEADERS:Content-Encoding "@pm gzip compress deflate br zstd" \
+    "id:955010,\
+    phase:4,\
+    pass,\
+    nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.4.0-dev',\
+    skipAfter:END-RESPONSE-955-WEB-SHELLS"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:955011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.4.0-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:955012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.4.0-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"


### PR DESCRIPTION
There is no sense in searching for any patters in compressed data.