### PR TITLE
fix: add 'user: root' directives and explanations

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -5,6 +5,11 @@ services:
   modsec2-apache:
     container_name: modsec2-apache
     image: owasp/modsecurity-crs:apache@sha256:36fc67d66f7761a6cb532c4855901a41792efa6e58303833c03aeed285c9c961 # pin v4.3.0
+    # NOTE: The user used to run the container process is explicitly set to
+    # 'root'. This fixes issues with permissions on the logging directories used
+    # as bind mounts. This is done as *a convenience for running the CRS testing
+    # setup only* and *should not be done in general!*
+    user: root
     environment:
       ACCESSLOG: "/var/log/apache2/access.log"
       BACKEND: http://backend
@@ -38,6 +43,11 @@ services:
   modsec3-nginx:
     container_name: modsec3-nginx
     image: owasp/modsecurity-crs:nginx@sha256:44b6e45fdc9eb9fdd34bb62f91f51513a87116e1445222cff7f4018bed7d42eb # pin v4.3.0
+    # NOTE: The user used to run the container process is explicitly set to
+    # 'root'. This fixes issues with permissions on the logging directories used
+    # as bind mounts. This is done as *a convenience for running the CRS testing
+    # setup only* and *should not be done in general!*
+    user: root
     environment:
       ACCESSLOG: "/var/log/nginx/access.log"
       BACKEND: http://backend


### PR DESCRIPTION
_Fixes: #3738._

The CRS Docker containers were recently changed to go root-less. This broke testing setups as the Docker bind mounts now run into permissions issues that prevent the CRS test containers from starting (the containers cannot write to the filesystem by default any more and the containers fail at startup).

For the purposes of running the CRS testing setup without issue:

**This PR:**

- Uses the Docker `user` directive to override the user that is used to run the testing container processes, setting them back to root like before. This means that the CRS testing setup that we ship once again "just works" out of the box
- Adds appropriate documentation warnings to the docker-compose file warning users not to blindly copy this setup with `user: root`