### PR TITLE
fix: use word bondary on 952110 to avoid matching non-java errors

### DIFF
--- a/regex-assembly/952110.ra
+++ b/regex-assembly/952110.ra
@@ -3,10 +3,12 @@
 
 ##!+ i
 
-java[a-z\.]+Exception
-java[a-z\.]+Error
-org\.[a-z\.]+Exception
-com\.[a-z\.]+Exception
+##! Word boundaries are used to reduce false positives.
+
+\bjava[a-z\.]+Exception\b
+\bjava[a-z\.]+Error\b
+\borg\.[a-z\.]+Exception\b
+\bcom\.[a-z\.]+Exception\b
 ##! Java stack strace errors
-Exception in thread "[^"]*"
-at\s+(?:java|javax|jakarta|org|com)
+\bException in thread "[^"]*"\b
+\bat\s+(?:java|javax|jakarta|org|com)\b

--- a/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
+++ b/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
@@ -34,7 +34,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:952012,phase:4,pass,nolog,tag:'O
 #
 # Ref: https://github.com/andresriancho/w3af/blob/master/w3af/plugins/grep/error_pages.py
 #
-SecRule RESPONSE_BODY "@rx (?i)java[\.a-z]+E(?:xception|rror)|(?:org|com)\.[\.a-z]+Exception|Exception in thread \"[^\"]*\"|at[\s\x0b]+(?:ja(?:vax?|karta)|org|com)" \
+SecRule RESPONSE_BODY "@rx (?i)\b(?:java[\.a-z]+E(?:xception|rror)|(?:org|com)\.[\.a-z]+Exception|Exception in thread \"[^\"]*\"|at[\s\x0b]+(?:ja(?:vax?|karta)|org|com))\b" \
     "id:952110,\
     phase:4,\
     block,\

--- a/tests/regression/tests/RESPONSE-952-DATA-LEAKAGES-JAVA/952110.yaml
+++ b/tests/regression/tests/RESPONSE-952-DATA-LEAKAGES-JAVA/952110.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "Xhoenix"
+  author: "Xhoenix, Esad Cetiner"
 rule_id: 952110
 tests:
   - test_id: 1
@@ -192,3 +192,24 @@ tests:
         output:
           log:
             expect_ids: [952110]
+  - test_id: 10
+    desc: "False Positive matching 'at com'"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          port: 80
+          headers:
+            Host: "localhost"
+            User-Agent: "OWASP CRS test agent"
+            Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+            Accept-Encoding: "gzip,deflate"
+            Accept-Language: "en-us,en;q=0.5"
+            Content-Type: "application/json"
+          method: "POST"
+          version: "HTTP/1.1"
+          uri: "/reflect"
+          data: |-
+            {"body": "Clicking on the date/time link will take you to that comment on your live site."}
+        output:
+          log:
+            no_expect_ids: [952110]


### PR DESCRIPTION
Adds a word boundary to 952110 to avoid non-java error messages from being matched.