### PR TITLE
Changed RegEx (920470) to match multiple whitespaces after `Content-Type` parameters to avoid false-positives

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -968,7 +968,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
 # - application/soap+xml; charset=utf-8; action="urn:localhost-hwh#getQuestions"
 # - application/*+json
 
-SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+*-]+(?:\s?;\s?(?:action|boundary|charset|component|start(?:-info)?|type|version)\s?=\s?['\"\w.()+,/:=?<>@#*-]+)*$" \
+SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+*-]+(?:\s?;\s*(?:action|boundary|charset|component|start(?:-info)?|type|version)\s?=\s?['\"\w.()+,/:=?<>@#*-]+)*$" \
     "id:920470,\
     phase:1,\
     block,\


### PR DESCRIPTION

## Description

This pull request addresses a false positive related to the `Content-Type` header being incorrectly flagged by rule ID 920470. The issue arises due to overly restrictive whitespace handling in the regex validation. The original regex allowed only an optional whitespace between parameters, which blocked valid headers containing additional whitespaces, even though these are permitted according to RFC standards.

- **ModSecurity Version:** OWASP CRS/3.3.4

## Problem

The original regex for rule ID 920470 did not account for multiple or flexible whitespaces between header parameters. This caused valid `Content-Type` headers, compliant with RFC 2045 and RFC 7231, to be blocked unnecessarily.

### Original regex

```regex
^[\w/.+*-]+(?:\s?;\s?(?:action|boundary|charset|component|start(?:-info)?|type|version)\s?=\s?['\"\w.()+,/:=?<>@#*-]+)*$
```

### Updated regex

```regex
^[\w/.+*-]+(?:\s?;\s*(?:action|boundary|charset|component|start(?:-info)?|type|version)\s?=\s?['\"\w.()+,/:=?<>@#*-]+)*$
```

## Changes

- The `\s?;\s?` has been updated to `\s?;\s*` to allow for flexible whitespace usage, in accordance with RFC 2045 and RFC 7231, which permit multiple whitespaces between parameters.

### Example

The blocked request contained the following Content-Type header:
```
Content-Type: multipart/related;    boundary="----=_part_224_386771358.1725612529970";    type="application/soap+xml"
```
This valid header was blocked because of extra spaces around the parameters, which are permitted under RFC specifications.

### Impact

This update will prevent unnecessary blocking of valid HTTP requests while still maintaining the security provided by the rule.

## Attachments 

### Original regex

![image](https://github.com/user-attachments/assets/06ea525f-9c80-4bf2-8731-31854a12f48a)

### Updated regex

![image](https://github.com/user-attachments/assets/c9c84f57-995b-4434-a965-fd2e6168da49)

