### PR TITLE
chore: add debug versions for quick local testing

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -84,6 +84,7 @@ services:
 
   modsec3-nginx-debug:
     <<: *nginx
+    command: ["nginx-debug", "-g", "daemon-off;"]
     environment:
       <<: *nginx-env
       MODSEC_DEBUG_LOG: "/var/log/nginx/modsec_debug.log"

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -22,7 +22,6 @@ x-apache-env: &apache-env
   ACCESSLOG: "/var/log/apache2/access.log"
   ERRORLOG: "/var/log/apache2/error.log"
   MODSEC_AUDIT_LOG: "/var/log/apache2/modsec_audit.log"
-  PORT: "8080"
   SERVERNAME: modsec2-apache
 
 x-nginx-env: &nginx-env

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,8 +1,40 @@
 # Only one of these will be up at a time for now.
 # Concurrency will be on the tests folder we have.
 
+x-common-env: &common-env
+  ARG_LENGTH: 400
+  BACKEND: http://backend
+  BLOCKING_PARANOIA: 4
+  COMBINED_FILE_SIZES: "65535"
+  CRS_ENABLE_TEST_MARKER: 1
+  MAX_FILE_SIZE: "64100"
+  MODSEC_AUDIT_LOG_FORMAT: Native
+  MODSEC_AUDIT_LOG_TYPE: Serial
+  MODSEC_RESP_BODY_ACCESS: "On"
+  MODSEC_RESP_BODY_MIMETYPE: "text/plain text/html text/xml application/json"
+  MODSEC_RULE_ENGINE: DetectionOnly
+  MODSEC_TMP_DIR: "/tmp"
+  PORT: "8080"
+  VALIDATE_UTF8_ENCODING: 1
+
+x-apache-env: &apache-env
+  <<: *common-env
+  ACCESSLOG: "/var/log/apache2/access.log"
+  ERRORLOG: "/var/log/apache2/error.log"
+  MODSEC_AUDIT_LOG: "/var/log/apache2/modsec_audit.log"
+  PORT: "8080"
+  SERVERNAME: modsec2-apache
+
+x-nginx-env: &nginx-env
+  <<: *common-env
+  ACCESSLOG: "/var/log/nginx/access.log"
+  ERRORLOG: "/var/log/nginx/error.log"
+  LOGLEVEL: "info"
+  MODSEC_AUDIT_LOG: "/var/log/nginx/modsec_audit.log"
+  SERVERNAME: modsec3-nginx
+
 services:
-  modsec2-apache:
+  modsec2-apache: &apache
     container_name: modsec2-apache
     image: owasp/modsecurity-crs:apache@sha256:36fc67d66f7761a6cb532c4855901a41792efa6e58303833c03aeed285c9c961 # pin v4.3.0
     # NOTE: The user used to run the container process is explicitly set to
@@ -11,25 +43,8 @@ services:
     # setup only* and *should not be done in general!*
     user: root
     environment:
-      ACCESSLOG: "/var/log/apache2/access.log"
-      BACKEND: http://backend
-      BLOCKING_PARANOIA: 4
-      COMBINED_FILE_SIZES: "65535"
-      CRS_ENABLE_TEST_MARKER: 1
-      ERRORLOG: "/var/log/apache2/error.log"
-      MAX_FILE_SIZE: "64100"
-      MODSEC_AUDIT_LOG_FORMAT: Native
-      MODSEC_AUDIT_LOG_TYPE: Serial
-      MODSEC_AUDIT_LOG: "/var/log/apache2/modsec_audit.log"
-      MODSEC_RESP_BODY_ACCESS: "On"
-      MODSEC_RESP_BODY_MIMETYPE: "text/plain text/html text/xml application/json"
-      MODSEC_RULE_ENGINE: DetectionOnly
-      MODSEC_TMP_DIR: "/tmp"
-      PORT: "8080"
-      SERVERNAME: modsec2-apache
-      VALIDATE_UTF8_ENCODING: 1
-      ARG_LENGTH: 400
-    volumes:
+      <<: *apache-env
+    volumes: 
       - ./logs/modsec2-apache:/var/log/apache2:rw
       - ../rules:/opt/owasp-crs/rules:ro
       - ../plugins:/opt/owasp-crs/plugins:ro
@@ -40,8 +55,14 @@ services:
     depends_on:
       - backend
 
+  modsec2-apache-debug:
+    <<: *apache
+    environment:
+      <<: *apache-env
+      MODSEC_DEBUG_LOG: "/var/log/apache2/modsec_debug.log"
+      MODSEC_DEBUG_LOGLEVEL: 9
 
-  modsec3-nginx:
+  modsec3-nginx: &nginx
     container_name: modsec3-nginx
     image: owasp/modsecurity-crs:nginx@sha256:44b6e45fdc9eb9fdd34bb62f91f51513a87116e1445222cff7f4018bed7d42eb # pin v4.3.0
     # NOTE: The user used to run the container process is explicitly set to
@@ -50,24 +71,7 @@ services:
     # setup only* and *should not be done in general!*
     user: root
     environment:
