### PR TITLE
fix: SprintForTheCause false positive by moving printf to 933160 (933150 PL-1, 933160 PL-1)

### DIFF
--- a/regex-assembly/933160.ra
+++ b/regex-assembly/933160.ra
@@ -39,6 +39,7 @@ md5
 opendir
 passthru
 popen
+printf
 readfile
 tmpfile
 unpack

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -243,13 +243,13 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
 # The list of PHP functions is divided into four groups of varying attack/false positive risk.
 # Four separate rules are used to detect these groups of functions:
 #
-# - Rule 933150: ~40 words highly common to PHP injection payloads and extremely rare in
+# - Rule 933150: ~39 words highly common to PHP injection payloads and extremely rare in
 #		natural language or other contexts.
 #		Examples: 'base64_decode', 'file_get_contents'.
 #		These words are detected as a match directly using @pmFromFile.
 #		Function names are defined in php-function-names-933150.data
 #
-# - Rule 933160: ~220 words which are common in PHP code, but have a higher chance to cause
+# - Rule 933160: ~221 words which are common in PHP code, but have a higher chance to cause
 #		false positives in natural language or other contexts.
 #		Examples: 'chr', 'eval'.
 #		To mitigate false positives, a regexp looks for PHP function syntax, e.g. 'eval()'.
@@ -331,7 +331,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 933160
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\b\(?[\"']*(?:assert(?:_options)?|c(?:hr|reate_function)|e(?:val|x(?:ec|p))|file(?:group)?|glob|i(?:mage(?:gif|(?:jpe|pn)g|wbmp|xbm)|s_a)|md5|o(?:pendir|rd)|p(?:assthru|open|rev)|(?:read|tmp)file|un(?:pac|lin)k|s(?:tat|ubstr|ystem))(?:/(?:\*.*\*/|/.*)|#.*|[\s\x0b\"])*[\"']*\)?[\s\x0b]*\(.*\)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\b\(?[\"']*(?:assert(?:_options)?|c(?:hr|reate_function)|e(?:val|x(?:ec|p))|file(?:group)?|glob|i(?:mage(?:gif|(?:jpe|pn)g|wbmp|xbm)|s_a)|md5|o(?:pendir|rd)|p(?:assthru|open|r(?:intf|ev))|(?:read|tmp)file|un(?:pac|lin)k|s(?:tat|ubstr|ystem))(?:/(?:\*.*\*/|/.*)|#.*|[\s\x0b\"])*[\"']*\)?[\s\x0b]*\(.*\)" \
     "id:933160,\
     phase:2,\
     block,\

--- a/rules/php-function-names-933150.data
+++ b/rules/php-function-names-933150.data
@@ -171,7 +171,6 @@ preg_replace_callback
 preg_replace_callback_array
 preg_split
 print_r
-printf
 proc_close
 proc_get_status
 proc_nice

--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933160.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933160.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "lifeforms, Franziska Bühler, Max Leske, azurit"
+  author: "lifeforms, Franziska Bühler, Max Leske, azurit, Esad Cetiner"
 rule_id: 933160
 tests:
   - test_id: 1
@@ -672,6 +672,38 @@ tests:
           method: POST
           port: 80
           uri: "/post/unPACK%28%24x%29"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [933160]
+  - test_id: 38
+    desc: False positive with SprintForTheCause matching printf
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post/?test=SprintForTheCause"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [933160]
+  - test_id: 39
+    desc: Block Printf PHP function
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post/?test=printf(foo)"
           version: "HTTP/1.1"
         output:
           log:


### PR DESCRIPTION
Fixes a false positive with ``printf`` matching ``SprintForTheCause`` by moving it to 933160 which checks for additional PHP syntax instead of just ``printf``.

closes #3641 