### PR TITLE
fix: add 'tx.total_arg_length' to rule 900005 for testing

### DIFF
--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -55,6 +55,7 @@ SecAction "id:900005,\
   setvar:tx.crs_validate_utf8_encoding=1,\
   setvar:tx.arg_name_length=100,\
   setvar:tx.arg_length=400,\
+  setvar:tx.total_arg_length=64000,\
   setvar:tx.max_file_size=64100,\
   setvar:tx.combined_file_sizes=65535"
 ```


### PR DESCRIPTION
Added `TX` variable `total_arg_length` with value `64000` because rule [920390](https://github.com/coreruleset/coreruleset/blob/main/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf#L881) uses that and its [test](https://github.com/coreruleset/coreruleset/blob/main/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920390.yaml#L29) expects it. Without that a "regular" test is failed.