### PR TITLE
fix: do not run scheduled in forked repos

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,6 +8,7 @@ jobs:
   nightly:
     name: Nightly Release
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'coreruleset' # do not run for forks
     steps:
       - name: Check GH API rate limits
         run: |


### PR DESCRIPTION
## what

- do not run scheduled in forked repos

## why

- forks will get failures once a day trying to push to upstream coreruleset