### PR TITLE
fix(954100): detect forward slash in path

### DIFF
--- a/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+++ b/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
@@ -35,7 +35,7 @@ SecRule RESPONSE_BODY "@rx (?i)[a-z]:[\x5c/]inetpub\b" \
     phase:4,\
     block,\
     capture,\
-    t:none,t:lowercase,\
+    t:none,\
     msg:'Disclosure of IIS install location',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}',\
     tag:'application-multi',\

--- a/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+++ b/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
@@ -30,7 +30,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:954012,phase:4,pass,nolog,tag:'O
 #
 
 # IIS default location
-SecRule RESPONSE_BODY "@rx [a-z]:[\x5c/]inetpub\b" \
+SecRule RESPONSE_BODY "@rx (?i)[a-z]:[\x5c/]inetpub\b" \
     "id:954100,\
     phase:4,\
     block,\

--- a/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+++ b/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
@@ -30,7 +30,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:954012,phase:4,pass,nolog,tag:'O
 #
 
 # IIS default location
-SecRule RESPONSE_BODY "@rx [a-z]:\x5cinetpub\b" \
+SecRule RESPONSE_BODY "@rx [a-z]:[\x5c/]inetpub\b" \
     "id:954100,\
     phase:4,\
     block,\

--- a/tests/regression/tests/RESPONSE-954-DATA-LEAKAGES-IIS/954100.yaml
+++ b/tests/regression/tests/RESPONSE-954-DATA-LEAKAGES-IIS/954100.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "Andrew Howe"
+  author: "Andrew Howe, Xhoenix"
 rule_id: 954100
 tests:
   - test_id: 1
@@ -18,6 +18,24 @@ tests:
           version: "HTTP/1.1"
           uri: "/reflect"
           data: "{\"body\": \"C:\\\\inetpub \\n\"}"
+        output:
+          log:
+            expect_ids: [954100]
+  - test_id: 2
+    desc: 'Returns C:/inetpub in the response body'
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          port: 80
+          headers:
+            Host: "localhost"
+            User-Agent: "OWASP CRS test agent"
+            Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+            Content-Type: "application/json"
+          method: "POST"
+          version: "HTTP/1.1"
+          uri: "/reflect"
+          data: "{\"body\": \"C:/inetpub \\n\"}"
         output:
           log:
             expect_ids: [954100]

--- a/tests/regression/tests/RESPONSE-954-DATA-LEAKAGES-IIS/954100.yaml
+++ b/tests/regression/tests/RESPONSE-954-DATA-LEAKAGES-IIS/954100.yaml
@@ -39,3 +39,21 @@ tests:
         output:
           log:
             expect_ids: [954100]
+  - test_id: 3
+    desc: 'Returns c:/inetpub(lower case) in the response body'
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          port: 80
+          headers:
+            Host: "localhost"
+            User-Agent: "OWASP CRS test agent"
+            Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+            Content-Type: "application/json"
+          method: "POST"
+          version: "HTTP/1.1"
+          uri: "/reflect"
+          data: "{\"body\": \"c:/inetpub \\n\"}"
+        output:
+          log:
+            expect_ids: [954100]


### PR DESCRIPTION
Fixes #4077 

>Note: Drive letter and colon are not made optional. 