### PR TITLE
fix: move rule's phase 950100 to 3

### DIFF
--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -96,7 +96,7 @@ SecRule TX:EXECUTING_PARANOIA_LEVEL "@lt 2" "id:950014,phase:4,pass,nolog,skipAf
 #
 SecRule RESPONSE_STATUS "@rx ^5\d{2}$" \
     "id:950100,\
-    phase:4,\
+    phase:3,\
     block,\
     capture,\
     t:none,\


### PR DESCRIPTION
Rule [950100](https://github.com/coreruleset/coreruleset/blob/v3.3/master/rules/RESPONSE-950-DATA-LEAKAGES.conf#L97-L117) in branch v3.3 has the `phase:4`, but it could be in `phase:3`.

There is an open issue about this problem: #3936, where the reporter describes the details. Also he mentioned my previously PR #1941, but it made for v3.4 (which wasn't released) and we haven't back-ported anything.

This PR only moves one rule's phase, but there are many other rules where we can make this step - the question is do we want to do this or not.