### PR TITLE
fix: FP against `pattern` with `=` following at arbitrary position

### DIFF
--- a/regex-assembly/941130.ra
+++ b/regex-assembly/941130.ra
@@ -3,15 +3,14 @@
 
 ##!+ i
 ##!^ .
-##!$ \b
 
-\bxlink:href
-\bxhtml
-\bxmlns
-!ENTITY\s+(?:\S+|%\s+\S+)\s+SYSTEM
-!ENTITY\s+(?:\S+|%\s+\S+)\s+PUBLIC
-\bdata:text/html
-\bformaction
-@import
-;base64
-\bpattern\b.*?=
+\bxlink:href\b
+\bxhtml\b
+\bxmlns\b
+!ENTITY\s+(?:\S+|%\s+\S+)\s+SYSTEM\b
+!ENTITY\s+(?:\S+|%\s+\S+)\s+PUBLIC\b
+\bdata:text/html\b
+\bformaction\b
+@import\b
+;base64\b
+\bpattern\s*=

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -135,7 +135,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 941130
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@rx (?i).(?:\b(?:x(?:link:href|html|mlns)|data:text/html|formaction|pattern\b.*?=)|!ENTITY[\s\x0b]+(?:%[\s\x0b]+)?[^\s\x0b]+[\s\x0b]+(?:SYSTEM|PUBLIC)|@import|;base64)\b" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@rx (?i).(?:\b(?:(?:x(?:link:href|html|mlns)|data:text/html|formaction)\b|pattern[\s\x0b]*=)|(?:!ENTITY[\s\x0b]+(?:%[\s\x0b]+)?[^\s\x0b]+[\s\x0b]+(?:SYSTEM|PUBLIC)|@import|;base64)\b)" \
     "id:941130,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941130.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941130.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "csanders-git, Christian Folini, azurit"
+  author: "csanders-git, Christian Folini, azurit, Max Leske"
 rule_id: 941130
 tests:
   - test_id: 1
@@ -323,3 +323,37 @@ tests:
         output:
           log:
             expect_ids: [941130]
+  - test_id: 20
+    desc: "True positive for `pattern` attribute"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          method: POST
+          port: 80
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          uri: "/post"
+          data: 'var=<input pattern="^a regex$">'
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [941130]
+  - test_id: 21
+    desc: "False positive for `pattern` with `=` following at an arbitrary position later"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          method: POST
+          port: 80
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          uri: "/post"
+          data: "var=There's a pattern in the dark background. Here's a video: <a href=\\x22https://www.youtube.com/watch?v="
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids: [941130]


### PR DESCRIPTION
- change regular expression to not match any `=`
- add FP and true positive tests

Fixes #3961