### PR TITLE
fix(ci): get version when releasing from branch name

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -81,7 +81,13 @@ jobs:
             minor="$(cut -d. -f2 <<<"${version}")"
             suffix="$(cut -d. -f3 <<<"${version}")"
             version="${prefix}.$((minor + 1)).${suffix}"
-            version="${version/-*-g*/}-dev"
+            release_ref="${{ github.head_ref }}"
+            if [[ "${release_ref}" =~ ^release/v ]]
+            then
+              version="${release_ref/release\/v/}"
+            else
+              version="${version/-*-g*/}-dev"
+            fi
           fi
           echo "Required version for check: ${version}"
           ./util/crs-rules-check/rules-check.py \


### PR DESCRIPTION
## what

- getting version in ci linting was broken for releases
