### PR TITLE
fix: fix response splitting rules and tests

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -123,7 +123,7 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@rx [\n\r]" \
     phase:1,\
     block,\
     capture,\
-    t:none,t:htmlEntityDecode,\
+    t:none,t:urlDecodeUni,\
     msg:'HTTP Header Injection Attack via headers',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
@@ -151,7 +151,7 @@ SecRule ARGS_NAMES "@rx [\n\r]" \
     phase:2,\
     block,\
     capture,\
-    t:none,t:htmlEntityDecode,\
+    t:none,\
     msg:'HTTP Header Injection Attack via payload (CR/LF detected)',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
@@ -172,7 +172,7 @@ SecRule ARGS_GET_NAMES|ARGS_GET "@rx [\n\r]+(?:\s|location|refresh|(?:set-)?cook
     phase:1,\
     block,\
     capture,\
-    t:none,t:htmlEntityDecode,t:lowercase,\
+    t:none,t:lowercase,\
     msg:'HTTP Header Injection Attack via payload (CR/LF and header-name detected)',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
@@ -350,7 +350,7 @@ SecRule ARGS_GET "@rx [\n\r]" \
     phase:1,\
     block,\
     capture,\
-    t:none,t:htmlEntityDecode,\
+    t:none,\
     msg:'HTTP Header Injection Attack via payload (CR/LF detected)',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921140.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921140.yaml
@@ -19,6 +19,7 @@ tests:
           uri: "/"
           version: "HTTP/1.1"
         output:
+          status: 400
           log:
             no_expect_ids: [921140]
   - test_id: 2
@@ -37,4 +38,4 @@ tests:
           version: "HTTP/1.1"
         output:
           log:
-            no_expect_ids: [921140]
+            expect_ids: [921140]


### PR DESCRIPTION
Response splitting can be achieved by injecting carriage return / new line characters at various places (headers, GET / POST arguments, cookies...). Some web servers or applications may be vulnerable to encoded injections (especially in URL paths), hence we explicitly decode URL encoding, where necessary.

httpd and nginx are not vulnerable to header splitting and will respond with status 400.

HTML entity decoding does not make sense in this context. No web server should ever decode HTML as part of the HTTP protocol. It is unclear why the original authors used `t:htmlEntityDecode` in some places, but at least in one test, a query argument separator (`&`) precedes a `%0d`, which leads to successful decoding of the escape sequence as HTML entity. This may explain an accidental use of `t:htmlEntityDecode`.

Fixes #3824