### PR TITLE
feat: added sendgrid.env into restricted files

### DIFF
--- a/rules/restricted-files.data
+++ b/rules/restricted-files.data
@@ -180,6 +180,8 @@ BlockCypher.log
 config.inc.php
 config.sample.php
 defaults.inc.php
+# Contains credentials for SendGrid service
+sendgrid.env
 
 # /proc entries (keep in sync with lfi-os-files.data)
 # grep -E "^proc/" lfi-os-files.data


### PR DESCRIPTION
File `sendgrid.env` contains API key for SendGrid service. It's already actively accessed by bots.