### PR TITLE
fix: enable docker-compose renovate manager properly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "local>coreruleset/renovate-config",
     "schedule:weekly"
   ],
+  "ignorePaths": [],
   "enabledManagers": [
     "docker-compose"
   ]


### PR DESCRIPTION
The presets we use for renovate implicitly exclude the path `**tests**`, where the docker-compose file resides. This causes renovate to ignore the file for the docker-compose manager.

Explicitly override `ignorePaths` to fix this.