### PR TITLE
fix: enable checking ARG_LENGTH in tests

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       PORT: "8080"
       SERVERNAME: modsec2-apache
       VALIDATE_UTF8_ENCODING: 1
+      ARG_LENGTH: 1
     volumes:
       - ./logs/modsec2-apache:/var/log/apache2:rw
       - ../rules:/opt/owasp-crs/rules:ro
@@ -66,6 +67,7 @@ services:
       PORT: "8080"
       SERVERNAME: modsec3-nginx
       VALIDATE_UTF8_ENCODING: 1
+      ARG_LENGTH: 1
     volumes:
       - ./logs/modsec3-nginx:/var/log/nginx:rw
       - ../rules:/opt/owasp-crs/rules:ro

--- a/tests/regression/httpd-overrides.yaml
+++ b/tests/regression/httpd-overrides.yaml
@@ -12,13 +12,6 @@ test_overrides:
       status: 200
       log:
         no_expect_ids: [920360]
-  - rule_id: 920370
-    test_ids: [1]
-    reason: Doesn't trigger. Needs to be fixed (https://github.com/coreruleset/coreruleset/issues/3745)
-    output:
-      status: 200
-      log:
-        no_expect_ids: [920370]
   - rule_id: 920380
     test_ids: [1]
     reason: Requires MAX_NUM_ARGS to be set to a sufficiently low value

--- a/tests/regression/nginx-overrides.yaml
+++ b/tests/regression/nginx-overrides.yaml
@@ -72,13 +72,6 @@ test_overrides:
       status: 200
       log:
         no_expect_ids: [920360]
-  - rule_id: 920370
-    test_ids: [1]
-    reason: Exceeds PCRE limits
-    output:
-      status: 200
-      log:
-        no_expect_ids: [920360]
   - rule_id: 920380
     test_ids: [1]
     reason: Requires MAX_NUM_ARGS to be set to a sufficiently low value


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

- activates existing variable to be used in tests

Fixes #3745 