### PR TITLE
feat: Check that all rules have the correct CRS tag and version

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,6 +36,11 @@ jobs:
           pip install secrules-parsing==${{ env.SECRULES_PARSING_VERSION }}
           secrules-parser -c --output-type github -f rules/*.conf
 
+      - name: "Fetch git tags"
+        run: |
+          git tag -l
+          git fetch --tags
+
       - name: "Check CRS formatting"
         run: |
           pip install --upgrade setuptools

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,6 +13,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+        with:
+          # we want to use `git describe` to find the latest tag
+          fetch-depth: 50
+          fetch-tags: true
 
       - name: Lint Yaml
         uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # v3.1.1
@@ -35,15 +39,6 @@ jobs:
           pip install --upgrade setuptools
           pip install secrules-parsing==${{ env.SECRULES_PARSING_VERSION }}
           secrules-parser -c --output-type github -f rules/*.conf
-
-      - name: "Fetch git tags"
-        run: |
-          git tag -l
-          git fetch --tags
-
-      - name: "Show current tag"
-        run: |
-          git describe --tags
 
       - name: "Check CRS formatting"
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -41,6 +41,10 @@ jobs:
           git tag -l
           git fetch --tags
 
+      - name: "Show current tag"
+        run: |
+          git describe --tags
+
       - name: "Check CRS formatting"
         run: |
           pip install --upgrade setuptools

--- a/util/crs-rules-check/README.md
+++ b/util/crs-rules-check/README.md
@@ -51,6 +51,10 @@ Second, the script loops over each of the parsed structures. Each iteration cons
 * **Check rule tags** - only tags listed in `util/APPROVED_TAGS` may be used as tags in rules
     * to use a new tag on a rule, it **must** first be registered in the util/APPROVED_TAGS file
 * **Check t:lowercase and (?i) flag** - No combination of t:lowercase and (?i) should appear in the same rule.
+* **Check rule has a tag with value `OWASP_CRS`** - Every rule must have a tag with value `OWASP_CRS`
+* **Check rule has a `ver` action with correct version** - Every rule must have `ver` action with correct value
+    * script accepts `-v` or `--version` argument if you want to pass it manually
+    * if no `-v` was given, the script tries to extract the version from result of `git describe --tags`
 
 Finally, the script prints a report of all unused TX variables. Usually, unused TX variables occur when a rule creates a TX variable (e.g., `setvar:tx.foo=1`) but the value of the variable is never used anywhere else. This will only be revealed after the script has checked all rules.
 
@@ -449,6 +453,99 @@ examples/test10.conf
  No new tags added.
  There are one or more combinations of t:lowercase and (?i) flag.
   file=examples/test10.conf, line=5, endLine=5, title=t:lowercase and (?i): rule uses (?i) in combination with t:lowercase: 'lowercase'; rule id: 1
+End of checking parsed rules
+Cumulated report about unused TX variables
+ No unused TX variable
+```
+
+### Test 11 - Check rule has a tag with value OWASP_CRS
+
+
+```
+# no tag with OWASP_CRS
+SecRule REQUEST_URI "@rx index.php" \
+    "id:1,\
+    phase:1,\
+    deny,\
+    t:none,\
+    nolog,\
+    tag:attack-xss"
+```
+
+Rule 1 does not have `tag:OWASP_CRS`
+
+```
+$ ./rules-check.py -r examples/test11.conf -t ../APPROVED_TAGS
+Config file: examples/test11.conf
+ Parsing ok.
+Checking parsed rules...
+examples/test11.conf
+ Ignore case check ok.
+ Action order check ok.
+ Indentation check ok.
+ no 'ctl:auditLogParts' action found.
+ no duplicate id's
+ paranoia-level tags are correct.
+ PL anomaly_scores are correct.
+ All TX variables are set.
+ No new tags added.
+ No t:lowercase and (?i) flag used.
+ There are one or more rules without OWASP_CRS tag.
+  file=examples/test11.conf, line=8, endLine=8, title=tag:OWASP_CRS is missing: rule does not have tag with value 'OWASP_CRS'; rule id: 1
+ There are one or more rules without ver action.
+  file=examples/test11.conf, line=8, endLine=8, title=ver is missing / incorrect: rule does not have 'ver' action; rule id: 1
+End of checking parsed rules
+Cumulated report about unused TX variables
+ No unused TX variable
+```
+
+### Test 12 - Check rule has a ver action with correct version
+
+
+```
+# no 'ver' action
+SecRule REQUEST_URI "@rx index.php" \
+    "id:1,\
+    phase:1,\
+    deny,\
+    t:none,\
+    nolog,\
+    tag:OWASP_CRS"
+
+# 'ver' action has invalid value
+SecRule REQUEST_URI "@rx index.php" \
+    "id:1,\
+    phase:1,\
+    deny,\
+    t:none,\
+    nolog,\
+    tag:OWASP_CRS,\
+    ver:OWASP_CRS/1.0.0-dev"
+```
+
+Rule 1 does not have `ver`.
+Rule 2 has incorrect `ver` value.
+
+```
+$ ./rules-check.py -r examples/test12.conf -t ../APPROVED_TAGS
+Config file: examples/test12.conf
+ Parsing ok.
+Checking parsed rules...
+examples/test12.conf
+ Ignore case check ok.
+ Action order check ok.
+ Indentation check ok.
+ no 'ctl:auditLogParts' action found.
+ no duplicate id's
+ paranoia-level tags are correct.
+ PL anomaly_scores are correct.
+ All TX variables are set.
+ No new tags added.
+ No t:lowercase and (?i) flag used.
+ No rule without OWASP_CRS tag.
+ There are one or more rules without ver action.
+  file=examples/test12.conf, line=8, endLine=8, title=ver is missing / incorrect: rule does not have 'ver' action; rule id: 1
+  file=examples/test12.conf, line=18, endLine=18, title=ver is missing / incorrect: rule's 'ver' action has incorrect value; rule id: 2, version: 'OWASP_CRS/1.0.0-dev', expected: 'OWASP_CRS/4.6.0-dev'
 End of checking parsed rules
 Cumulated report about unused TX variables
  No unused TX variable

--- a/util/crs-rules-check/examples/test11.conf
+++ b/util/crs-rules-check/examples/test11.conf
@@ -1,0 +1,8 @@
+# no tag with OWASP_CRS
+SecRule REQUEST_URI "@rx index.php" \
+    "id:1,\
+    phase:1,\
+    deny,\
+    t:none,\
+    nolog,\
+    tag:attack-xss"

--- a/util/crs-rules-check/examples/test12.conf
+++ b/util/crs-rules-check/examples/test12.conf
@@ -1,0 +1,18 @@
+# no 'ver' action
+SecRule REQUEST_URI "@rx index.php" \
+    "id:1,\
+    phase:1,\
+    deny,\
+    t:none,\
+    nolog,\
+    tag:OWASP_CRS"
+
+# 'ver' action has invalid value
+SecRule REQUEST_URI "@rx index.php" \
+    "id:2,\
+    phase:1,\
+    deny,\
+    t:none,\
+    nolog,\
+    tag:OWASP_CRS,\
+    ver:OWASP_CRS/1.0.0-dev"

--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -665,7 +665,7 @@ class Check(object):
                         'ruleid' : ruleid,
                         'line'   : a['lineno'],
                         'endLine': a['lineno'],
-                        'message': "rule does not have tag with value 'OWASP_CRS'; rule id: %d" % (ruleid)
+                        'message': f"rule does not have tag with value 'OWASP_CRS'; rule id: {ruleid}"
                     })
 
     def check_ver_action(self, version):

--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -7,6 +7,7 @@ import msc_pyparser
 import difflib
 import argparse
 import re
+import subprocess
 
 oformat = "native"
 
@@ -80,8 +81,10 @@ class Check(object):
         self.ids            = {}    # list of rule id's
         self.newtags        = []    # list of new, unlisted tags
         self.ignorecase     = []    # list of combinations of t:lowercase and (?i)
+        self.nocrstags      = []    # list of rules without tag:OWASP_CRS
+        self.noveract       = []    # list of rules without ver action or incorrect ver
 
-        self.re_tx_var      = re.compile("%\{\}")
+        self.re_tx_var      = re.compile("%\\{\\}")
 
     def store_error(self, msg):
         # store the error msg in the list
@@ -278,7 +281,7 @@ class Check(object):
                             # OR
                             # key exists but the existing struct's phase is higher
                             if (txv[0] not in self.globtxvars or self.globtxvars[txv[0]]['phase'] > phase) and \
-                               not re.search("%\{[^%]+\}", txv[0]):
+                               not re.search("%\\{[^%]+\\}", txv[0]):
                                 self.globtxvars[txv[0]] = {
                                     'phase'  : phase,
                                     'used'   : False,
@@ -343,13 +346,13 @@ class Check(object):
                     #  act_atg_val <- 5
                     #
                     if "act_arg" in a and a['act_arg'] is not None:
-                        val_act = re.findall("%\{(tx.[^%]*)\}", a['act_arg'], re.I)
+                        val_act = re.findall("%\\{(tx.[^%]*)\\}", a['act_arg'], re.I)
                     if "act_arg_val" in a and a['act_arg_val'] is not None:
-                        val_act_arg = re.findall("%\{(tx.[^%]*)\}", a['act_arg_val'], re.I)
+                        val_act_arg = re.findall("%\\{(tx.[^%]*)\\}", a['act_arg_val'], re.I)
                     for v in val_act + val_act_arg:
                         v = v.lower().replace("tx.", "")
                         # check whether the variable is a captured var, eg TX.1 - we do not care that case
-                        if not re.match("^\d$", v, re.I):
+                        if not re.match("^\\d$", v, re.I):
                             # v holds the tx.ANY variable, but not the captured ones
                             # we should collect these variables
                             if (v not in self.globtxvars or phase < self.globtxvars[v]['phase']):
@@ -368,14 +371,14 @@ class Check(object):
                     aidx += 1
 
                 if "operator_argument" in d:
-                    oparg = re.findall("%\{(tx.[^%]*)\}", d['operator_argument'], re.I)
+                    oparg = re.findall("%\\{(tx.[^%]*)\\}", d['operator_argument'], re.I)
                     if oparg:
                         for o in oparg:
                             o = o.lower()
-                            o = re.sub("tx\.", "", o, re.I)
+                            o = re.sub("tx\\.", "", o, re.I)
                             if (o not in self.globtxvars or phase < self.globtxvars[o]['phase']) and \
-                              not re.match("^\d$", o) and \
-                              not re.match("\/.*\/", o) and \
+                              not re.match("^\\d$", o) and \
+                              not re.match("\\/.*\\/", o) and \
                               check_exists is None:
                                 self.undef_txvars.append({
                                     'var'    : o,
@@ -385,8 +388,8 @@ class Check(object):
                                     'message': "TX variable '%s' not set / later set (OPARG) in rule %d" % (o, ruleid)
                                 })
                             elif o in self.globtxvars and phase >= self.globtxvars[o]['phase'] and \
-                                not re.match("^\d$", o) and \
-                                not re.match("\/.*\/", o):
+                                not re.match("^\\d$", o) and \
+                                not re.match("\\/.*\\/", o):
                                     self.globtxvars[o]['used'] = True
                 if "variables" in d:
                     for v in d['variables']:
@@ -402,8 +405,8 @@ class Check(object):
                                 # * rule's phase lower than declaration's phase
                                 rvar = v['variable_part'].lower()
                                 if (rvar not in self.globtxvars or (ruleid != self.globtxvars[rvar]['ruleid'] and phase < self.globtxvars[rvar]['phase'])) and \
-                                  not re.match("^\d$", rvar) and \
-                                  not re.match("\/.*\/", rvar):
+                                  not re.match("^\\d$", rvar) and \
+                                  not re.match("\\/.*\\/", rvar):
                                     self.undef_txvars.append({
                                         'var'    : rvar,
                                         'ruleid' : ruleid,
@@ -412,8 +415,8 @@ class Check(object):
                                         'message': "TX variable '%s' not set / later set (VAR)" % (v['variable_part'])
                                     })
                                 elif rvar in self.globtxvars and phase >= self.globtxvars[rvar]['phase'] and \
-                                    not re.match("^\d$", rvar) and \
-                                    not re.match("\/.*\/", rvar):
+                                    not re.match("^\\d$", rvar) and \
+                                    not re.match("\\/.*\\/", rvar):
                                         self.globtxvars[rvar]['used'] = True
                             else:
                                 check_exists = True
@@ -469,7 +472,7 @@ class Check(object):
                 for v in d['variables']:
                     if v['variable'].lower() == "tx" and \
                        v['variable_part'].lower() == "detection_paranoia_level" and \
-                       d['operator'] == "@lt" and re.match("^\d$", d['operator_argument']):
+                       d['operator'] == "@lt" and re.match("^\\d$", d['operator_argument']):
                             curr_pl = int(d['operator_argument'])
 
             if "actions" in d:
@@ -494,9 +497,9 @@ class Check(object):
                             txv = a['act_arg'][3:].split("=")
                             txv[0] = txv[0].lower()                     # variable name
                             if len(txv) > 1:
-                                txv[1] = txv[1].lower().strip("+\{\}")  # variable value
+                                txv[1] = txv[1].lower().strip("+\\{\\}")  # variable value
                             else:
-                                txv.append(a['act_arg_val'].strip("+\{\}"))
+                                txv.append(a['act_arg_val'].strip("+\\{\\}"))
                             _txvars[txv[0]] = txv[1]
                             _txvlines[txv[0]] = a['lineno']
                     if a['act_name'] == "nolog":
@@ -535,8 +538,8 @@ class Check(object):
 
                 for t in _txvars:
                     subst_val = re.search("%{tx.[a-z]+_anomaly_score}", _txvars[t], re.I)
-                    val = re.sub("[\+\%\{\}]", "", _txvars[t]).lower()
-                    scorepl = re.search("anomaly_score_pl\d$", t)   # check if last char is a numeric, eg ...anomaly_score_pl1
+                    val = re.sub("[\\+\\%\\{\\}]", "", _txvars[t]).lower()
+                    scorepl = re.search("anomaly_score_pl\\d$", t)   # check if last char is a numeric, eg ...anomaly_score_pl1
                     if scorepl:
                         if curr_pl > 0 and int(t[-1]) != curr_pl:
                             self.plscores.append({
@@ -627,6 +630,102 @@ class Check(object):
                             })
                                 aidx += 1
 
+    def check_crs_tag(self):
+        """
+        check that every rule has a `tag:'OWASP_CRS'` action
+        """
+        chained    = False
+        ruleid     = 0
+        chainlevel = 0
+        has_crs    = False
+        for d in self.data:
+            if "actions" in d:
+                aidx       = 0        # stores the index of current action
+                chainlevel = 0
+
+                if chained == False:
+                    ruleid     = 0
+                    has_crs    = False
+                    chainlevel = 0
+                else:
+                    chained    = False
+                while aidx < len(d['actions']):
+                    # read the action into 'a'
+                    a = d['actions'][aidx]
+                    if a['act_name'] == "id":
+                        ruleid = int(a['act_arg'])
+                    if a['act_name'] == "chain":
+                        chained = True
+                        chainlevel += 1
+                    if a['act_name'] == "tag":
+                        if chainlevel == 0:
+                            if a['act_arg'] == 'OWASP_CRS':
+                                has_crs = True
+                    aidx += 1
+                if ruleid > 0 and has_crs == False:
+                    self.nocrstags.append({
+                        'ruleid' : ruleid,
+                        'line'   : a['lineno'],
+                        'endLine': a['lineno'],
+                        'message': "rule does not have tag with value 'OWASP_CRS'; rule id: %d" % (ruleid)
+                    })
+
+    def check_ver_action(self, version):
+        """
+        check that every rule has a `ver` action
+        """
+        chained    = False
+        ruleid     = 0
+        chainlevel = 0
+        has_ver    = False
+        ver_is_ok  = False
+        crsversion = version
+        ruleversion = ""
+        for d in self.data:
+            if "actions" in d:
+                aidx       = 0        # stores the index of current action
+                chainlevel = 0
+
+                if chained == False:
+                    ruleid     = 0
+                    has_ver    = False
+                    ver_is_ok  = False
+                    chainlevel = 0
+                else:
+                    chained    = False
+                while aidx < len(d['actions']):
+                    # read the action into 'a'
+                    a = d['actions'][aidx]
+                    if a['act_name'] == "id":
+                        ruleid = int(a['act_arg'])
+                    if a['act_name'] == "chain":
+                        chained = True
+                        chainlevel += 1
+                    if a['act_name'] == "ver":
+                        if chainlevel == 0:
+                            has_ver = True
+                            if a['act_arg'] == version:
+                                ver_is_ok = True
+                            else:
+                                ruleversion = a['act_arg']
+                    aidx += 1
+                if ruleid > 0 and chainlevel == 0:
+                    if has_ver == False:
+                        self.noveract.append({
+                            'ruleid' : ruleid,
+                            'line'   : a['lineno'],
+                            'endLine': a['lineno'],
+                            'message': "rule does not have 'ver' action; rule id: %d" % (ruleid)
+                        })
+                    else:
+                        if ver_is_ok == False:
+                            self.noveract.append({
+                                'ruleid' : ruleid,
+                                'line'   : a['lineno'],
+                                'endLine': a['lineno'],
+                                'message': "rule's 'ver' action has incorrect value; rule id: %d, version: '%s', expected: '%s'" % (ruleid, ruleversion, crsversion)
+                            })
+
 def remove_comments(data):
     """
     In some special cases, remove the comments from the beginning of the lines.
@@ -711,6 +810,23 @@ def msg(msg):
     else:
         print(msg)
 
+def generate_version_string():
+    """
+    generate version string from git tag
+    program calls "git describe --tags" and converts it to version
+    eg:
+      v4.5.0-6-g872a90ab -> "4.6.0-dev"
+      v4.5.0-0-abcd01234 -> "4.5.0"
+    """
+    result = subprocess.run(["git", "describe", "--tags"], capture_output=True, text=True)
+    version = re.sub("^v", "", result.stdout.strip())
+    ver, commits = version.split("-")[0:2]
+    if int(commits) > 0:
+        version = ver.split(".")
+        version[1] = "%d" % (int(version[1]) + 1)
+        ver = "%s-dev" % (".".join(version))
+    return ver
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="CRS Rules Check tool")
     parser.add_argument("-o", "--output", dest="output", help="Output format native[default]|github", required=False)
@@ -718,6 +834,7 @@ if __name__ == "__main__":
                             nargs='*', help='Directory path to CRS rules', required=True,
                             action="append")
     parser.add_argument("-t", "--tags-list", dest="tagslist", help="Path to file with permitted tags", required=True)
+    parser.add_argument("-v", "--version", dest="version", help="Version string", required=False)
     args = parser.parse_args()
 
     crspath = []
@@ -729,6 +846,15 @@ if __name__ == "__main__":
             print("--output can be one of the 'native' or 'github'. Default value is 'native'")
             sys.exit(1)
     oformat = args.output
+
+    if args.version is None:
+        # if no --version/-v was given, get version from git describe --tags output
+        crsversion = generate_version_string()
+    else:
+        crsversion = args.version
+    # if no "OWASP_CRS/" prefix, append it
+    if not crsversion.startswith("OWASP_CRS/"):
+        crsversion = "OWASP_CRS/" + crsversion
 
     tags = []
     try:
@@ -791,6 +917,7 @@ if __name__ == "__main__":
             continue
 
     msg("Checking parsed rules...")
+    crsver = ""
     for f in parsed_structs.keys():
 
         msg(f)
@@ -856,7 +983,7 @@ if __name__ == "__main__":
             retval = 1
         for d in diff:
             d = d.strip("\n")
-            r = re.match("^@@ -(\d+),(\d+) \+\d+,\d+ @@$", d)
+            r = re.match("^@@ -(\\d+),(\\d+) \\+\\d+,\\d+ @@$", d)
             if r:
                 line1, line2 = [int(i) for i in r.groups()]
                 e = {
@@ -959,6 +1086,30 @@ if __name__ == "__main__":
                 a['indent'] = 2
                 a['file']   = f
                 a['title']  = "t:lowercase and (?i)"
+                errmsgf(a)
+                retval = 1
+        ### check for tag:'OWASP_CRS'
+        c.check_crs_tag()
+        if len(c.nocrstags) == 0:
+            msg(" No rule without OWASP_CRS tag.")
+        else:
+            errmsg(" There are one or more rules without OWASP_CRS tag.")
+            for a in c.nocrstags:
+                a['indent'] = 2
+                a['file']   = f
+                a['title']  = "tag:OWASP_CRS is missing"
+                errmsgf(a)
+                retval = 1
+        ### check for ver action
+        c.check_ver_action(crsversion)
+        if len(c.noveract) == 0:
+            msg(" No rule without correct ver action.")
+        else:
+            errmsg(" There are one or more rules without ver action.")
+            for a in c.noveract:
+                a['indent'] = 2
+                a['file']   = f
+                a['title']  = "ver is missing / incorrect"
                 errmsgf(a)
                 retval = 1
 

--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -604,7 +604,7 @@ class Check(object):
                     aidx += 1
 
     def check_lowercase_ignorecase(self):
-        ruleid = 0 
+        ruleid = 0
         for d in self.data:
             if d['type'].lower() == "secrule":
                 if d['operator'] == "@rx":
@@ -614,7 +614,7 @@ class Check(object):
                             aidx = 0        # stores the index of current action
                             while aidx < len(d['actions']):
                                 # read the action into 'a'
-                                a = d['actions'][aidx]               
+                                a = d['actions'][aidx]
                                 if a['act_name'] == "id":
                                     ruleid = int(a['act_arg'])
                                 if a['act_name'] == 't':
@@ -816,7 +816,7 @@ def generate_version_string():
       v4.5.0-6-g872a90ab -> "4.6.0-dev"
       v4.5.0-0-abcd01234 -> "4.5.0"
     """
-    result = subprocess.run(["git", "describe", "--tags"], capture_output=True, text=True)
+    result = subprocess.run(["git", "describe", "--tags", "--match", "v*.*.*"], capture_output=True, text=True)
     version = re.sub("^v", "", result.stdout.strip())
     ver, commits = version.split("-")[0:2]
     if int(commits) > 0:
@@ -1074,7 +1074,7 @@ if __name__ == "__main__":
                 a['title']  = "new unlisted tag"
                 errmsgf(a)
                 retval = 1
-        ### check for t:lowercase in combination with (?i) in regex       
+        ### check for t:lowercase in combination with (?i) in regex
         c.check_lowercase_ignorecase()
         if len(c.ignorecase) == 0:
             msg(" No t:lowercase and (?i) flag used.")
@@ -1130,4 +1130,3 @@ if __name__ == "__main__":
         msg(" No unused TX variable")
 
     sys.exit(retval)
-

--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -816,10 +816,6 @@ def generate_version_string():
       v4.5.0-6-g872a90ab -> "4.6.0-dev"
       v4.5.0-0-abcd01234 -> "4.5.0"
     """
-    result = subprocess.run(["git", "tag", "-l"], capture_output=True, text=True)
-    print(result.stdout.strip())
-    result = subprocess.run(["git", "fetch", "--tags"], capture_output=True, text=True)
-    print(result.stdout.strip())
     result = subprocess.run(["git", "describe", "--tags"], capture_output=True, text=True)
     version = re.sub("^v", "", result.stdout.strip())
     ver, commits = version.split("-")[0:2]

--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -536,7 +536,7 @@ class Check(object):
 
                 for t in _txvars:
                     subst_val = re.search("%{tx.[a-z]+_anomaly_score}", _txvars[t], re.I)
-                    val = re.sub(r"[\+\%\{\}]", "", _txvars[t]).lower()
+                    val = re.sub(r"[+%{}]", "", _txvars[t]).lower()
                     scorepl = re.search(r"anomaly_score_pl\d$", t)   # check if last char is a numeric, eg ...anomaly_score_pl1
                     if scorepl:
                         if curr_pl > 0 and int(t[-1]) != curr_pl:

--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -816,7 +816,10 @@ def generate_version_string():
       v4.5.0-6-g872a90ab -> "4.6.0-dev"
       v4.5.0-0-abcd01234 -> "4.5.0"
     """
-    subprocess.run(["git", "fetch", "--tags"], capture_output=True, text=True)
+    result = subprocess.run(["git", "tag", "-l"], capture_output=True, text=True)
+    print(result.stdout.strip())
+    result = subprocess.run(["git", "fetch", "--tags"], capture_output=True, text=True)
+    print(result.stdout.strip())
     result = subprocess.run(["git", "describe", "--tags"], capture_output=True, text=True)
     version = re.sub("^v", "", result.stdout.strip())
     ver, commits = version.split("-")[0:2]

--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -387,7 +387,7 @@ class Check(object):
                                 })
                             elif o in self.globtxvars and phase >= self.globtxvars[o]['phase'] and \
                                 not re.match(r"^\d$", o) and \
-                                not re.match(r"\/.*\/", o):
+                                not re.match(r"/.*/", o):
                                     self.globtxvars[o]['used'] = True
                 if "variables" in d:
                     for v in d['variables']:

