### PR TITLE
feat: refresh restricted-upload.data

### DIFF
--- a/rules/restricted-upload.data
+++ b/rules/restricted-upload.data
@@ -5,25 +5,29 @@
 # w
 # q
 # EOF
-# words="$(awk ' !/^#/ {split($0, segments, "/")} {word = segments[length(segments)]} length(word) > 3 {print word}' rules/restricted-files.data | \
-#   sort | uniq)"
+# words="$(awk ' !/^#/ && NF {
+#  n = split($0, segments, "/");
+#  word = segments[n];
+#  if (length(word) > 3) print word
+# }' rules/restricted-files.data | sort | uniq)"
 # while read -r word; do
 #   if [ "$(util/fp-finder/spell.sh -m -e - <<<"${word}")" != "${word}" ]; then
 #     echo "${word}" >> rules/restricted-upload.data
 #   fi
 # done <<<"${words}"
-
-.DS_Store
 .addressbook
 .bash_
 .bashrc
+.boto
 .bowerrc
 .cshrc
-.docker
+.DS_Store
 .env
+.envrc
 .eslintignore
 .eslintrc
 .fbcindex
+.fish
 .forward
 .gitattributes
 .gitconfig
@@ -45,7 +49,9 @@
 .my.cnf
 .mysql_history
 .nano_history
+.netrc
 .node_repl_history
+.npmrc
 .nsconfig
 .nsr
 .oh-my-
@@ -65,50 +71,59 @@
 .rediscli_history
 .rhistory
 .rhosts
+.selected_editor
 .sh_history
 .sqlite_history
+.svnignore
 .tcshrc
+.tmux.conf
 .travis.yml
 .user.ini
 .viminfo
 .vimrc
+.vscode
 .ws_ftp.ini
 .www_acl
 .wwwacl
 .xauthority
+.yarnrc
 .zhistory
 .zsh_history
+.zshenv
 .zshrc
-Desktop.ini
-Dockerfile
-Thumbs.db
-Web.config
 acpi
 asound
 auth.json
+BlockCypher.log
 bootconfig
 bower.json
 buddyinfo
 cgroups
+cloud-config.yml
 cmdline
+compose.yaml
+compose.yml
 composer.json
 composer.lock
+config_dev.yml
+config_prod.yml
+config_test.yml
 config.gz
 config.inc.php
 config.php
 config.sample.php
 config.yml
-config_dev.yml
-config_prod.yml
-config_test.yml
 cpuinfo
 database.yml
-defaults.inc.php
 default.settings.php
+defaults.inc.php
+Desktop.ini
 diskstats
+Dockerfile
 dynamic_debug
 execdomains
 filesystems
+fish_variables
 gruntfile.js
 hplip.conf
 hypervisor
@@ -123,6 +138,7 @@ kpagecgroup
 kpagecount
 kpageflags
 latency_stats
+ldap-authentication-report.csv
 loadavg
 local.xml
 mdstat
@@ -138,15 +154,17 @@ packages.json
 pagetypeinfo
 parameters.php
 parameters.yml
-php.ini
 php_error.log
 php_errors.log
+php.ini
 phpcs.xml
 phpcs.xml.dist
 routing.yml
 sched_debug
 schedstat
+secrets.json
 security.yml
+sendgrid.env
 services.yml
 settings.inc.php
 settings.local.php
@@ -159,12 +177,15 @@ sslvpn_websession
 sysrq-trigger
 sysvipc
 thread-self
+Thumbs.db
 timer_list
 timer_stats
 tsconfig.json
+user_secrets.yml
 version_signature
 vmallocinfo
 vmstat
+Web.config
 weblogic.xml
 webpack.config.js
 wp-config.bak


### PR DESCRIPTION
Dear coreruleset community,

After browsing the list of issues, I found [this one](https://github.com/coreruleset/coreruleset/issues/3916) that I can help with and familiarize myself with the contribution process.

I will first propose to refresh this data file by fixing and executing again the legacy script that I downloaded from previous version of this repository. I sorted the list alphabetically, in order to help the reviewer, here is the list of new keywords and the ones removed :

Added ✅ 

- .boto
- .envrc
- .fish
- .netrc
- .npmrc
- .selected_editor
- .svnignore
- .tmux.conf
- .vscode
- .yarnrc
- .zshenv
- BlockCypher.log
- cloud-config.yml
- compose.yaml
- compose.yml
- fish_variables
- ldap-authentication-report.csv
- secrets.json
- sendgrid.env
- user_secrets.yml

Removed ❌ 

- .docker (because it's now a folder)

The second step will be to port this script in crs-toolchain by addressing issue [coreruleset/crs-toolchain/issues/181](https://github.com/coreruleset/crs-toolchain/issues/181)

Refs: #3916