### PR TITLE
fix: bypass by supplying whitespace or path argument (933120 PL-1)

### DIFF
--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -129,7 +129,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     setvar:'tx.933120_matched_var=%{MATCHED_VAR}',\
     setvar:'tx.933120_matched_var_name=%{MATCHED_VAR_NAME}',\
     chain"
-    SecRule MATCHED_VARS "@rx \b([^\s]+)\s*=(?:\w+)" \
+    SecRule MATCHED_VARS "@rx \b([^\s]+)\s*=[^=]" \
         "capture,\
         chain"
         SecRule TX:1 "@pmFromFile php-config-directives.data" \

--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933120.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933120.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "Christian S.J. Peron, azurit"
+  author: "Christian S.J. Peron, azurit, Esad Cetiner"
 rule_id: 933120
 tests:
   - test_id: 1
@@ -182,3 +182,37 @@ tests:
         output:
           log:
             no_expect_ids: [933120]
+  - test_id: 11
+    desc: "PHP Injection Attack: Block config directive with whitespace"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: "localhost"
+            Cache-Control: "no-cache, no-store, must-revalidate"
+            User-Agent: "OWASP CRS test agent"
+            Accept: "*/*"
+          method: GET
+          uri: "/get?code=memory_limit%20=%20512M"
+          port: 80
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [933120]
+  - test_id: 12
+    desc: "PHP Injection Attack: Block config directive with a path"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: "localhost"
+            Cache-Control: "no-cache, no-store, must-revalidate"
+            User-Agent: "OWASP CRS test agent"
+            Accept: "*/*"
+          method: GET
+          uri: "/get?code=extension_dir=/path/to/example"
+          port: 80
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [933120]


### PR DESCRIPTION
This PR fixes a bypass introduced in #3863 to fix false positives with base64 encoded requests with double equals sign. This rule can be bypassed by either adding a white space, for example ``memory_limit = 512M`` or by supplying a path ``extension_dir=/path/to/example`` to a directive. I've used a negated set to avoid false positive with a double equals sign while also fixing the bypass.