### PR TITLE
refactor: 3835 pylint interventions

### DIFF
--- a/util/change-version/change-version.py
+++ b/util/change-version/change-version.py
@@ -87,10 +87,12 @@ class FileHandler(object):
 if len(sys.argv) < 4:
     print("Argument missing!")
     print("Use: %s rule.conf /path/to/output/directory version" % sys.argv[0])
-    print("     %s \"/path/to/rules/*.conf\" /path/to/output/directory version [comment_version]" % sys.argv[0])
+    print("     %s \"/path/to/rules/*.conf\" /path/to/output/directory version [comment_version]"
+          % sys.argv[0])
     print("Example:")
     print("     mkdir ../../rulestmp")
-    print("     %s \"../../rules/*.conf\" ../../rulestmp \"OWASP_CRS/3.4.0-dev\" \"3.4.0-dev\"" % sys.argv[0])
+    print("     %s \"../../rules/*.conf\" ../../rulestmp \"OWASP_CRS/3.4.0-dev\" \"3.4.0-dev\""
+          % sys.argv[0])
     sys.exit(1)
 
 args = {

--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -431,7 +431,7 @@ class Check(object):
                                 if has_disruptive == True:
                                     self.globtxvars[v['variable_part'].lower()]['used'] = True
                                 if len(self.undef_txvars) > 0 and self.undef_txvars[-1]['var'] == v['variable_part'].lower():
-                                    del(self.undef_txvars[-1])
+                                    del self.undef_txvars[-1]
                 if chained == False:
                     check_exists   = None
                     has_disruptive = False


### PR DESCRIPTION
Fixing two alerts for [pylint intervention experiment](https://github.com/coreruleset/coreruleset/issues/3835)
The plan was 3 [interventions](https://github.com/evidencebp/pylint-intervention/blob/main/interventions/candidates/coreruleset_coreruleset_interventions_September_27_2024.csv)

Changes are minor
- The first long line represented the output and should stay as is
- Unneeded parentheses were removed when calling the del keyword
- Add line breaks to two too long lines making them shorter

Each intervention was done in a dedicated commit with a message explaining it.
 
@fzipi 