### PR TITLE
fix: added pre-check of unset TX variable

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -330,7 +330,7 @@ SecAction \
 # The creation of the IP and the GLOBAL collection is not being tested as
 # of this writing due to limits in ftw and our testing setup.
 # Proper testing would involve the checking of a variable in the said collections.
-SecRule TX:ENABLE_DEFAULT_COLLECTIONS "@eq 1" \
+SecRule &TX:ENABLE_DEFAULT_COLLECTIONS "@eq 1" \
     "id:901320,\
     phase:1,\
     pass,\
@@ -339,10 +339,12 @@ SecRule TX:ENABLE_DEFAULT_COLLECTIONS "@eq 1" \
     ver:'OWASP_CRS/4.13.0-dev',\
     setvar:'tx.ua_hash=%{REQUEST_HEADERS.User-Agent}',\
     chain"
-    SecRule TX:ua_hash "@unconditionalMatch" \
-        "t:none,t:sha1,t:hexEncode,\
-        initcol:global=global,\
-        initcol:ip=%{remote_addr}_%{MATCHED_VAR}"
+    SecRule TX:ENABLE_DEFAULT_COLLECTIONS "@eq 1" \
+        "chain"
+        SecRule TX:ua_hash "@unconditionalMatch" \
+            "t:none,t:sha1,t:hexEncode,\
+            initcol:global=global,\
+            initcol:ip=%{remote_addr}_%{MATCHED_VAR}"
 
 #
 # -=[ Initialize Correct Body Processing ]=-


### PR DESCRIPTION
It seems like we check the unset variable `TX:ENABLE_DEFAULT_COLLECTIONS` in [REQUEST-901-INITIALIZATION.conf](https://github.com/airween/coreruleset/blob/main/rules/REQUEST-901-INITIALIZATION.conf#L323).

This PR adds an extra check where we can be sure the variable is set or not, then we can get the value.

This needs because we the linter has a [step](https://github.com/coreruleset/crs-linter?tab=readme-ov-file#test-9---check-state-of-used-tx-variables) where we want to check this.