-      ACCESSLOG: "/var/log/nginx/access.log"
-      BACKEND: http://backend
-      BLOCKING_PARANOIA: 4
-      COMBINED_FILE_SIZES: "65535"
-      CRS_ENABLE_TEST_MARKER: 1
-      ERRORLOG: "/var/log/nginx/error.log"
-      LOGLEVEL: "info"
-      MAX_FILE_SIZE: "64100"
-      MODSEC_AUDIT_LOG_FORMAT: Native
-      MODSEC_AUDIT_LOG_TYPE: Serial
-      MODSEC_AUDIT_LOG: "/var/log/nginx/modsec_audit.log"
-      MODSEC_RESP_BODY_ACCESS: "On"
-      MODSEC_RESP_BODY_MIMETYPE: "text/plain text/html text/xml application/json"
-      MODSEC_RULE_ENGINE: DetectionOnly
-      PORT: "8080"
-      SERVERNAME: modsec3-nginx
-      VALIDATE_UTF8_ENCODING: 1
-      ARG_LENGTH: 400
+      <<: *nginx-env
     volumes:
       - ./logs/modsec3-nginx:/var/log/nginx:rw
       - ../rules:/opt/owasp-crs/rules:ro
@@ -79,6 +83,12 @@ services:
     depends_on:
       - backend
 
+  modsec3-nginx-debug:
+    <<: *nginx
+    environment:  
+      MODSEC_DEBUG_LOG: "/var/log/nginx/modsec_debug.log"
+      MODSEC_DEBUG_LOGLEVEL: 9
+    
   backend:
     image: ghcr.io/coreruleset/albedo:0.0.16@sha256:0961035bb0ecce95f9b485e1ab1cfc89b626925699576495cfa4287f6fd1cda4
     command: ["--port", "80"]

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -56,8 +56,10 @@ services:
 
   modsec2-apache-debug:
     <<: *apache
+    container_name: modsec2-apache-debug
     environment:
       <<: *apache-env
+      LOGLEVEL: "debug"
       MODSEC_DEBUG_LOG: "/var/log/apache2/modsec_debug.log"
       MODSEC_DEBUG_LOGLEVEL: 9
 
@@ -84,9 +86,11 @@ services:
 
   modsec3-nginx-debug:
     <<: *nginx
-    command: ["nginx-debug", "-g", "daemon-off;"]
+    container_name: modsec3-nginx-debug
+    entrypoint: ["/bin/sh", "-c", "/bin/cp /etc/modsecurity.d/owasp-crs/crs-setup.conf.example /etc/modsecurity.d/owasp-crs/crs-setup.conf && /docker-entrypoint.sh nginx-debug -g 'daemon off;'"]
     environment:
       <<: *nginx-env
+      LOGLEVEL: "debug"
       MODSEC_DEBUG_LOG: "/var/log/nginx/modsec_debug.log"
       MODSEC_DEBUG_LOGLEVEL: 9
 

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -84,7 +84,8 @@ services:
 
   modsec3-nginx-debug:
     <<: *nginx
-    environment:  
+    environment:
+      <<: *nginx-env
       MODSEC_DEBUG_LOG: "/var/log/nginx/modsec_debug.log"
       MODSEC_DEBUG_LOGLEVEL: 9
     

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     user: root
     environment:
       <<: *apache-env
-    volumes: 
+    volumes:
       - ./logs/modsec2-apache:/var/log/apache2:rw
       - ../rules:/opt/owasp-crs/rules:ro
       - ../plugins:/opt/owasp-crs/plugins:ro
@@ -88,7 +88,7 @@ services:
       <<: *nginx-env
       MODSEC_DEBUG_LOG: "/var/log/nginx/modsec_debug.log"
       MODSEC_DEBUG_LOGLEVEL: 9
-    
+
   backend:
     image: ghcr.io/coreruleset/albedo:0.0.16@sha256:0961035bb0ecce95f9b485e1ab1cfc89b626925699576495cfa4287f6fd1cda4
     command: ["--port", "80"]

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -59,7 +59,6 @@ services:
     container_name: modsec2-apache-debug
     environment:
       <<: *apache-env
-      LOGLEVEL: "debug"
       MODSEC_DEBUG_LOG: "/var/log/apache2/modsec_debug.log"
       MODSEC_DEBUG_LOGLEVEL: 9
 
@@ -90,7 +89,6 @@ services:
     entrypoint: ["/bin/sh", "-c", "/bin/cp /etc/modsecurity.d/owasp-crs/crs-setup.conf.example /etc/modsecurity.d/owasp-crs/crs-setup.conf && /docker-entrypoint.sh nginx-debug -g 'daemon off;'"]
     environment:
       <<: *nginx-env
-      LOGLEVEL: "debug"
       MODSEC_DEBUG_LOG: "/var/log/nginx/modsec_debug.log"
       MODSEC_DEBUG_LOGLEVEL: 9
 


### PR DESCRIPTION
## what

- add `debug` versions of base containers

## why

- simplify local testing