### PR TITLE
feat: add quantitative testing to Git workflow

### DIFF
--- a/.github/workflows/quantitative.yaml
+++ b/.github/workflows/quantitative.yaml
@@ -1,0 +1,46 @@
+name: Quantitative tests
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'rules/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'rules/**'
+  merge_group:
+
+# Pin tool versions to prevent problems
+env:
+  GO_FTW_VERSION: '1.1.0'
+
+jobs:
+  regression:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        languange: ["eng"]
+        year: ["2023"]
+        size: ["10K"]
+        paranoia_level: ["1"]
+    steps:
+      - name: "Checkout repo"
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+
+      - name: "Install dependencies"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download -R coreruleset/go-ftw "v${{ env.GO_FTW_VERSION }}" \
+            -p "ftw_${{ env.GO_FTW_VERSION }}_linux_amd64.tar.gz" -O - | tar -xzvf - ftw
+
+      - name: "Run tests for language: ${{ matrix.language }}, year: ${{ matrix.year}}, size: ${{ matrix.size }}, paranoia level: ${{ matrix.paranoia_level }}"
+        run: |
+          ./ftw quantitative \
+            -L ${{ matrix.language }} \
+            -y ${{ matrix.year }} \
+            -s ${{ matrix.size }} \
+            -P ${{ matrix.paranoia_level }}


### PR DESCRIPTION
This PR adds a new workflow where we run [go-ftw](https://github.com/coreruleset/go-ftw/commit/518e626c635075e70ee91cb8245c9b603174a381)'s quantitative testing feature.