### PR TITLE
ci: add pre-commit crs-toolchain run

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,19 +29,10 @@ jobs:
           # required for version detection using `git describe`
           fetch-depth: 50
 
-      - name: Lint Yaml
-        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # v3.1.1
-        with:
-          format: github
-          file_or_dir: tests/regression/tests
-          config_file: .yamllint.yml
-
       - name: Set up Python 3
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
           python-version: 3.x
-
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
       - name: "Check CRS syntax"
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,10 +29,18 @@ jobs:
           # required for version detection using `git describe`
           fetch-depth: 50
 
+      - name: Lint Yaml
+        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # v3.1.1
+        with:
+          format: github
+          file_or_dir: tests/regression/tests
+          config_file: .yamllint.yml
+
       - name: Set up Python 3
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
           python-version: 3.x
+
 
       - name: "Check CRS syntax"
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ ci:
         for more information, see https://pre-commit.ci
     autofix_prs: true
     autoupdate_branch: ''
-    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+    autoupdate_commit_msg: 'chore(deps): pre-commit autoupdate'
     autoupdate_schedule: monthly
     skip: []
     submodules: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,11 @@ repos:
     - id: trailing-whitespace
       exclude: '^regex-assembly/'
       args: [--markdown-linebreak-ext=md]
+- repo: https://github.com/adrienverge/yamllint.git
+  rev: v1.29.0
+  hooks:
+    - id: yamllint
+      args: [-f=github, -c=.yamllint.yml, tests/regression/tests]
 - repo: local
   hooks:
     - id: run-crs-toolchain

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 ci:
     autofix_commit_msg: |
-        [pre-commit.ci] auto fixes from pre-commit.com hooks
+        chore(formatting): auto fixes from pre-commit hooks
 
         for more information, see https://pre-commit.ci
     autofix_prs: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,6 @@ repos:
   hooks:
     - id: run-crs-toolchain
       name: run-crs-toolchain
-      entry: crs-toolchain regex update --all
-      language: system
+      entry: ghcr.io/coreruleset/crs-toolchain:2.4.0 regex update --all
+      language: docker_image
       files: '^regex-assembly/.*\.ra$'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,10 @@ repos:
     - id: trailing-whitespace
       exclude: '^regex-assembly/'
       args: [--markdown-linebreak-ext=md]
+- repo: local
+  hooks:
+    - id: run-crs-toolchain
+      name: run-crs-toolchain
+      entry: crs-toolchain regex update --all
+      language: system
+      files: '^regex-assembly/.*\.ra$'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,9 +5,6 @@ ci:
 
         for more information, see https://pre-commit.ci
     autofix_prs: true
-    autoupdate_branch: ''
-    autoupdate_commit_msg: 'chore(deps): pre-commit autoupdate'
-    autoupdate_schedule: monthly
     skip: []
     submodules: false
 # Update the rev variable with the release version that you want, from the yamllint repo

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
   hooks:
     - id: run-crs-toolchain
       name: run-crs-toolchain
-      entry: ghcr.io/coreruleset/crs-toolchain:2.4.0 regex update --all
-      language: docker_image
-      files: '^regex-assembly/.*\.ra$'
+      entry: crs-toolchain regex update
+      additional_dependencies: ['github.com/coreruleset/crs-toolchain/v2@v2.4.0']
+      language: golang
+      files: '^regex-assembly/.*\.ra'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,15 @@
 ---
+ci:
+    autofix_commit_msg: |
+        [pre-commit.ci] auto fixes from pre-commit.com hooks
+
+        for more information, see https://pre-commit.ci
+    autofix_prs: true
+    autoupdate_branch: ''
+    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+    autoupdate_schedule: monthly
+    skip: []
+    submodules: false
 # Update the rev variable with the release version that you want, from the yamllint repo
 # You can pass your custom .yamllint with args attribute.
 repos:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,8 @@ repos:
   hooks:
     - id: run-crs-toolchain
       name: run-crs-toolchain
-      entry: crs-toolchain regex update
+      entry: crs-toolchain regex update --all -l error
       additional_dependencies: ['github.com/coreruleset/crs-toolchain/v2@v2.4.0']
       language: golang
-      files: '^regex-assembly/.*\.ra'
+      pass_filenames: false
+      files: '^regex-assembly/'


### PR DESCRIPTION
## what

- add pre-commit run
- move pre-commit out of lint so it is not run twice
- remove yaml lint from lint and execute as pre-commit

## why

- fix files quickly
- update files after suggestions in code review

## refs

- Fixes #4174 