### PR TITLE
fix: add argument name to function call

### DIFF
--- a/util/crs-rules-check/rules-check.py
+++ b/util/crs-rules-check/rules-check.py
@@ -374,7 +374,7 @@ class Check(object):
                     if oparg:
                         for o in oparg:
                             o = o.lower()
-                            o = re.sub(r"tx\.", "", o, re.I)
+                            o = re.sub(r"tx\.", "", o, count = 0, flags = re.I)
                             if (o not in self.globtxvars or phase < self.globtxvars[o]['phase']) and \
                               not re.match(r"^\d$", o) and \
                               not re.match(r"/.*/", o) and \


### PR DESCRIPTION
It seems like in Python 3.13 the [re.sub()](https://docs.python.org/3/library/re.html#re.sub) syntax changed:

_Deprecated since version 3.13: Passing count and flags as positional arguments is deprecated. In future Python versions they will be [keyword-only parameters](https://docs.python.org/3/glossary.html#keyword-only-parameter)._

This PR aligns the `crs-rules-check` script and fixes the CI [errors](https://github.com/coreruleset/coreruleset/actions/runs/13437073040/job/37541853363?pr=4006#step:8:61).