### PR TITLE
perf: remove unnecessary chain rule and capture for 921180

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -457,11 +457,8 @@ SecRule TX:/paramcounter_.*/ "@gt 1" \
     tag:'capec/1000/152/137/15/460',\
     ver:'OWASP_CRS/4.6.0-dev',\
     severity:'CRITICAL',\
-    chain"
-    SecRule MATCHED_VARS_NAMES "@rx TX:paramcounter_(.*)" \
-        "capture,\
-        setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
-        setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+    setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
 # -=[ HTTP Parameter Pollution ]=-

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -446,8 +446,8 @@ SecRule TX:/paramcounter_.*/ "@gt 1" \
     "id:921180,\
     phase:2,\
     pass,\
-    msg:'HTTP Parameter Pollution (%{TX.1})',\
-    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    msg:'HTTP Parameter Pollution (%{MATCHED_VAR_NAME})',\
+    logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\


### PR DESCRIPTION
921180 works fine without the chained rule. It still correctly counts and blocks duplicate HTTP parameters