### PR TITLE
fix(953100): remove generic SQLSTATE error codes causing false positives

### DIFF
--- a/rules/php-errors.data
+++ b/rules/php-errors.data
@@ -356,8 +356,6 @@ Glob support is not available
 Got chunk
 HTTP request failed!
 HTTP wrapper does not support writeable connections
-(HY000/
-SQLSTATE[
 Handler name must be a string
 Header "
 Header may not contain

--- a/rules/php-errors.data
+++ b/rules/php-errors.data
@@ -357,10 +357,7 @@ Got chunk
 HTTP request failed!
 HTTP wrapper does not support writeable connections
 (HY000/
-SQLSTATE[HY000]
-SQLSTATE[HY093]
-SQLSTATE[HY105]
-SQLSTATE[IM001]
+SQLSTATE[
 Handler name must be a string
 Header "
 Header may not contain

--- a/rules/php-errors.data
+++ b/rules/php-errors.data
@@ -356,9 +356,11 @@ Glob support is not available
 Got chunk
 HTTP request failed!
 HTTP wrapper does not support writeable connections
-HY000
-HY093
-HY105
+(HY000/
+SQLSTATE[HY000]
+SQLSTATE[HY093]
+SQLSTATE[HY105]
+SQLSTATE[IM001]
 Handler name must be a string
 Header "
 Header may not contain
@@ -367,7 +369,6 @@ Header name "
 Header name cannot be numeric,
 Header to delete may not contain colon.
 Hour cannot be higher than 12
-IM001
 ISO Week must be between 1 and 53
 Ignoring session_start() because a session has already been started
 Illegal member variable name

--- a/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
+++ b/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
@@ -104,69 +104,6 @@ tests:
           log:
             no_expect_ids: [953100]
   - test_id: 6
-    desc: "TP: SQLSTATE[HY000] in response body should trigger 953100"
-    stages:
-      - input:
-          dest_addr: "127.0.0.1"
-          port: 80
-          version: "HTTP/1.1"
-          method: "POST"
-          uri: "/reflect"
-          headers:
-            Host: "localhost"
-            User-Agent: "OWASP CRS test agent"
-            Accept: "application/json"
-            Content-Type: "application/json"
-          data: |
-            {
-              "body": "SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo failed"
-            }
-        output:
-          log:
-            expect_ids: [953100]
-  - test_id: 7
-    desc: "TP: SQLSTATE[HY093] Invalid parameter number"
-    stages:
-      - input:
-          dest_addr: "127.0.0.1"
-          port: 80
-          version: "HTTP/1.1"
-          method: "POST"
-          uri: "/reflect"
-          headers:
-            Host: "localhost"
-            User-Agent: "OWASP CRS test agent"
-            Accept: "application/json"
-            Content-Type: "application/json"
-          data: |
-            {
-              "body": "SQLSTATE[HY093]: Invalid parameter number: parameter was not defined"
-            }
-        output:
-          log:
-            expect_ids: [953100]
-  - test_id: 8
-    desc: "TP: SQLSTATE[HY105] in response body"
-    stages:
-      - input:
-          dest_addr: "127.0.0.1"
-          port: 80
-          version: "HTTP/1.1"
-          method: "POST"
-          uri: "/reflect"
-          headers:
-            Host: "localhost"
-            User-Agent: "OWASP CRS test agent"
-            Accept: "application/json"
-            Content-Type: "application/json"
-          data: |
-            {
-              "body": "SQLSTATE[HY105]: Invalid parameter type: -999 Parameter requires non-null value"
-            }
-        output:
-          log:
-            expect_ids: [953100]
-  - test_id: 9
     desc: "TP: (HY000/NNNN) variant seen in PDO/MySQL messages"
     stages:
       - input:
@@ -187,8 +124,8 @@ tests:
         output:
           log:
             expect_ids: [953100]
-  - test_id: 10
-    desc: "TP: ODBC IM001 classic phrase + SQLSTATE[IM001]"
+  - test_id: 7
+    desc: "TP: SQLSTATE[HY000] in response body should trigger 953100"
     stages:
       - input:
           dest_addr: "127.0.0.1"
@@ -203,12 +140,12 @@ tests:
             Content-Type: "application/json"
           data: |
             {
-              "body": "SQLSTATE[IM001]: Driver does not support this function"
+              "body": "SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo failed"
             }
         output:
           log:
             expect_ids: [953100]
-  - test_id: 11
+  - test_id: 8
     desc: "FP regression: random token containing 'hy000' must NOT trigger (after php-errors.data patch)"
     stages:
       - input:
@@ -225,27 +162,6 @@ tests:
           data: |
             {
               "body": "{\"tablet\":\"ipad\",\"field\":\"number\",\"token\":\"493000hazhhy0004\"}"
-            }
-        output:
-          log:
-            no_expect_ids: [953100]
-  - test_id: 12
-    desc: "FP regression: random id 'sim001a' containing 'im001' must NOT trigger (after php-errors.data patch)"
-    stages:
-      - input:
-          dest_addr: "127.0.0.1"
-          port: 80
-          version: "HTTP/1.1"
-          method: "POST"
-          uri: "/reflect"
-          headers:
-            Host: "localhost"
-            User-Agent: "OWASP CRS test agent"
-            Accept: "application/json"
-            Content-Type: "application/json"
-          data: |
-            {
-              "body": "{\"id\":\"sim001a\",\"ok\":true}"
             }
         output:
           log:

--- a/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
+++ b/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
@@ -229,7 +229,7 @@ tests:
         output:
           log:
             no_expect_ids: [953100]
-  - test_id: 13
+  - test_id: 12
     desc: "FP regression: random id 'sim001a' containing 'im001' must NOT trigger (after php-errors.data patch)"
     stages:
       - input:

--- a/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
+++ b/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "M4tteoP, Esad Cetiner, azurit, elnadrion.dev"
+  author: "M4tteoP, Esad Cetiner, azurit"
 rule_id: 953100
 tests:
   - test_id: 1
@@ -100,69 +100,6 @@ tests:
           version: "HTTP/1.1"
           uri: "/post"
           data: "Field cannot be empty."
-        output:
-          log:
-            no_expect_ids: [953100]
-  - test_id: 6
-    desc: "TP: (HY000/NNNN) variant seen in PDO/MySQL messages"
-    stages:
-      - input:
-          dest_addr: "127.0.0.1"
-          port: 80
-          version: "HTTP/1.1"
-          method: "POST"
-          uri: "/reflect"
-          headers:
-            Host: "localhost"
-            User-Agent: "OWASP CRS test agent"
-            Accept: "application/json"
-            Content-Type: "application/json"
-          data: |
-            {
-              "body": "mysqli::real_connect(): (HY000/2002): No such file or directory"
-            }
-        output:
-          log:
-            expect_ids: [953100]
-  - test_id: 7
-    desc: "TP: SQLSTATE[HY000] in response body should trigger 953100"
-    stages:
-      - input:
-          dest_addr: "127.0.0.1"
-          port: 80
-          version: "HTTP/1.1"
-          method: "POST"
-          uri: "/reflect"
-          headers:
-            Host: "localhost"
-            User-Agent: "OWASP CRS test agent"
-            Accept: "application/json"
-            Content-Type: "application/json"
-          data: |
-            {
-              "body": "SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo failed"
-            }
-        output:
-          log:
-            expect_ids: [953100]
-  - test_id: 8
-    desc: "FP regression: random token containing 'hy000' must NOT trigger (after php-errors.data patch)"
-    stages:
-      - input:
-          dest_addr: "127.0.0.1"
-          port: 80
-          version: "HTTP/1.1"
-          method: "POST"
-          uri: "/reflect"
-          headers:
-            Host: "localhost"
-            User-Agent: "OWASP CRS test agent"
-            Accept: "application/json"
-            Content-Type: "application/json"
-          data: |
-            {
-              "body": "{\"tablet\":\"ipad\",\"field\":\"number\",\"token\":\"493000hazhhy0004\"}"
-            }
         output:
           log:
             no_expect_ids: [953100]

--- a/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
+++ b/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "M4tteoP, Esad Cetiner, azurit"
+  author: "M4tteoP, Esad Cetiner, azurit, elnadrion.dev"
 rule_id: 953100
 tests:
   - test_id: 1
@@ -100,6 +100,153 @@ tests:
           version: "HTTP/1.1"
           uri: "/post"
           data: "Field cannot be empty."
+        output:
+          log:
+            no_expect_ids: [953100]
+  - test_id: 6
+    desc: "TP: SQLSTATE[HY000] in response body should trigger 953100"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          port: 80
+          version: "HTTP/1.1"
+          method: "POST"
+          uri: "/reflect"
+          headers:
+            Host: "localhost"
+            User-Agent: "OWASP CRS test agent"
+            Accept: "application/json"
+            Content-Type: "application/json"
+          data: |
+            {
+              "body": "SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo failed"
+            }
+        output:
+          log:
+            expect_ids: [953100]
+  - test_id: 7
+    desc: "TP: SQLSTATE[HY093] Invalid parameter number"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          port: 80
+          version: "HTTP/1.1"
+          method: "POST"
+          uri: "/reflect"
+          headers:
+            Host: "localhost"
+            User-Agent: "OWASP CRS test agent"
+            Accept: "application/json"
+            Content-Type: "application/json"
+          data: |
+            {
+              "body": "SQLSTATE[HY093]: Invalid parameter number: parameter was not defined"
+            }
+        output:
+          log:
+            expect_ids: [953100]
+  - test_id: 8
+    desc: "TP: SQLSTATE[HY105] in response body"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          port: 80
+          version: "HTTP/1.1"
+          method: "POST"
+          uri: "/reflect"
+          headers:
+            Host: "localhost"
+            User-Agent: "OWASP CRS test agent"
+            Accept: "application/json"
+            Content-Type: "application/json"
+          data: |
+            {
+              "body": "SQLSTATE[HY105]: Invalid parameter type: -999 Parameter requires non-null value"
+            }
+        output:
+          log:
+            expect_ids: [953100]
+  - test_id: 9
+    desc: "TP: (HY000/NNNN) variant seen in PDO/MySQL messages"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          port: 80
+          version: "HTTP/1.1"
+          method: "POST"
+          uri: "/reflect"
+          headers:
+            Host: "localhost"
+            User-Agent: "OWASP CRS test agent"
+            Accept: "application/json"
+            Content-Type: "application/json"
+          data: |
+            {
+              "body": "mysqli::real_connect(): (HY000/2002): No such file or directory"
+            }
+        output:
+          log:
+            expect_ids: [953100]
+  - test_id: 10
+    desc: "TP: ODBC IM001 classic phrase + SQLSTATE[IM001]"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          port: 80
+          version: "HTTP/1.1"
+          method: "POST"
+          uri: "/reflect"
+          headers:
+            Host: "localhost"
+            User-Agent: "OWASP CRS test agent"
+            Accept: "application/json"
+            Content-Type: "application/json"
+          data: |
+            {
+              "body": "SQLSTATE[IM001]: Driver does not support this function"
+            }
+        output:
+          log:
+            expect_ids: [953100]
+  - test_id: 11
+    desc: "FP regression: random token containing 'hy000' must NOT trigger (after php-errors.data patch)"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          port: 80
+          version: "HTTP/1.1"
+          method: "POST"
+          uri: "/reflect"
+          headers:
+            Host: "localhost"
+            User-Agent: "OWASP CRS test agent"
+            Accept: "application/json"
+            Content-Type: "application/json"
+          data: |
+            {
+              "body": "{\"tablet\":\"ipad\",\"field\":\"number\",\"token\":\"493000hazhhy0004\"}"
+            }
+        output:
+          log:
+            no_expect_ids: [953100]
+  - test_id: 13
+    desc: "FP regression: random id 'sim001a' containing 'im001' must NOT trigger (after php-errors.data patch)"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          port: 80
+          version: "HTTP/1.1"
+          method: "POST"
+          uri: "/reflect"
+          headers:
+            Host: "localhost"
+            User-Agent: "OWASP CRS test agent"
+            Accept: "application/json"
+            Content-Type: "application/json"
+          data: |
+            {
+              "body": "{\"id\":\"sim001a\",\"ok\":true}"
+            }
         output:
           log:
             no_expect_ids: [953100]


### PR DESCRIPTION
This patch refines rule **953100 (PHP leakage)** by removing overly broad markers (`HY000`, `HY093`, `HY105`, `IM001`) from `php-errors.data` and replacing them with context-aware signatures:

- `SQLSTATE[HY000]`, `(HY000/`
- `SQLSTATE[HY093]`
- `SQLSTATE[HY105]`
- `SQLSTATE[IM001]`

These patterns align with real PDO/ODBC error messages while eliminating false positives caused by random substrings in response bodies (e.g. I had tokens like `hazhhy0004`,`sim001a`). This improves detection accuracy without weakening coverage of genuine leakage events.