### PR TITLE
fix: use correct value to trigger test

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       PORT: "8080"
       SERVERNAME: modsec2-apache
       VALIDATE_UTF8_ENCODING: 1
-      ARG_LENGTH: 1
+      ARG_LENGTH: 400
     volumes:
       - ./logs/modsec2-apache:/var/log/apache2:rw
       - ../rules:/opt/owasp-crs/rules:ro
@@ -67,7 +67,7 @@ services:
       PORT: "8080"
       SERVERNAME: modsec3-nginx
       VALIDATE_UTF8_ENCODING: 1
-      ARG_LENGTH: 1
+      ARG_LENGTH: 400
     volumes:
       - ./logs/modsec3-nginx:/var/log/nginx:rw
       - ../rules:/opt/owasp-crs/rules:ro


### PR DESCRIPTION
In https://github.com/coreruleset/coreruleset/commit/50a1fdf875fd4d5b1c204f4db5cead5fd23700b9 we added the check for argument length, but it was added as boolean when it should have been an integer.
