### PR TITLE
chore(quant): run quantitative testing only on pull requests

### DIFF
--- a/.github/workflows/quantitative.yaml
+++ b/.github/workflows/quantitative.yaml
@@ -1,12 +1,6 @@
 name: Quantitative tests
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'rules/**'
-      - '.github/workflows/quantitative.yaml'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Quantitative tests in the CI of merged PRs is failing because there is not anymore a related PR where the job can write the comment. This PR proposes to run the quantitative testing just inside the pull requests (on every commit), and not when the PR is merged into main. 

E.g. https://github.com/coreruleset/coreruleset/actions/runs/11889334419
```
Run thollander/actions-comment-pull-request@v3
Error: No issue/pull request in input neither in current context.
```