### PR TITLE
fix: old schema field `stop_magic` in 920181.yaml

### DIFF
--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920181.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920181.yaml
@@ -18,7 +18,7 @@ tests:
             Transfer-Encoding: "chunked"
             User-Agent: "OWASP CRS test agent"
           data: "7\x0D\x0Afoo=bar\x0D\x0A0\x0D\x0A\x0D\x0A"
-          stop_magic: true
+          autocomplete_headers: false
         output:
           # Apache unsets the Content-Length header if Transfer-Encoding is found!
           status: 200


### PR DESCRIPTION
`stop_magic` has been replaced with `autocomplete_headers` as per the recent test schema change in 4.5. It looks like this somehow slipped through the cracks