### PR TITLE
ci: disable fail fast in regression tests, bump go-ftw

### DIFF
--- a/.github/workflows/quantitative.yaml
+++ b/.github/workflows/quantitative.yaml
@@ -11,7 +11,7 @@ on:
 
 # Pin tool versions to prevent problems
 env:
-  GO_FTW_VERSION: '1.2.0'
+  GO_FTW_VERSION: '1.3.0'
 
 permissions: {}
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,12 +24,13 @@ on:
 
 # Pin tool versions to prevent problems
 env:
-  GO_FTW_VERSION: '1.2.0'
+  GO_FTW_VERSION: '1.3.0'
 
 jobs:
   regression:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         modsec_version: [modsec2-apache, modsec3-nginx]
     steps:


### PR DESCRIPTION
This PR proposes making regression test runs across engines independent. Right now, if one engine test fails, the others are canceled. See for example https://github.com/coreruleset/coreruleset/actions/runs/14175241361/attempts/1.
Setting `fail-fast: false` would allow us to:
- Simplify detecting if a change is affecting only one engine or all of them. All the tests will individually succeed or fail, independently from the outcome of the others.
- See all the failing tests at once, avoiding having to eventually fix one engine and then having to rerun the tests to find further failings on other engines.
- In case of flaky results, rerun just the failing engine(s) and not the whole matrix.
- Bonus point: it will be even more beneficial when Coraza joins the matrix, enabling better comparisons across 3 engines.

Also, bumps go-ftw to the latest [v1.3.0](https://github.com/coreruleset/go-ftw/releases/tag/v1.3.0).