### PR TITLE
feat: remove unnecessary character class from 933151

### DIFF
--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -595,7 +595,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     setvar:'tx.933151_matched_var=%{MATCHED_VAR}',\
     setvar:'tx.933151_matched_var_name=%{MATCHED_VAR_NAME}',\
     chain"
-    SecRule MATCHED_VARS "@rx \b([^\s]+)\s*[(]" \
+    SecRule MATCHED_VARS "@rx \b([^\s]+)\s*\(" \
         "capture,\
         chain"
         SecRule TX:1 "@pmFromFile php-function-names-933151.data" \


### PR DESCRIPTION
For the regex used in 933151, the regex in the first chained rule contains a character class at the end:
`\b([^\s]+)\s*[(]`
However, removing the character class is better for performance (and arguably more readable):
`\b([^\s]+)\s*\(`
