### PR TITLE
fix: remove duplicate test for 920270

### DIFF
--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920270.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920270.yaml
@@ -102,20 +102,6 @@ tests:
           log:
             no_expect_ids: [920270]
   - test_id: 8
-    stages:
-      - input:
-          dest_addr: "127.0.0.1"
-          port: 80
-          uri: "/?test%FD=test1"
-          headers:
-            User-Agent: "OWASP CRS test agent"
-            Host: "localhost"
-            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-          version: "HTTP/1.1"
-        output:
-          log:
-            no_expect_ids: [920270]
-  - test_id: 9
     desc: Test converted from old tests
     stages:
       - input:


### PR DESCRIPTION
test id 8 has been removed as it was a duplicate of test id 7. 
test id 9 has now been renamed to test id 8.