--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -369,7 +369,7 @@ class Check(object):
                     aidx += 1
 
                 if "operator_argument" in d:
-                    oparg = re.findall("%\\{(tx.[^%]*)\\}", d['operator_argument'], re.I)
+                    oparg = re.findall(r"%\{(tx.[^%]*)\}", d['operator_argument'], re.I)
                     if oparg:
                         for o in oparg:
                             o = o.lower()

--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -350,7 +350,7 @@ class Check(object):
                     for v in val_act + val_act_arg:
                         v = v.lower().replace("tx.", "")
                         # check whether the variable is a captured var, eg TX.1 - we do not care that case
-                        if not re.match("^\\d$", v, re.I):
+                        if not re.match(r"^\d$", v, re.I):
                             # v holds the tx.ANY variable, but not the captured ones
                             # we should collect these variables
                             if (v not in self.globtxvars or phase < self.globtxvars[v]['phase']):

--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -821,7 +821,7 @@ def generate_version_string():
     ver, commits = version.split("-")[0:2]
     if int(commits) > 0:
         version = ver.split(".")
-        version[1] = "%d" % (int(version[1]) + 1)
+        version[1] = str((int(version[1]) + 1))
         ver = "%s-dev" % (".".join(version))
     return ver
 

--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -822,7 +822,7 @@ def generate_version_string():
     if int(commits) > 0:
         version = ver.split(".")
         version[1] = str((int(version[1]) + 1))
