### PR TITLE
fix: shell history invocation false negative

### DIFF
--- a/regex-assembly/932330.ra
+++ b/regex-assembly/932330.ra
@@ -3,10 +3,10 @@
 
 ##!> assemble
 
-##! shell history invocation
+  ##! shell history invocation
 
-!!
-!-\d
-!\d
+  !!
+  !-\d
+  !\d
 
 ##!<

--- a/regex-assembly/932330.ra
+++ b/regex-assembly/932330.ra
@@ -1,0 +1,12 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##!> assemble
+
+##! shell history invocation
+
+!!
+!-\d
+!\d
+
+##!<

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -512,7 +512,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # This rule has stricter siblings:
 #   * 932331 (PL3)
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx !-\d" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx !(?:[!0-9]|-[0-9])" \
     "id:932330,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932330.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932330.yaml
@@ -34,7 +34,7 @@ tests:
             method: GET
             port: 80
             uri: "/get?rce=!!1-3"
-            version: HTTP/1.0
+            version: HTTP/1.1
           output:
             log_contains: id "932330"
   - test_title: 932330-3

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932330.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932330.yaml
@@ -38,7 +38,7 @@ tests:
           output:
             log_contains: id "932330"
   - test_title: 932330-3
-    desc: "Unix shell history invocation: relative position"
+    desc: "Unix shell history invocation: absolute position"
     stages:
       - stage:
           input:

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932330.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932330.yaml
@@ -50,7 +50,7 @@ tests:
             method: GET
             port: 80
             uri: "/get?rce=!1!2"
-            version: HTTP/1.0
+            version: HTTP/1.1
           output:
             log_contains: id "932330"
   - test_title: 932330-4

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932330.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932330.yaml
@@ -22,7 +22,7 @@ tests:
           output:
             log_contains: id "932330"
   - test_title: 932330-2
-    desc: "Unix shell history invocation: argument injection"
+    desc: "Unix shell history invocation: select word from previous command"
     stages:
       - stage:
           input:

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932330.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932330.yaml
@@ -21,3 +21,51 @@ tests:
             version: HTTP/1.0
           output:
             log_contains: id "932330"
+  - test_title: 932330-2
+    desc: "Unix shell history invocation: argument injection"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: "localhost"
+              User-Agent: "OWASP CRS test agent"
+            method: GET
+            port: 80
+            uri: "/get?rce=!!1-3"
+            version: HTTP/1.0
+          output:
+            log_contains: id "932330"
+  - test_title: 932330-3
+    desc: "Unix shell history invocation: relative position"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: "localhost"
+              User-Agent: "OWASP CRS test agent"
+            method: GET
+            port: 80
+            uri: "/get?rce=!1!2"
+            version: HTTP/1.0
+          output:
+            log_contains: id "932330"
+  - test_title: 932330-4
+    desc: "Unix shell history invocation: previous command"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+              Host: "localhost"
+              User-Agent: "OWASP CRS test agent"
+            method: GET
+            port: 80
+            uri: "/get?rce=!!"
+            version: HTTP/1.0
+          output:
+            log_contains: id "932330"

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932330.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932330.yaml
@@ -66,6 +66,6 @@ tests:
             method: GET
             port: 80
             uri: "/get?rce=!!"
-            version: HTTP/1.0
+            version: HTTP/1.1
           output:
             log_contains: id "932330"


### PR DESCRIPTION
Detect payloads like:

!! - Last command executed 
!1 - First command in history
!!2-3 - 3rd and 4th word(argument) from previous command.