### PR TITLE
fix: remove .env from lfi-os-files.data

### DIFF
--- a/rules/lfi-os-files.data
+++ b/rules/lfi-os-files.data
@@ -33,7 +33,7 @@
 .dbus/
 .docker
 .drush/
-.env
+# .env
 .eslintignore
 .fbcindex
 .forward

--- a/rules/restricted-files.data
+++ b/rules/restricted-files.data
@@ -3,8 +3,9 @@
 .htaccess
 .htdigest
 .htpasswd
-# home level dotfiles (keep in sync with lfi-os-files.data)
-# grep -E '^\.' lfi-os-files.data
+# home level dotfiles (keep in sync with lfi-os-files.data).
+# Also include commented values (e.g., `# .env`), but not comments.
+# grep -E '^(?:#\s*)?\.[^\s]+$' lfi-os-files.data | sed 's/^#\s*//'
 .addressbook
 .aptitude/config
 .aws/

--- a/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930120.yaml
+++ b/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930120.yaml
@@ -182,3 +182,21 @@ tests:
         output:
           log:
             no_expect_ids: [930120]
+  - test_id: 11
+    desc: |
+      False positive test.
+      Don't match `.env`
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          method: "GET"
+          port: 80
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: "localhost"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          uri: "/get?code=>/test.environment"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [930120]

--- a/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930121.yaml
+++ b/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930121.yaml
@@ -213,3 +213,21 @@ tests:
         output:
           log:
             expect_ids: [930121]
+  - test_id: 11
+    desc: |
+      False positive test.
+      Don't match `.env`
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          method: "GET"
+          port: 80
+          headers:
+            Host: "localhost"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            User-Agent: "/test.environment"
+          uri: "/get"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [930121]


### PR DESCRIPTION
`.env` is probably the most generic entry in `lfi-os-files.data`. Unfortunatlye, since the words are matched using `@pmFromFile`, `.env` is easily matched as a substring. Most other entries are fairly unique or have a prefix or suffix that makes it unlikely for them to become FPs.

Note that `.env` is only commented out on purpose. `lfi-os-files.data` is also used as the base for other word files (e.g., `restricted-files.data` and since `.env` hasn't been an issue there until now, we don't want to remove it from those lists.

Fixes #3775