### PR TITLE
feat: add new rule to catch invalid character in multipart headers (v3)

### DIFF
--- a/rules/REQUEST-922-MULTIPART-ATTACK.conf
+++ b/rules/REQUEST-922-MULTIPART-ATTACK.conf
@@ -90,3 +90,27 @@ SecRule MULTIPART_PART_HEADERS "@rx content-transfer-encoding:(.*)" \
     ver:'OWASP_CRS/3.3.6-dev',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+ # Multipart header names can't contain any characters outside of range 33 and 126,
+ # excluding 58 (':') which is the separator.
+ # RFC 2045 refers RFC 822 about the header syntax.
+ # Note: this is in phase:2 because these are headers that come in the body
+ SecRule MULTIPART_PART_HEADERS "@rx [^\x21-\x7E][\x21-\x39\x3B-\x7E]*:" \
+     "id:922130,\
+     phase:2,\
+     block,\
+     capture,\
+     t:none,t:lowercase,\
+     msg:'Multipart header contains characters outside of valid range',\
+     logdata:'Matched Data: %{TX.0}',\
+     tag:'application-multi',\
+     tag:'language-multi',\
+     tag:'platform-multi',\
+     tag:'attack-multipart-header',\
+     tag:'paranoia-level/1',\
+     tag:'OWASP_CRS',\
+     tag:'capec/272/220',\
+     ver:'OWASP_CRS/3.3.6-dev',\
+     severity:'CRITICAL',\
+     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+

--- a/rules/REQUEST-922-MULTIPART-ATTACK.conf
+++ b/rules/REQUEST-922-MULTIPART-ATTACK.conf
@@ -91,25 +91,25 @@ SecRule MULTIPART_PART_HEADERS "@rx content-transfer-encoding:(.*)" \
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
- # Multipart header names can't contain any characters outside of range 33 and 126,
- # excluding 58 (':') which is the separator.
- # RFC 2045 refers RFC 822 about the header syntax.
- # Note: this is in phase:2 because these are headers that come in the body
- SecRule MULTIPART_PART_HEADERS "@rx [^\x21-\x7E][\x21-\x39\x3B-\x7E]*:" \
-     "id:922130,\
-     phase:2,\
-     block,\
-     capture,\
-     t:none,t:lowercase,\
-     msg:'Multipart header contains characters outside of valid range',\
-     logdata:'Matched Data: %{TX.0}',\
-     tag:'application-multi',\
-     tag:'language-multi',\
-     tag:'platform-multi',\
-     tag:'attack-multipart-header',\
-     tag:'paranoia-level/1',\
-     tag:'OWASP_CRS',\
-     tag:'capec/272/220',\
-     ver:'OWASP_CRS/3.3.6-dev',\
-     severity:'CRITICAL',\
-     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+# Multipart header names can't contain any characters outside of range 33 and 126,
+# excluding 58 (':') which is the separator.
+# RFC 2045 refers RFC 822 about the header syntax.
+# Note: this is in phase:2 because these are headers that come in the body
+SecRule MULTIPART_PART_HEADERS "@rx [^\x21-\x7E][\x21-\x39\x3B-\x7E]*:" \
+    "id:922130,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:lowercase,\
+    msg:'Multipart header contains characters outside of valid range',\
+    logdata:'Matched Data: %{TX.0}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-multipart-header',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/272/220',\
+    ver:'OWASP_CRS/3.3.6-dev',\
+    severity:'CRITICAL',\
+    setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"

