### PR TITLE
fix: update ``docker-compose`` to ``docker compose``

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,8 @@ jobs:
       - name: "Run tests for ${{ matrix.modsec_version }}"
         run: |
           mkdir -p "tests/logs/${{ matrix.modsec_version }}/{nginx,apache2}"
-          docker-compose -f ./tests/docker-compose.yml up -d "${{ matrix.modsec_version }}"
-          docker-compose -f ./tests/docker-compose.yml logs
+          docker compose -f ./tests/docker-compose.yml up -d "${{ matrix.modsec_version }}"
+          docker compose -f ./tests/docker-compose.yml logs
           if ! [ "$(docker inspect ${{ matrix.modsec_version }} --format='{{.State.Running}}')" = "true" ]; then
             echo "Web server failed to start. Aborting."
             exit 1
@@ -66,5 +66,5 @@ jobs:
 
       - name: Clean docker-compose
         run: |
-          docker-compose -f ./tests/docker-compose.yml stop "${{ matrix.modsec_version }}"
-          docker-compose -f ./tests/docker-compose.yml down
+          docker compose -f ./tests/docker-compose.yml stop "${{ matrix.modsec_version }}"
+          docker compose -f ./tests/docker-compose.yml down


### PR DESCRIPTION
Regression tests are failing because the ``docker-compose`` command is no longer being recognized. Docker is now using ``docker compose``

https://github.com/coreruleset/coreruleset/actions/runs/10226259306/job/28315644800#step:4:21