### PR TITLE
fix(933160): use better regex

### DIFF
--- a/regex-assembly/933160.ra
+++ b/regex-assembly/933160.ra
@@ -18,7 +18,7 @@
 ##!$ \)?\s*
 
 ##! mandatory parentheses containing optional parameters
-##!$ \(.*\)
+##!$ \([^)]*\)
 
 assert
 assert_options

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -362,7 +362,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 933160
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\b\(?[\"']*(?:assert(?:_options)?|c(?:hr|reate_function)|e(?:val|x(?:ec|p))|file(?:group)?|glob|i(?:mage(?:gif|(?:jpe|pn)g|wbmp|xbm)|s_a)|md5|o(?:pendir|rd)|p(?:assthru|open|rev)|(?:read|tmp)file|un(?:pac|lin)k|s(?:tat|ubstr|ystem))(?:/(?:\*.*\*/|/.*)|#.*|[\s\x0b\"])*[\"']*\)?[\s\x0b]*\(.*\)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\b\(?[\"']*(?:assert(?:_options)?|c(?:hr|reate_function)|e(?:val|x(?:ec|p))|file(?:group)?|glob|i(?:mage(?:gif|(?:jpe|pn)g|wbmp|xbm)|s_a)|md5|o(?:pendir|rd)|p(?:assthru|open|rev)|(?:read|tmp)file|un(?:pac|lin)k|s(?:tat|ubstr|ystem))(?:/(?:\*.*\*/|/.*)|#.*|[\s\x0b\"])*[\"']*\)?[\s\x0b]*\([^\)]*\)" \
     "id:933160,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933160.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933160.yaml
@@ -676,3 +676,20 @@ tests:
         output:
           log:
             expect_ids: [933160]
+  - test_id: 38
+    desc: |
+      Positive test: eval('runExploit()')
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: "*/*"
+          method: GET
+          port: 80
+          uri: "/get?933160-38=eval%28%27runExploit%28%29%27%29"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [933160]


### PR DESCRIPTION
## what

- update regex to be more specific
- change from `.` (anything) to `[^)]`, which performs better while keeping the semantic

## why

- follow standards
- optimize matching speed
- prevent potential backtrackings