### PR TITLE
fix: add missing expect_ids/no_expect_ids

### DIFF
--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920160.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920160.yaml
@@ -20,6 +20,8 @@ tests:
           version: "HTTP/1.1"
         output:
           status: 400
+          log:
+            expect_ids: [920160]
   - test_id: 2
     desc: Non digit content-length with content-type
     stages:
@@ -37,6 +39,8 @@ tests:
           version: "HTTP/1.1"
         output:
           status: 400
+          log:
+            expect_ids: [920160]
   - test_id: 3
     desc: Mixed digit and non digit content length
     stages:
@@ -54,6 +58,8 @@ tests:
           version: "HTTP/1.1"
         output:
           status: 400
+          log:
+            expect_ids: [920160]
   - test_id: 4
     desc: |
       Content-Length HTTP header is not numeric (920160)  from old modsec regressions
@@ -101,3 +107,5 @@ tests:
           data: abc
         output:
           status: 400
+          log:
+            expect_ids: [920160]

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920270.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920270.yaml
@@ -58,6 +58,8 @@ tests:
           version: "HTTP/1.1"
         output:
           status: 400
+          log:
+            expect_ids: [920270]
   - test_id: 5
     stages:
       - input:

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920274.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920274.yaml
@@ -16,6 +16,8 @@ tests:
           version: "HTTP/1.1"
         output:
           status: 400
+          log:
+            expect_ids: [920274]
   - test_id: 2
     stages:
       - input:

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920280.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920280.yaml
@@ -45,3 +45,5 @@ tests:
         output:
           # Technically valid but Apache doesn't allow 0.9 anymore
           status: 400
+          log:
+            no_expect_ids: [920280]

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920290.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920290.yaml
@@ -20,6 +20,8 @@ tests:
           version: "HTTP/1.1"
         output:
           status: 400
+          log:
+            expect_ids: [920290]
   - test_id: 2
     stages:
       - input:

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920430.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920430.yaml
@@ -44,6 +44,8 @@ tests:
           uri: "/"
         output:
           status: 400
+          log:
+            expect_ids: [920430]
   - test_id: 4
     stages:
       - input:

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920610.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920610.yaml
@@ -32,3 +32,5 @@ tests:
             Accept: text/html;q=0.9,*/*;q=0.8
         output:
           status: 400
+          log:
+            expect_ids: [920610]


### PR DESCRIPTION
Certain tests that check for a specific status code do not contain `expect_ids` or `no_expect_ids`. This pr aims to address that, so that if these tests are not being ran against a specific server, the test can still be used to check if the rule matches or not. 