-        ver = "%s-dev" % (".".join(version))
+        ver = f"{".".join(version)}-dev"
     return ver
 
 if __name__ == "__main__":

--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -495,7 +495,7 @@ class Check(object):
                             txv = a['act_arg'][3:].split("=")
                             txv[0] = txv[0].lower()                     # variable name
                             if len(txv) > 1:
-                                txv[1] = txv[1].lower().strip("+\\{\\}")  # variable value
+                                txv[1] = txv[1].lower().strip(r"+\{\}")  # variable value
                             else:
                                 txv.append(a['act_arg_val'].strip(r"+\{\}"))
                             _txvars[txv[0]] = txv[1]

--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -376,7 +376,7 @@ class Check(object):
                             o = re.sub(r"tx\.", "", o, re.I)
                             if (o not in self.globtxvars or phase < self.globtxvars[o]['phase']) and \
                               not re.match(r"^\d$", o) and \
-                              not re.match(r"\/.*\/", o) and \
+                              not re.match(r"/.*/", o) and \
                               check_exists is None:
                                 self.undef_txvars.append({
                                     'var'    : o,

--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -713,7 +713,7 @@ class Check(object):
                             'ruleid' : ruleid,
                             'line'   : a['lineno'],
                             'endLine': a['lineno'],
-                            'message': "rule does not have 'ver' action; rule id: %d" % (ruleid)
+                            'message': f"rule does not have 'ver' action; rule id: {ruleid}"
                         })
                     else:
                         if ver_is_ok == False:

