### PR TITLE
test: remove redundant commented tests in 920480

### DIFF
--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920480.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920480.yaml
@@ -95,7 +95,7 @@ tests:
         output:
           log:
             no_expect_ids: [920480]
-  - test_id: 2
+  - test_id: 7
     stages:
       - input:
           dest_addr: "127.0.0.1"
@@ -192,7 +192,7 @@ tests:
         output:
           log:
             no_expect_ids: [920480]
-  - test_id: 5
+  - test_id: 13
     stages:
       - input:
           dest_addr: "127.0.0.1"
@@ -210,7 +210,7 @@ tests:
           log:
             no_expect_ids: [920480]
   # TODO: this case is not yet handled by 3.1, future work (https://github.com/coreruleset/coreruleset/issues/3743)
-  # - test_id: 6
+  # - test_id: 14
   #   stages:
   #     - input:
   #        dest_addr: "127.0.0.1"
@@ -226,7 +226,7 @@ tests:
   #      output:
   #         log:
   #          epxect_ids:: [920480]
-  - test_id: 7
+  - test_id: 15
     stages:
       - input:
           dest_addr: "127.0.0.1"
@@ -243,7 +243,7 @@ tests:
         output:
           log:
             expect_ids: [920480]
-  - test_id: 8
+  - test_id: 16
     stages:
       - input:
           dest_addr: "127.0.0.1"
@@ -261,7 +261,7 @@ tests:
           log:
             expect_ids: [920480]
   # TODO: this test should pass (works with curl), to be researched (https://github.com/coreruleset/coreruleset/issues/3743)
-  # - test_id: 9
+  # - test_id: 17
   #   stages:
   #     - input:
   #        dest_addr: "127.0.0.1"
@@ -278,7 +278,7 @@ tests:
   #        log:
   #          expect_ids: [920480]
   # TODO: this test should pass (works with curl), to be researched (https://github.com/coreruleset/coreruleset/issues/3743)
-  # - test_id: 10
+  # - test_id: 18
   #   stages:
   #     - input:
   #         dest_addr: "127.0.0.1"
@@ -294,7 +294,7 @@ tests:
   #       output:
   #         log:
   #           expect_ids: [920480]
-  - test_id: 11
+  - test_id: 19
     stages:
       - input:
           dest_addr: "127.0.0.1"
@@ -310,41 +310,7 @@ tests:
         output:
           log:
             expect_ids: [920480]
-  # TODO: this case is not yet checked by CRS, future work (https://github.com/coreruleset/coreruleset/issues/3743)
-  # - test_id: 12
-  #   stages:
-  #     - input:
-  #        dest_addr: "127.0.0.1"
-  #        port: 80
-  #        method: "POST"
-  #        headers:
-  #          User-Agent: "OWASP CRS test agent"
-  #          Host: "localhost"
-  #          Content-Type: "application/x-www-form-urlencoded;charset=utf-8;charset=ibm037" #double charset may cause evasion
-  #        uri: "/"
-  #        data: "test=value"
-  #        version: "HTTP/1.1"
-  #      output:
-  #        log:
-  #          expect_ids: [920480]
-  # TODO: this case is not yet checked by CRS, future work (https://github.com/coreruleset/coreruleset/issues/3743)
-  # - test_id: 13
-  #   stages:
-  #     - input:
-  #        dest_addr: "127.0.0.1"
-  #        port: 80
-  #        method: "POST"
-  #        headers:
-  #          User-Agent: "OWASP CRS test agent"
-  #          Host: "localhost"
-  #          Content-Type: "application/x-www-form-urlencoded;charset=ibm037;charset=UTF-8" #double charset may cause evasion
-  #        uri: "/"
-  #        data: "test=value"
-  #        version: "HTTP/1.1"
-  #      output:
-  #        log:
-  #          expect_ids: [920480]
-  - test_id: 14
+  - test_id: 20
     stages:
       - input:
           dest_addr: "127.0.0.1"
@@ -361,7 +327,7 @@ tests:
         output:
           log:
             no_expect_ids: [920480]
-  - test_id: 15
+  - test_id: 21
     stages:
       - input:
           dest_addr: "127.0.0.1"
@@ -378,7 +344,7 @@ tests:
         output:
           log:
             no_expect_ids: [920480]
-  - test_id: 16
+  - test_id: 22
     stages:
       - input:
           dest_addr: "127.0.0.1"
@@ -395,7 +361,7 @@ tests:
         output:
           log:
             expect_ids: [920480]
-  - test_id: 17
+  - test_id: 23
     stages:
       - input:
           dest_addr: "127.0.0.1"


### PR DESCRIPTION
The conditions of the removed tests are already covered by 920530

Fixes #3692