### PR TITLE
fix: missing capture action

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -1374,6 +1374,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx ;[\s\x
     "id:932210,\
     phase:2,\
     block,\
+    capture,\
     t:none,t:escapeSeqDecode,t:compressWhitespace,\
     msg:'Remote Command Execution: SQLite System Command Execution',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -1485,6 +1486,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?is)\
     "id:932310,\
     phase:2,\
     block,\
+    capture,\
     t:none,t:escapeSeqDecode,\
     msg:'Remote Command Execution: IMAP Command Execution',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -1519,6 +1521,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?is)\
     "id:932320,\
     phase:2,\
     block,\
+    capture,\
     t:none,t:escapeSeqDecode,\
     msg:'Remote Command Execution: POP3 Command Execution',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -1928,6 +1931,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \r\n.*
     "id:932301,\
     phase:2,\
     block,\
+    capture,\
     t:none,t:escapeSeqDecode,\
     msg:'Remote Command Execution: SMTP Command Execution',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -1961,6 +1965,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?is)\
     "id:932311,\
     phase:2,\
     block,\
+    capture,\
     t:none,t:escapeSeqDecode,\
     msg:'Remote Command Execution: IMAP Command Execution',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -1994,6 +1999,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \r\n.*
     "id:932321,\
     phase:2,\
     block,\
+    capture,\
     t:none,t:escapeSeqDecode,\
     msg:'Remote Command Execution: POP3 Command Execution',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -2026,6 +2032,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx !(?:\d
     "id:932331,\
     phase:2,\
     block,\
+    capture,\
     t:none,\
     msg:'Remote Command Execution: Unix shell history invocation',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\


### PR DESCRIPTION
Hello,  

Just a small quick fix while working on audit logs.  

We should avoid using %{TX.0} if capture undefined.

Thanks you

Vincent