### PR TITLE
fix: add 'tx.max_num_args' to rule 900005 for testing

### DIFF
--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -56,6 +56,7 @@ SecAction "id:900005,\
   setvar:tx.arg_name_length=100,\
   setvar:tx.arg_length=400,\
   setvar:tx.total_arg_length=64000,\
+  setvar:tx.max_num_args=255,\
   setvar:tx.max_file_size=64100,\
   setvar:tx.combined_file_sizes=65535"
 ```


### PR DESCRIPTION
Added `TX` variable `max_num_args` with value `255` because rule [920380](https://github.com/coreruleset/coreruleset/blob/main/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf#L805) uses that and its [test](https://github.com/coreruleset/coreruleset/blob/main/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920380.yaml#L26) expects it. Without that a "regular" test is failed.

Similar as #3956.