### PR TITLE
fix: tests typos

### DIFF
--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920430.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920430.yaml
@@ -75,7 +75,8 @@ tests:
           uri: "/"
         output:
           expect_error: true
-          expect_ids: [920430]
+          log:
+            expect_ids: [920430]
   - test_id: 6
     stages:
       - input:

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932235.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932235.yaml
@@ -682,4 +682,4 @@ tests:
           version: HTTP/1.1
         output:
           log:
-            no_expectIds: [932235]
+            no_expect_ids: [932235]


### PR DESCRIPTION
Two typos:
- 932235 - test id 38 - had `no_expectIds` instead of `no_expect_ids`
- 920430 - `expect_ids` was directly under `output`, instead of being nested under `log` i.e. `output` -> `log` -> `expect_ids`