--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -404,7 +404,7 @@ class Check(object):
                                 rvar = v['variable_part'].lower()
                                 if (rvar not in self.globtxvars or (ruleid != self.globtxvars[rvar]['ruleid'] and phase < self.globtxvars[rvar]['phase'])) and \
                                   not re.match(r"^\d$", rvar) and \
-                                  not re.match(r"\/.*\/", rvar):
+                                  not re.match(r"/.*/", rvar):
                                     self.undef_txvars.append({
                                         'var'    : rvar,
                                         'ruleid' : ruleid,

--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -721,7 +721,7 @@ class Check(object):
                                 'ruleid' : ruleid,
                                 'line'   : a['lineno'],
                                 'endLine': a['lineno'],
-                                'message': "rule's 'ver' action has incorrect value; rule id: %d, version: '%s', expected: '%s'" % (ruleid, ruleversion, crsversion)
+                                'message': f"rule's 'ver' action has incorrect value; rule id: {ruleid}, version: '{ruleversion}', expected: '{crsversion}'"
                             })
 
 def remove_comments(data):

--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -497,7 +497,7 @@ class Check(object):
                             if len(txv) > 1:
                                 txv[1] = txv[1].lower().strip("+\\{\\}")  # variable value
                             else:
-                                txv.append(a['act_arg_val'].strip("+\\{\\}"))
+                                txv.append(a['act_arg_val'].strip(r"+\{\}"))
                             _txvars[txv[0]] = txv[1]
                             _txvlines[txv[0]] = a['lineno']
                     if a['act_name'] == "nolog":

