### PR TITLE
feat: prevent V1 cookie format use

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -313,7 +313,7 @@ SecRule REQUEST_URI "@rx unix:[^|]*\|" \
 # See:
 # - https://portswigger.net/research/stealing-httponly-cookies-with-the-cookie-sandwich-technique
 # - https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-%28v2.x%29#seccookieformat
-SecRule REQUEST_COOKIES:/\"?\$Version/ "@streq 1" \
+SecRule REQUEST_COOKIES:/\x22?\x24Version/ "@streq 1" \
     "id:921250,\
     phase:1,\
     block,\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -305,6 +305,31 @@ SecRule REQUEST_URI "@rx unix:[^|]*\|" \
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
+# Detection for Cookie Sandwich attacks
+# This issue affects Apache Tomcat, Python, and maybe others.
+# See:
+# - https://portswigger.net/research/stealing-httponly-cookies-with-the-cookie-sandwich-technique
+# - https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-%28v2.x%29#seccookieformat
+SecRule REQUEST_COOKIES "@rx ^\s*\$Version=1" \
+    "id:921250,\
+    phase:1,\
+    block,\
+    capture,\
+    t:none,t:lowercase,\
+    msg:'cookie sandwich attack attempt detected',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-tomcat',\
+    tag:'attack-protocol',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'capec/1000/210/272/220/33',\
+    ver:'OWASP_CRS/4.12.0-dev',\
+    severity:'CRITICAL',\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:921013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.12.0-dev',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:921014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.12.0-dev',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 #

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -305,22 +305,24 @@ SecRule REQUEST_URI "@rx unix:[^|]*\|" \
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-# Detection for Cookie Sandwich attacks
-# This issue affects Apache Tomcat, Python, and maybe others.
+# Detection for old V1 cookie format from RFC 2109.
+#
+# This has been abused by the cookie sandwich technique, in diverse issues affecting Apache Tomcat, Python, and maybe others.
+# RFC 6265 deprecated and replaced RFCs 2109 and 2965.
+# It completely removed "$Version", meaning user agents and servers no longer use this attribute.
 # See:
 # - https://portswigger.net/research/stealing-httponly-cookies-with-the-cookie-sandwich-technique
 # - https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-%28v2.x%29#seccookieformat
-SecRule REQUEST_COOKIES "@rx ^\s*\$Version=1" \
+SecRule REQUEST_COOKIES:/\"?\$Version/ "@streq 1" \
     "id:921250,\
     phase:1,\
     block,\
     capture,\
     t:none,t:lowercase,\
-    msg:'cookie sandwich attack attempt detected',\
+    msg:'Old Cookies V1 usage attempt detected',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\
-    tag:'platform-tomcat',\
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921250.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921250.yaml
@@ -1,7 +1,7 @@
 ---
 meta:
   author: "fzipi"
-  description: "Rule for detecting Cookie Sandwich attacks"
+  description: "Rule for preventing usage of deprecated V1 cookies from rfc 2109"
 rule_id: 921250
 tests:
   - test_id: 1

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921250.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921250.yaml
@@ -1,0 +1,24 @@
+---
+meta:
+  author: "fzipi"
+  description: "Rule for detecting Cookie Sandwich attacks"
+rule_id: 921250
+tests:
+  - test_id: 1
+    desc: "Detect attacks using cookie sandwich techniques for PHPSESSID"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          headers:
+            Host: "localhost"
+            User-Agent: "OWASP CRS test agent"
+            Accept: "*/*"
+            Origin: https://www.example.com
+            Referer: https://www.example.com/
+            Cookie: "$Version=1; session=\"deadbeef; PHPSESSID=secret; dummy=qaz\""
+          port: 80
+          uri: "/"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [921250]

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921250.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921250.yaml
@@ -5,7 +5,25 @@ meta:
 rule_id: 921250
 tests:
   - test_id: 1
-    desc: "Detect attacks using cookie sandwich techniques for PHPSESSID"
+    desc: "Positive test: Detect if the cookie V1 is present in the request headers"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          headers:
+            Host: "localhost"
+            User-Agent: "OWASP CRS test agent"
+            Accept: "*/*"
+            Origin: https://www.example.com
+            Referer: https://www.example.com/
+            Cookie: $Version=1; session=\"deadbeef; PHPSESSID=secret; dummy=qaz\"
+          port: 80
+          uri: "/"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [921250]
+  - test_id: 2
+    desc: "Positive test: Detect if cookie V1 and also quoting is trying to be abused in the request headers"
     stages:
       - input:
           dest_addr: "127.0.0.1"
@@ -22,3 +40,19 @@ tests:
         output:
           log:
             expect_ids: [921250]
+  - test_id: 2
+    desc: "Negative test: do not match if Version is used as part of a cookie name"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          headers:
+            Host: "localhost"
+            User-Agent: "OWASP CRS test agent"
+            Accept: "*/*"
+            Cookie: MyVersion=1; PHPSESSID=secret
+          port: 80
+          uri: "/"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [921250]

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921250.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921250.yaml
@@ -40,7 +40,7 @@ tests:
         output:
           log:
             expect_ids: [921250]
-  - test_id: 2
+  - test_id: 3
     desc: "Negative test: do not match if Version is used as part of a cookie name"
     stages:
       - input:


### PR DESCRIPTION
## what

- prevent using cookie V1 protocol

## why

- preventing cookie sandwich attacks