### PR TITLE
feat: detect compressed database dumps

### DIFF
--- a/rules/lfi-os-files.data
+++ b/rules/lfi-os-files.data
@@ -128,6 +128,39 @@
 /php.ini
 /tmp/
 
+# Compressed database dumps
+.sql.001
+.sql.7z
+.sql.bz
+.sql.ace
+.sql.arj
+.sql.cpio
+.sql.gz
+.sql.lha
+.sql.lz
+.sql.pa
+.sql.pea
+.sql.r00
+.sql.r01
+.sql.r02
+.sql.r03
+.sql.r04
+.sql.r05
+.sql.r06
+.sql.r07
+.sql.r08
+.sql.r09
+.sql.rar
+.sql.rev
+.sql.tar
+.sql.taz
+.sql.tbz
+.sql.tgz
+.sql.txz
+.sql.uha
+.sql.xz
+.sql.yz1
+.sql.z
 # AWS cli
 aws.yaml
 aws.yml

--- a/rules/restricted-files.data
+++ b/rules/restricted-files.data
@@ -113,6 +113,39 @@
 .zsh_history
 .zshrc
 
+# Compressed database dumps
+.sql.001
+.sql.7z
+.sql.bz
+.sql.ace
+.sql.arj
+.sql.cpio
+.sql.gz
+.sql.lha
+.sql.lz
+.sql.pa
+.sql.pea
+.sql.r00
+.sql.r01
+.sql.r02
+.sql.r03
+.sql.r04
+.sql.r05
+.sql.r06
+.sql.r07
+.sql.r08
+.sql.r09
+.sql.rar
+.sql.rev
+.sql.tar
+.sql.taz
+.sql.tbz
+.sql.tgz
+.sql.txz
+.sql.uha
+.sql.xz
+.sql.yz1
+.sql.z
 # AWS cli
 aws.yaml
 aws.yml

--- a/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930120.yaml
+++ b/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930120.yaml
@@ -236,3 +236,21 @@ tests:
         output:
           log:
             expect_ids: [930120]
+  - test_id: 14
+    desc: |
+      True positive test.
+      Accessing compressed database dump
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          method: "GET"
+          port: 80
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: "localhost"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          uri: "/get?code=backup.sql.zip"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [930120]

--- a/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930130.yaml
+++ b/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930130.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "Andrew Howe, azurit"
+  author: "Andrew Howe, azurit, Esad Cetiner"
 rule_id: 930130
 tests:
   - test_id: 1
@@ -31,6 +31,24 @@ tests:
             Host: "localhost"
             Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
           uri: "/get/proc/interrupts"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [930130]
+  - test_id: 3
+    desc: |
+      True positive test.
+      Accessing compressed database dump
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          method: "GET"
+          port: 80
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: "localhost"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          uri: "/get/backup.sql.zip"
           version: "HTTP/1.1"
         output:
           log:


### PR DESCRIPTION
Adds support for blocking compressed database dumps by adding `.sql.archive-extension`.
I used this list https://www.ncsc.admin.ch/dam/ncsc/de/dokumente/infos-it-spezialisten/govcert/govcert-ncsc_blocked-filetypes.txt.download.txt/govcert-ncsc_blocked-filetypes.txt for all of the archive filetypes, and then removed file formats that you typically won't use for this use case (For example there were some extensions for Unreal Engine, deb and rpm packages). I've left the niche archive types just in case somebody does use them.