--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -822,7 +822,7 @@ def generate_version_string():
     if int(commits) > 0:
         version = ver.split(".")
         version[1] = str((int(version[1]) + 1))
-        ver = f"{".".join(version)}-dev"
+        ver = f"""{".".join(version)}-dev"""
     return ver
 
 if __name__ == "__main__":

--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -414,7 +414,7 @@ class Check(object):
                                     })
                                 elif rvar in self.globtxvars and phase >= self.globtxvars[rvar]['phase'] and \
                                     not re.match(r"^\d$", rvar) and \
-                                    not re.match(r"\/.*\/", rvar):
+                                    not re.match(r"/.*/", rvar):
                                         self.globtxvars[rvar]['used'] = True
                             else:
                                 check_exists = True


### PR DESCRIPTION
Add two new features for `rules-check.py` linter:
* check that all rules have a `tag` with `OWASP_CRS`
* check that all rules have `ver` action with correct version string

Version can be passed manually with `-v`/`--version`. If no argument given, the script tries to get that from output of `git describe --tags`.

How the version is determined:
* eg `git describe --tags` gives string `v4.5.0-6-g872a90ab`
* `-6-` means there are 6 commits after `4.6.0`, so this is a `dev` version
  * in this case we increment MINOR version: `5` -> `6`
  * and version gets `-dev`
* the result will be: `4.6.0-dev` (`v` will be removed from the start position)
* if the version string is something like this: `v4.5.0-0-abcd01234` then the version will be `4.5.0`

In all cases the `OWASP_CRS/` prefix will be appended.
