### PR TITLE
fix: rules not logging correct target (920220 PL1, 920221 PL2)

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -379,7 +379,7 @@ SecRule REQUEST_URI_RAW "@rx \x25" \
     phase:1,\
     block,\
     t:none,t:urlDecodeUni,\
-    msg:'URL Encoding Abuse Attack Attempt',\
+    msg:'URL Encoding Abuse Attack Attempt found in REQUEST_URI_RAW',\
     logdata:'%{REQUEST_URI_RAW}',\
     tag:'application-multi',\
     tag:'language-multi',\
@@ -413,7 +413,7 @@ SecRule REQUEST_BASENAME "!@rx ^.*%.*\.[^\s\x0b\.]+$" \
     block,\
     capture,\
     t:none,t:urlDecodeUni,\
-    msg:'URL Encoding Abuse Attack Attempt',\
+    msg:'URL Encoding Abuse Attack Attempt found in REQUEST_BASENAME',\
     logdata:'%{REQUEST_BASENAME}',\
     tag:'application-multi',\
     tag:'language-multi',\

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920220.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920220.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "csanders-git, Max Leske, azurit"
+  author: "csanders-git, Max Leske, azurit, Esad Cetiner"
   description: "Detect invalid URI encoding in the request URI"
 rule_id: 920220
 tests:
@@ -126,3 +126,19 @@ tests:
         output:
           log:
             no_expect_ids: [920220]
+  - test_id: 9
+    desc: Make sure the correct parameter name is being logged
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          port: 80
+          uri: "/get?parm=%62%61%64%"
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: "localhost"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [920220]
+            match_regex: [REQUEST_URI_RAW]

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920221.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920221.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "Max Leske, azurit"
+  author: "Max Leske, azurit, Esad Cetiner"
   description: "Detect invalid URI encoding in the last path segment of the URI"
 rule_id: 920221
 tests:
@@ -34,3 +34,19 @@ tests:
         output:
           log:
             no_expect_ids: [920221]
+  - test_id: 3
+    desc: Make sure the correct parameter name is being logged
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          port: 80
+          uri: "/get/%25w20"
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: "localhost"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [920221]
+            match_regex: [REQUEST_BASENAME]


### PR DESCRIPTION
Rules 920220 and 920221 are logging wrong target `TX.0`, `TX.1`, or `TX.2` instead of `REQUEST_URI_RAW` and `REQUEST_BASENAME` respectively.

I couldn't find a better solution outside of manually adding the target in the log message, but I think this is fine since each of the rules are only have one target.