### PR TITLE
feat: block header related to CVE-2025-29927 (Next.js)

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -579,7 +579,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # [ Basic ]
 # Includes deprecated headers and headers with known security risks. Always
 # forbidden.
-# Default: /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/
+# Default: /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/ /x-middleware-subrequest/
 #
 # /content-encoding/
 #   Used to list any encodings that have been applied to the original payload.
@@ -605,6 +605,9 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #   Blocking these headers prevents method override attacks, as described here:
 #   https://www.sidechannel.blog/en/http-method-override-what-it-is-and-how-a-pentester-can-use-it
 #
+# x-middleware-subrequest
+#   CVE-2025-29927 (Next.js)
+#
 # Uncomment this rule to change the default.
 #SecAction \
 #    "id:900250,\
@@ -614,7 +617,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    nolog,\
 #    tag:'OWASP_CRS',\
 #    ver:'OWASP_CRS/4.13.0-dev',\
-#    setvar:'tx.restricted_headers_basic=/content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/'"
+#    setvar:'tx.restricted_headers_basic=/content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/ /x-middleware-subrequest/'"
 #
 # [ Extended ]
 # Includes deprecated headers that are still in use (so false positives are

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -605,7 +605,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #   Blocking these headers prevents method override attacks, as described here:
 #   https://www.sidechannel.blog/en/http-method-override-what-it-is-and-how-a-pentester-can-use-it
 #
-# x-middleware-subrequest
+# /x-middleware-subrequest/
 #   CVE-2025-29927 (Next.js)
 #
 # Uncomment this rule to change the default.

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -237,7 +237,7 @@ SecRule &TX:restricted_headers_basic "@eq 0" \
     nolog,\
     tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.13.0-dev',\
-    setvar:'tx.restricted_headers_basic=/content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/'"
+    setvar:'tx.restricted_headers_basic=/content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/ /x-middleware-subrequest/'"
 
 # Default HTTP policy: restricted_headers_extended (rule 900255 in crs-setup.conf)
 SecRule &TX:restricted_headers_extended "@eq 0" \


### PR DESCRIPTION
This PR adds header `x-middleware-subrequest` into `tx.restricted_headers_basic`, so it's going to be blocked by default. At first, we were considering to not block it by default (as it will disable some features of Next.js) but after it was [completely removed from Next.js](https://github.com/vercel/next.js/pull/77474), i suggest to just block it. If we do not agree on this, i can move it into `tx.restricted_headers_extended` which will block it from PL2.

Fixes: #4051