### PR TITLE
feat: block CVE-2023-5003

### DIFF
--- a/rules/restricted-files.data
+++ b/rules/restricted-files.data
@@ -185,6 +185,8 @@ sendgrid.env
 # Fish shell files
 .fish
 fish_variables
+# CVE-2023-5003
+ldap-authentication-report.csv
 
 # /proc entries (keep in sync with lfi-os-files.data)
 # grep -E "^proc/" lfi-os-files.data


### PR DESCRIPTION
Block file related to [CVE-2023-5003](https://nvd.nist.gov/vuln/detail/CVE-2023-5003), already actively accessed by bots.