### PR TITLE
fix: false positive with `title_strip_tags` by moving `strip_tags` to 933160

### DIFF
--- a/regex-assembly/933160.ra
+++ b/regex-assembly/933160.ra
@@ -41,6 +41,7 @@ opendir
 passthru
 popen
 readfile
+strip_tags
 tmpfile
 unpack
 

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -370,7 +370,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 933160
 #
-SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\b\(?[\"']*(?:assert(?:_options)?|c(?:hr|reate_function)|e(?:val|x(?:ec|p))|f(?:ile(?:group)?|open)|glob|i(?:mage(?:gif|(?:jpe|pn)g|wbmp|xbm)|s_a)|md5|o(?:pendir|rd)|p(?:assthru|open|rev)|(?:read|tmp)file|un(?:pac|lin)k|s(?:tat|ubstr|ystem))(?:/(?:\*.*\*/|/.*)|#.*|[\s\x0b\"])*[\"']*\)?[\s\x0b]*\([^\)]*\)" \
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\b\(?[\"']*(?:assert(?:_options)?|c(?:hr|reate_function)|e(?:val|x(?:ec|p))|f(?:ile(?:group)?|open)|glob|i(?:mage(?:gif|(?:jpe|pn)g|wbmp|xbm)|s_a)|md5|o(?:pendir|rd)|p(?:assthru|open|rev)|(?:read|tmp)file|s(?:t(?:rip_tags|at)|ubstr|ystem)|un(?:pac|lin)k)(?:/(?:\*.*\*/|/.*)|#.*|[\s\x0b\"])*[\"']*\)?[\s\x0b]*\([^\)]*\)" \
     "id:933160,\
     phase:2,\
     block,\

--- a/rules/php-function-names-933150.data
+++ b/rules/php-function-names-933150.data
@@ -224,7 +224,6 @@ sqlite_unbuffered_query
 str_replace
 stream_context_create
 stream_socket_client
-strip_tags
 stripcslashes
 stripslashes
 strlen

--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933150.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933150.yaml
@@ -567,3 +567,21 @@ tests:
         output:
           log:
             no_expect_ids: [933150]
+  - test_id: 34
+    desc: |
+      SEO Framework false positive
+      matching 'strip_tags' in 'title_strip_tags'
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: GET
+          port: 80
+          uri: "/get?foo=autodescription-site-settings[title_strip_tags]"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [933150]

--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933160.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933160.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "lifeforms, Franziska Bühler, Max Leske, azurit"
+  author: "lifeforms, Franziska Bühler, Max Leske, azurit, Esad Cetiner"
 rule_id: 933160
 tests:
   - test_id: 1
@@ -728,3 +728,38 @@ tests:
         output:
           log:
             no_expect_ids: [933160]
+  - test_id: 41
+    desc: |
+      SEO Framework false positive
+      matching 'strip_tags' in 'title_strip_tags'
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: GET
+          port: 80
+          uri: "/get?foo=autodescription-site-settings[title_strip_tags]"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [933160]
+  - test_id: 42
+    desc: |
+      Block strip_tags function
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: GET
+          port: 80
+          uri: "/get?foo=strip_tags()"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [933160]


### PR DESCRIPTION
Fixes a false positive when using `autodescription-site-settings[title_strip_tags]` as an parameter name in The SEO Framework plugin in WordPress by moving `strip_tags` to 933160.