### PR TITLE
fix(933120): do not match on base64 encoded strings

### DIFF
--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -129,7 +129,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.933120_matched_var=%{MATCHED_VAR}',\
     setvar:'tx.933120_matched_var_name=%{MATCHED_VAR_NAME}',\
     chain"
-    SecRule MATCHED_VARS "@rx \b([^\s]+)\s*=" \
+    SecRule MATCHED_VARS "@rx \b([^\s]+)\s*=(?:\w+)" \
         "capture,\
         chain"
         SecRule TX:1 "@pmFromFile php-config-directives.data" \

--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933120.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933120.yaml
@@ -165,3 +165,20 @@ tests:
         output:
           log:
             expect_ids: [933120]
+  - test_id: 10
+    desc: "FP PHP Injection Attack: prevent matching base64 encoded requests"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: "localhost"
+            Cache-Control: "no-cache, no-store, must-revalidate"
+            User-Agent: "OWASP CRS test agent"
+            Accept: "*/*"
+          method: GET
+          uri: "/get?SAMLRequest=mhXNy9pMlFhTjBlRkkzSkpia1Y2cSMtPEE9PTwvc2FtbDpBdHRyaWJ1dGVWYWx1ZT48L3NhbWw6QXR0cmlidXRlPjwvc2FtbDpBdHRyaWJ1dGVTdGF0ZW1lbnQ+PC9zYW1sOkFzc2VydGlvbj48L3NhbWxwOlJlc3BvbnNlPg=="
+          port: 80
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids: [933120]


### PR DESCRIPTION
## what

- rule should match on PHP configuration modification attacks
- uses pmfromfile to match config names
- then there should be an equal sign, and the value to modify

👉 modify the rule to have a value after the equal sign, so it is relevant to what we try to match.

## why

- rule is matching on base64 encoded strings with double equal signs

Fixes #3723 