### PR TITLE
feat: add file which contains rule id's without tests

### DIFF
--- a/util/TESTS_EXCLUSIONS
+++ b/util/TESTS_EXCLUSIONS
@@ -1,0 +1,61 @@
+# crs-setup.conf.example
+1234
+900
+901
+905
+910
+912
+949
+# 921170 prepares 921180
+921170
+# 942441 is an exclusion rule
+942441
+# 942442 is an exclusion rule
+942442
+# 950100 needs 5XX response
+950100
+# 950130 needs Apache directory listing response
+950130
+# 950140 needs a shebang in first line
+950140
+# 951100 needs a specific SQL error message in resp. body
+951100
+# 953110 needs a specific PHP fn name in resp. body
+953110
+# 954110 needs a specific IIS message in resp. body
+954110
+# 954120 needs a specific message in resp. body
+954130
+# 955XXX rules need a specific webshell resp.
+955130
+955140
+955150
+955160
+955170
+955180
+955190
+955200
+955210
+955220
+955230
+955240
+955250
+955270
+955280
+955290
+955300
+955310
+955320
+955330
+955340
+955350
+# 959XXX rules are blocking eval. rules
+959101
+959152
+959153
+959154
+959155
+959160
+959161
+959162
+959163

--- a/util/TESTS_EXCLUSIONS
+++ b/util/TESTS_EXCLUSIONS
@@ -6,16 +6,6 @@
 # rule number prefix (e.g., 1234, or 12). Prefixes will match all rules IDs with the same prefix.
 # The linter will skip the "rules without tests" lint check for any matching rule ID.
 #
-# You can add explicit rule id's or rules' groups, like
-# 921170
-# or
-# 900
-# 9551
-#
-# Linter tries to match the pattern to the rule ID, with the
-# length of given pattern. 900 means all rules were id like with 900XXX,
-# 9551 means rules where id like 9551XX
-#
 # See https://github.com/coreruleset/crs-linter for reference.
 
 # crs-setup.conf.example

--- a/util/TESTS_EXCLUSIONS
+++ b/util/TESTS_EXCLUSIONS
@@ -2,7 +2,7 @@
 # These are mainly administrative rules.
 #
 # Lines starting with `#` are considered comments.
-# Every non-empty, non-commented line is expected to be a rule number (e.g. 123456) or 
+# Every non-empty, non-commented line is expected to be a rule number (e.g. 123456) or
 # rule number prefix (e.g., 1234, or 12). Prefixes will match all rules IDs with the same prefix.
 # The linter will skip the "rules without tests" lint check for any matching rule ID.
 #

--- a/util/TESTS_EXCLUSIONS
+++ b/util/TESTS_EXCLUSIONS
@@ -2,8 +2,9 @@
 # These are mainly administrative rules.
 #
 # Lines starting with `#` are considered comments.
-# Every non-empty, non-commented line is expected to be a rule number or rule number prefix
-# for which the "rules without tests" lint check will be skipped for matching rules.
+# Every non-empty, non-commented line is expected to be a rule number (e.g. 123456) or 
+# rule number prefix (e.g., 1234, or 12). Prefixes will match all rules IDs with the same prefix.
+# The linter will skip the "rules without tests" lint check for any matching rule ID.
 #
 # You can add explicit rule id's or rules' groups, like
 # 921170

--- a/util/TESTS_EXCLUSIONS
+++ b/util/TESTS_EXCLUSIONS
@@ -5,6 +5,16 @@
 # Every non-empty, non-commented line is expected to be a rule number or rule number prefix
 # for which the "rules without tests" lint check will be skipped for matching rules.
 #
+# You can add explicit rule id's or rules' groups, like
+# 921170
+# or
+# 900
+# 9551
+#
+# Linter tries to match the pattern to the rule ID, with the
+# length of given pattern. 900 means all rules were id like with 900XXX,
+# 9551 means rules where id like 9551XX
+#
 # See https://github.com/coreruleset/crs-linter for reference.
 
 # crs-setup.conf.example

--- a/util/TESTS_EXCLUSIONS
+++ b/util/TESTS_EXCLUSIONS
@@ -1,3 +1,12 @@
+# This file defines rules that are expected to fail the "rules without tests" lint check.
+# These are mainly administrative rules.
+#
+# Lines starting with `#` are considered comments.
+# Every non-empty, non-commented line is expected to be a rule number or rule number prefix
+# for which the "rules without tests" lint check will be skipped for matching rules.
+#
+# See https://github.com/coreruleset/crs-linter for reference.
+
 # crs-setup.conf.example
 1234
 900


### PR DESCRIPTION
The new [linter](https://github.com/coreruleset/crs-linter) needs this file.

Actually we use a [script](https://github.com/coreruleset/coreruleset/tree/main/util/find-rules-without-test) in our [CI](https://github.com/coreruleset/coreruleset/blob/main/.github/workflows/lint.yaml#L102-L106), which checks what rule does not have any tests.

The new linter is [able](https://github.com/coreruleset/crs-linter/pull/47) to do this job, but it needs an exclusion list - this file is it.