### PR TITLE
docs: enable correct body processor when allowing content types

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -494,7 +494,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # could lead to a WAF bypass. For example, a malicious JSON payload submitted with a "text/plain"
 # content type may still be interpreted as JSON by a backend application but would not trigger the
 # JSON body parser at the WAF, leading to a bypass. To avoid bypasses, you must enable the appropriate
-# body parser based on what data is sent in the request body (For example JSON for JSON data, XML for XML data, etc).
+# body parser based on the expected data in the request bodies (For example JSON for JSON data, XML for XML data, etc).
 #
 # When additional JSON content types are legitimately used in a deployment,
 # e.g. application/cloudevents+json, it is extremely important to ensure that a
@@ -507,7 +507,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #
 # To prevent blocking request with not allowed content-type by default, you can create an exclusion
 # rule that removes rule 920420. It's important that you enable the correct body parser when allowing
-# an additional content type to avoid an bypass. For example, this rule enables the JSON body processor
+# an additional content type to prevent bypasses. For example, this rule enables the JSON body processor
 # for the text/plain content type:
 #SecRule REQUEST_HEADERS:Content-Type "@beginsWith text/plain" \
 #    "id:1234,\

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -37,8 +37,8 @@
 #
 # The CRS assumes that modsecurity.conf has been loaded. It is bundled with
 # ModSecurity. If you don't have it, you can get it from:
-# 2.x: https://raw.githubusercontent.com/SpiderLabs/ModSecurity/v2/master/modsecurity.conf-recommended
-# 3.x: https://raw.githubusercontent.com/SpiderLabs/ModSecurity/v3/master/modsecurity.conf-recommended
+# 2.x: https://raw.githubusercontent.com/owasp-modsecurity/ModSecurity/v2/master/modsecurity.conf-recommended
+# 3.x: https://raw.githubusercontent.com/owasp-modsecurity/ModSecurity/v3/master/modsecurity.conf-recommended
 #
 # The order of file inclusion in your webserver configuration should always be:
 # 1. modsecurity.conf
@@ -493,7 +493,8 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # body processor (for example: "text/plain", "application/x-amf", "application/octet-stream", etc..)
 # could lead to a WAF bypass. For example, a malicious JSON payload submitted with a "text/plain"
 # content type may still be interpreted as JSON by a backend application but would not trigger the
-# JSON body parser at the WAF, leading to a bypass.
+# JSON body parser at the WAF, leading to a bypass. To avoid bypasses, you must enable the appropriate
+# body parser based on what data is sent in the request body (For example JSON for JSON data, XML for XML data, etc).
 #
 # When additional JSON content types are legitimately used in a deployment,
 # e.g. application/cloudevents+json, it is extremely important to ensure that a
@@ -505,19 +506,25 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # JSON body processor for a wide variety of JSON content types.
 #
 # To prevent blocking request with not allowed content-type by default, you can create an exclusion
-# rule that removes rule 920420. For example:
-#SecRule REQUEST_HEADERS:Content-Type "@rx ^text/plain" \
+# rule that removes rule 920420. It's important that you enable the correct body parser when allowing
+# an additional content type to avoid an bypass. For example, this rule enables the JSON body processor
+# for the text/plain content type:
+#SecRule REQUEST_HEADERS:Content-Type "@beginsWith text/plain" \
 #    "id:1234,\
 #    phase:1,\
 #    pass,\
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ctl:ruleRemoveById=920420,\
 #    ver:'OWASP_CRS/4.14.0-dev',\
 #    chain"
 #    SecRule REQUEST_URI "@rx ^/foo/bar" \
-#        "t:none"
+#        "t:none,\
+#        ctl:ruleRemoveById=920420,\
+#        ctl:requestBodyProcessor=JSON"
+#
+# See: https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v2.x)#ctl
+# See: https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v3.x)#ctl
 #
 # Uncomment this rule to change the default.
 #


### PR DESCRIPTION
Adds documentation on how to safely allow additional content types by enabling the appropriate request body parser to avoid a request body bypass.