--- a/tests/regression/tests/REQUEST-922-MULTIPART-ATTACK/922130.yaml
+++ b/tests/regression/tests/REQUEST-922-MULTIPART-ATTACK/922130.yaml
@@ -1,0 +1,169 @@
+---
+meta:
+  author: "Ervin Hegedus"
+  description: Test Multipart/form-data
+  name: 922130.yaml
+tests:
+  - test_title: 922130-1
+    desc: |
+      Positive test: special character in multipart header.
+      Request is a multipart request with 2 Content-Disposition headers,
+      where the first one contains a 0x0E character at the first position.
+      --boundary
+      \x0EContent-Disposition: form-data; name="file"; filename="1.php"
+      Content-Disposition: form-data; name="post"
+
+      <?php var_dump(file_get_contents("/etc/passwd"));
+      --boundary--
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            port: 80
+            uri: "/post"
+            version: "HTTP/1.1"
+            encoded_request: "UE9TVCAvcG9zdCBIVFRQLzEuMQ0KQWNjZXB0OiAqLyoNCkNvbm5lY3Rpb246IGNsb3NlDQpDb250ZW50LUxlbmd0aDogMTg1DQpDb250ZW50LVR5cGU6IG11bHRpcGFydC9mb3JtLWRhdGE7IGJvdW5kYXJ5PWJvdW5kYXJ5DQpIb3N0OiBsb2NhbGhvc3QNClVzZXItQWdlbnQ6IE9XQVNQIENSUyB0ZXN0IGFnZW50DQoNCi0tYm91bmRhcnkNCg5Db250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iMS5waHAiDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9InBvc3QiDQoNCjxwaHAgdmFyX2R1bXAoZmlsZV9nZXRfY29udGVudHMoIi9ldGMvcGFzc3dkIikpOw0KLS1ib3VuZGFyeS0t"
+          output:
+            # The rule will match when an older version of the engine doesn't fail parsing. In newer versions of the engine,
+            # parsing will fail and the body will be considered invalid.
+            log_contains: 'Multipart parsing error: Multipart: Invalid part header \(contains invalid character\)|\[id "922130"\] \[msg "Multipart header contains characters outside of valid range"\]'
+  - test_title: 922130-2
+    desc: |
+      Positive test: special character in multipart header.
+      Request is a multipart request with 2 Content-Disposition headers,
+      where the first one contains a 0x0E character at the last position.
+      --boundary
+      Content-Disposition\x0E: form-data; name="file"; filename="1.php"
+      Content-Disposition: form-data; name="post"
+
+      <?php var_dump(file_get_contents("/etc/passwd"));
+      --boundary--
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            method: POST
+            port: 80
+            uri: "/post"
+            version: "HTTP/1.1"
+            encoded_request: "UE9TVCAvcG9zdCBIVFRQLzEuMQ0KQWNjZXB0OiAqLyoNCkNvbm5lY3Rpb246IGNsb3NlDQpDb250ZW50LUxlbmd0aDogMTg2DQpDb250ZW50LVR5cGU6IG11bHRpcGFydC9mb3JtLWRhdGE7IGJvdW5kYXJ5PWJvdW5kYXJ5DQpIb3N0OiBsb2NhbGhvc3QNClVzZXItQWdlbnQ6IE9XQVNQIENSUyB0ZXN0IGFnZW50DQoNCi0tYm91bmRhcnkNCkNvbnRlbnQtRGlzcG9zaXRpb24OOiBmb3JtLWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iMS5waHAiDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9InBvc3QiDQoNCjw/cGhwIHZhcl9kdW1wKGZpbGVfZ2V0X2NvbnRlbnRzKCIvZXRjL3Bhc3N3ZCIpKTsNCi0tYm91bmRhcnktLQ=="
+          output:
+            # The rule will match when an older version of the engine doesn't fail parsing. In newer versions of the engine,
+            # parsing will fail and the body will be considered invalid.
+            log_contains: 'Multipart parsing error: Multipart: Invalid part header \(contains invalid character\)|\[id "922130"\] \[msg "Multipart header contains characters outside of valid range"\]'
+  - test_title: 922130-3
+    desc: "Negative test: no special character in multipart header"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP CRS test agent"
+              Content-Type: multipart/form-data; boundary=boundary
+              Accept: "*/*"
+            method: POST
+            port: 80
+            uri: "/post"
+            version: "HTTP/1.1"
+            data: |
+              --boundary
+              Content-Disposition: form-data; name="file"; filename="1.php"
+
+              <?php var_dump(file_get_contents("/etc/passwd")); ?>
+              --boundary--
+          output:
+            no_log_contains: 'Multipart parsing error: Multipart: Invalid part header \(contains invalid character\)|\[id "922130"\] \[msg "Multipart header contains characters outside of valid range"\]'
+  - test_title: 922130-4
+    desc: |
+      Positive test: special character in multipart header.
+      Request is a multipart request with 2 Content-Disposition headers,
+      where the first one contains a 0x20 character, the last invalid character before the valid range.
+      --boundary
+      Content-\x20Disposition: form-data; name="file"; filename="1.php"
+      Content-Disposition: form-data; name="post"
+
+      <?php var_dump(file_get_contents("/etc/passwd"));
+      --boundary--
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            port: 80
+            uri: "/post"
+            version: "HTTP/1.1"
+            encoded_request: "UE9TVCAvcG9zdCBIVFRQLzEuMQ0KQWNjZXB0OiAqLyoNCkNvbm5lY3Rpb246IGNsb3NlDQpDb250ZW50LUxlbmd0aDogMTg2DQpDb250ZW50LVR5cGU6IG11bHRpcGFydC9mb3JtLWRhdGE7IGJvdW5kYXJ5PWJvdW5kYXJ5DQpIb3N0OiBsb2NhbGhvc3QNClVzZXItQWdlbnQ6IE9XQVNQIENSUyB0ZXN0IGFnZW50DQoNCi0tYm91bmRhcnkNCkNvbnRlbnQtIERpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iMS5waHAiDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9InBvc3QiDQoNCjw/cGhwIHZhcl9kdW1wKGZpbGVfZ2V0X2NvbnRlbnRzKCIvZXRjL3Bhc3N3ZCIpKTsNCi0tYm91bmRhcnktLQ=="
+          output:
+            # The rule will match when an older version of the engine doesn't fail parsing. In newer versions of the engine,
+            # parsing will fail and the body will be considered invalid.
+            log_contains: 'Multipart parsing error: Multipart: Invalid part header \(contains invalid character\)|\[id "922130"\] \[msg "Multipart header contains characters outside of valid range"\]'
+  - test_title: 922130-5
+    desc: "Negative test: no character from outside of range in multipart header; '!' is allowed (!, the first character in the range of valid characters))"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP CRS test agent"
+              Content-Type: multipart/form-data; boundary=boundary
+              Accept: "*/*"
+            method: POST
+            port: 80
+            uri: "/post"
+            version: "HTTP/1.1"
+            data: |
+              --boundary
+              Content-!Disposition: form-data; name="file"; filename="1.php"
+
+              <?php var_dump(file_get_contents("/etc/passwd")); ?>
+              --boundary--
+          output:
+            no_log_contains: 'Multipart parsing error: Multipart: Invalid part header \(contains invalid character\)|\[id "922130"\] \[msg "Multipart header contains characters outside of valid range"\]'
+  - test_title: 922130-6
+    desc: "Negative test: no character from outside of range in multipart header; '~' is allowed (~, the last valid character in the range of valid characters)"
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: "localhost"
+              User-Agent: "OWASP CRS test agent"
+              Content-Type: multipart/form-data; boundary=boundary
+              Accept: "*/*"
+            method: POST
+            port: 80
+            uri: "/post"
+            version: "HTTP/1.1"
+            data: |
+              --boundary
+              Content~Disposition: form-data; name="file"; filename="1.php"
+              Content-Disposition: form-data; name="post"
+
+              <?php var_dump(file_get_contents("/etc/passwd")); ?>
+              --boundary--
+          output:
+            no_log_contains: 'Multipart parsing error: Multipart: Invalid part header \(contains invalid character\)|\[id "922130"\] \[msg "Multipart header contains characters outside of valid range"\]'
+  - test_title: 922130-7
+    desc: |
+      Positive test: special character in multipart header.
+      Request is a multipart request with 2 Content-Disposition headers,
+      where the first one contains a 0x7F character, the first invalid character after the valid range.
+      --boundary
+      Content\x7F-Disposition: form-data; name="file"; filename="1.php"
+      Content-Disposition: form-data; name="post"
+
+      <?php var_dump(file_get_contents("/etc/passwd"));
+      --boundary--
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            port: 80
+            uri: "/post"
+            version: "HTTP/1.1"
+            encoded_request: "UE9TVCAvcG9zdCBIVFRQLzEuMQ0KQWNjZXB0OiAqLyoNCkNvbm5lY3Rpb246IGNsb3NlDQpDb250ZW50LUxlbmd0aDogMTg2DQpDb250ZW50LVR5cGU6IG11bHRpcGFydC9mb3JtLWRhdGE7IGJvdW5kYXJ5PWJvdW5kYXJ5DQpIb3N0OiBsb2NhbGhvc3QNClVzZXItQWdlbnQ6IE9XQVNQIENSUyB0ZXN0IGFnZW50DQoNCi0tYm91bmRhcnkNCkNvbnRlbnR/LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iMS5waHAiDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9InBvc3QiDQoNCjw/cGhwIHZhcl9kdW1wKGZpbGVfZ2V0X2NvbnRlbnRzKCIvZXRjL3Bhc3N3ZCIpKTsNCi0tYm91bmRhcnktLQ=="
+          output:
+            # The rule will match when an older version of the engine doesn't fail parsing. In newer versions of the engine,
+            # parsing will fail and the body will be considered invalid.
+            log_contains: 'Multipart parsing error: Multipart: Invalid part header \(contains invalid character\)|\[id "922130"\] \[msg "Multipart header contains characters outside of valid range"\]'


### PR DESCRIPTION
Add a new rule `922130` which check if any MULTIPART header contains a non-ascii character.

Fixes 3MU-240701-1 by @luelueking for v3.