### PR TITLE
fix: fixing double URL decode or REQUEST_URI

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -461,7 +461,7 @@ SecRule REQUEST_URI|REQUEST_BODY "@rx (?i)%uff[0-9a-f]{2}" \
 # 920274 generally has few positives. However, it would detect rare attacks
 # on Accept request headers and friends.
 
-SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 1-255" \
+SecRule REQUEST_URI_RAW|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 1-255" \
     "id:920270,\
     phase:2,\
     block,\
@@ -1352,7 +1352,7 @@ SecRule ARGS "@rx %[0-9a-fA-F]{2}" \
 #
 # PL2: This is a stricter sibling of 920270.
 #
-SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 9,10,13,32-126,128-255" \
+SecRule REQUEST_URI_RAW|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 9,10,13,32-126,128-255" \
     "id:920271,\
     phase:2,\
     block,\
@@ -1514,7 +1514,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:920016,phase:2,pass,nolog,tag:'O
 # This rule is also triggered by the following exploit(s):
 # [ SAP CRM Java vulnerability CVE-2018-2380 - Exploit tested: https://www.exploit-db.com/exploits/44292 ]
 #
-SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteRange 32-36,38-126" \
+SecRule REQUEST_URI_RAW|REQUEST_HEADERS|ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteRange 32-36,38-126" \
     "id:920272,\
     phase:2,\
     block,\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -285,7 +285,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^\s\x0b,;]+[\s\x0b,;].*?(?:applicati
 # This issue affects Apache HTTP Server 2.4.48 and earlier.
 # GET /?unix:AAAAAAAAAAAAA|http://coreruleset.org/
 #
-SecRule REQUEST_URI "@rx unix:[^|]*\|" \
+SecRule REQUEST_URI_RAW "@rx unix:[^|]*\|" \
     "id:921240,\
     phase:1,\
     block,\

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -64,7 +64,7 @@ SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|FILES|XML:
 #
 # Semicolon added to prevent path traversal via reverse proxy mapping '/..;/' (Tomcat)
 #
-SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|FILES|XML:/* "@rx (?:(?:^|[\x5c/;])\.{2,3}[\x5c/;]|[\x5c/;]\.{2,3}(?:[\x5c/;]|$))" \
+SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|FILES|XML:/* "@rx (?:(?:^|[\x5c/;])\.{2,3}[\x5c/;]|[\x5c/;]\.{2,3}(?:[\x5c/;]|$))" \
     "id:930110,\
     phase:2,\
     block,\


### PR DESCRIPTION
Variable `REQUEST_URI` is URL decoded by the engine so we should NOT use `t:urlDecodeUni` / `t:urlDecode` actions with it, otherwise, the value gets URL decoded twice.

It looks as better fix for rule `921240` to remove action `t:urlDecodeUni` and keep using `REQUEST_URI` but it is not as rule runs in phase 1 and, thanks to a bug in modsec2, `REQUEST_URI` is URL decoded at the start of phase 2. This does not apply for modsec3, where it is URL decoded at the start of phase1, so we need to use `REQUEST_URI_RAW` + `t:urlDecodeUni` to keep consistent bahavior accross the engines (by the way, current behavior of this rule differs between modsec2 and 3 as it gets double URL decoded in modsec3 but not in modsec2).

Note: Variable `REQUEST_URI_RAW` mat contain also domain name (if it was send by client) which is a different behavior from `REQUEST_URI` but it shoud not interfere with affected rules.