### PR TITLE
chore: temporarily deactivate test for 920390

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,11 +54,13 @@ jobs:
           fi
 
           ./ftw check -d tests/regression/tests
+          # temporarily deactivate 920390
           ./ftw run \
             -d tests/regression/tests \
             --log-file "tests/logs/${{ matrix.modsec_version }}/error.log" \
             --overrides tests/regression/${{ matrix.modsec_version == 'modsec2-apache' && 'httpd' || 'nginx' }}-overrides.yaml \
-            --show-failures-only
+            --show-failures-only \
+            --exclude 920390
 
       - name: "Change permissions of artifacts for upload"
         if: failure()

--- a/tests/regression/httpd-overrides.yaml
+++ b/tests/regression/httpd-overrides.yaml
@@ -19,10 +19,3 @@ test_overrides:
       status: 200
       log:
         no_expect_ids: [920380]
-  - rule_id: 920390
-    test_ids: [1]
-    reason: Exceeds PCRE limits, currently segfaults on the CI
-    output:
-      expect_error: true
-      log:
-        no_expect_ids: [920390]


### PR DESCRIPTION
We currently override the test result for 920390 to expect an error because the httpd image segfaults on that test. The new images we are building no longer segfault, making the test fail. To resolve the situation, we'll disable the test until the new images have been released (the images are verified using the CRS test setup, which currently fails because the test _does not fail_).