### PR TITLE
fix: reduce false positives with php response rules

### DIFF
--- a/regex-assembly/953101.ra
+++ b/regex-assembly/953101.ra
@@ -1,0 +1,20 @@
+##! For more information, see comments at the beginning of the php-errors.data file.
+
+##!+ i
+
+cannot be empty
+File size is
+Invalid date
+Static function\b
+The function\b
+Password is too long
+Path cannot be empty
+error reading
+Unknown reason
+invalid option
+Out of memory
+Empty string
+Freeing memory
+No active class
+empty password
+Telling...

--- a/regex-assembly/953101.ra
+++ b/regex-assembly/953101.ra
@@ -20,7 +20,7 @@ Reading file
 Restarting!
 Session is not active
 Static function\b
-Telling...
+Telling\.\.\.
 The function\b
 Unknown reason
 cannot be empty

--- a/regex-assembly/953101.ra
+++ b/regex-assembly/953101.ra
@@ -8,6 +8,8 @@
 Empty string
 File size is
 Freeing memory
+Header "
+Header name "
 Invalid date
 No active class
 Out of memory
@@ -25,5 +27,3 @@ cannot be empty
 empty password
 error reading
 invalid option
-Header "
-Header name "

--- a/regex-assembly/953101.ra
+++ b/regex-assembly/953101.ra
@@ -15,7 +15,6 @@ No active class
 Out of memory
 Pair level
 Password is too long
-Path cannot be empty
 Reading file
 Restarting!
 Session is not active

--- a/regex-assembly/953101.ra
+++ b/regex-assembly/953101.ra
@@ -1,20 +1,29 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
 ##! For more information, see comments at the beginning of the php-errors.data file.
 
 ##!+ i
 
-cannot be empty
+Empty string
 File size is
+Freeing memory
 Invalid date
-Static function\b
-The function\b
+No active class
+Out of memory
+Pair level
 Password is too long
 Path cannot be empty
-error reading
-Unknown reason
-invalid option
-Out of memory
-Empty string
-Freeing memory
-No active class
-empty password
+Reading file
+Restarting!
+Session is not active
+Static function\b
 Telling...
+The function\b
+Unknown reason
+cannot be empty
+empty password
+error reading
+invalid option
+Header "
+Header name "

--- a/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -114,9 +114,10 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:953014,phase:4,pass,nolog,tag:'O
 # -=[ PHP Error Message Leakage ]=-
 #
 # This is a stricter sibling of rule 953100.
-# This stricter sibling checks for additional error messages which has a higher chance to appear in common language.
+# This stricter sibling checks for additional error messages which has a higher chance to appear in common language and uses regular
+# expressions to reduce false positives where possible.
 #
-SecRule RESPONSE_BODY "@pmFromFile php-errors-pl2.data" \
+SecRule RESPONSE_BODY "@rx (?i)(?:cannot be empt|Out of memor)y|F(?:ile size is|reeing memory)|Invalid date|Static function\b|T(?:he function\b|elling...)|Pa(?:ssword is too long|th cannot be empty)|e(?:rror reading|mpty password)|(?:Unknown reas|invalid opti)on|Empty string|No active class" \
     "id:953101,\
     phase:4,\
     block,\

--- a/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -117,7 +117,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:953014,phase:4,pass,nolog,tag:'O
 # This stricter sibling checks for additional error messages which has a higher chance to appear in common language and uses regular
 # expressions to reduce false positives where possible.
 #
-SecRule RESPONSE_BODY "@rx (?i)(?:cannot be empt|Out of memor)y|F(?:ile size is|reeing memory)|Invalid date|Static function\b|T(?:he function\b|elling...)|Pa(?:ssword is too long|th cannot be empty)|e(?:rror reading|mpty password)|(?:Unknown reas|invalid opti)on|Empty string|No active class" \
+SecRule RESPONSE_BODY "@rx (?i)Empty string|F(?:ile size is|reeing memory)|Header (?:name )?\"|Invalid date|No active class|(?:Out of memor|cannot be empt)y|Pa(?:ir level|ssword is too long)|Re(?:ading file|starting!)|S(?:ession is not active|tatic function\b)|T(?:elling\.\.\.|he function\b)|(?:Unknown reas|invalid opti)on|e(?:mpty password|rror reading)" \
     "id:953101,\
     phase:4,\
     block,\

--- a/rules/php-errors-pl2.data
+++ b/rules/php-errors-pl2.data
@@ -1,7 +1,0 @@
-# For more information, see comments at the beginning of the php-errors.data file.
-
-cannot be empty
-File size is
-Invalid date
-Static function
-The function

--- a/rules/php-errors.data
+++ b/rules/php-errors.data
@@ -580,6 +580,7 @@ Parsing WSDL: No binding associated with <port>
 Parsing WSDL: No location associated with <port>
 Parsing WSDL: Unspecified encodingStyle
 Password hashing failed for unknown reason
+Path cannot be empty
 Path to document must not contain any null bytes
 PostgreSQL connection has already been closed
 PostgreSQL large object has already been closed

--- a/rules/php-errors.data
+++ b/rules/php-errors.data
@@ -355,10 +355,8 @@ Got chunk
 HTTP request failed!
 HTTP wrapper does not support writeable connections
 Handler name must be a string
-Header "
 Header may not contain
 Header may not contain NUL bytes
-Header name "
 Header name cannot be numeric,
 Header to delete may not contain colon.
 Hour cannot be higher than 12
@@ -537,7 +535,6 @@ PDO::ATTR_STATEMENT_CLASS value must be an array with the format
 PDO::FETCH_INTO and PDO::FETCH_CLASS cannot be set as the default fetch mode
 PNG support is not available
 POST Content-Length of
-Pair level
 Paletter image not supported by webp
 Parser must not be called recursively
 Parsing Schema: <restriction> or <extension> expected in complexContent
@@ -600,7 +597,6 @@ Putting int...
 Putting word...
 Read Error: truncated data
 Read-only segment cannot be written
-Reading file
 Reading gd2 header info
 Recursion detected
 Redeclaration of "
@@ -610,7 +606,6 @@ Registered tick function cannot be unregistered while it is being executed
 Remote file already exists and overwrite context option not specified
 ResourceBundle does not support writable iterators
 ResourceBundle object is already constructed
-Restarting!
 Returning by reference from a void function is deprecated
 SNMP output print format must be an SNMP_OID_OUTPUT_* constant
 SNMP retrieval method must be a bitmask of SNMP_VALUE_LIBRARY, SNMP_VALUE_PLAIN, and SNMP_VALUE_OBJECT
@@ -670,7 +665,6 @@ Security protocol must be one of "
 Seeking...
 Server doesn't support FTPS.
 Session id must be a string
-Session is not active
 Set autocommit
 SetConnectOption
 SetStmtOption

--- a/rules/php-errors.data
+++ b/rules/php-errors.data
@@ -272,7 +272,6 @@ Double timezone specification
 Duplicate field name "
 During class fetch
 EOF before image was complete
-Empty string
 Empty string as an extension
 Encoding mode must be ZLIB_ENCODING_RAW, ZLIB_ENCODING_GZIP or ZLIB_ENCODING_DEFLATE
 Encoding: '*' may only be first arraySize value in list
@@ -345,7 +344,6 @@ Found unconstructed ResourceBundle
 Found unconstructed Spoofchecker
 Found unconstructed transliterator
 Found unexpected data
-Freeing memory
 GC buffer overflow (GC disabled)\n
 Generated salt too short
 Generator already closed
@@ -456,7 +454,6 @@ Nanoseconds was not in the range 0 to 999 999 999 or seconds was negative
 Negative width in bit-field "
 No PostgreSQL connection opened yet
 No URL resource specified
-No active class
 No active op array!
 No active symbol table!
 No execution context
@@ -531,7 +528,6 @@ Only variables should be assigned by reference
 Only variables should be passed by reference
 # Option "
 Options should have the form [\
-Out of memory
 Overflow in enumeration values "
 PDO object is not initialized, constructor was not called
 PDO object is uninitialized
@@ -587,8 +583,6 @@ Parsing WSDL: No binding associated with <port>
 Parsing WSDL: No location associated with <port>
 Parsing WSDL: Unspecified encodingStyle
 Password hashing failed for unknown reason
-Password is too long
-Path cannot be empty
 Path to document must not contain any null bytes
 PostgreSQL connection has already been closed
 PostgreSQL large object has already been closed
@@ -691,7 +685,6 @@ Spoofchecker class not defined
 String offset cast occurred
 String size overflow
 TCP/IP option is not available for error logging
-Telling...
 # The
 # The "
 The (unset) cast is no longer supported
@@ -756,7 +749,6 @@ Unknown SOAP version
 Unknown and uncaught modification type.
 Unknown file open mode
 Unknown format specifier "
-Unknown reason
 Unmatched [ in format string
 Unsupported "
 Unsupported argument type
@@ -860,10 +852,8 @@ could not obtain parameters for parsing
 declare(encoding=...) ignored because
 define(): Argument #3 ($case_insensitive) is ignored since declaration of case-insensitive constants is no longer supported
 deflate_init(): "
-empty password
 error converting input string
 error copying from pipe to temp file
-error reading
 error seeking
 error while writing to temp file
 failed setting compression level
@@ -902,7 +892,6 @@ input LOB is no longer a stream
 invalid capture index
 invalid format (repeated flags)
 invalid format (width or precision too long)
-invalid option
 invalid order function for sorting
 invalid pattern capture
 is an invalid DocumentType object

--- a/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953101.yaml
+++ b/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953101.yaml
@@ -108,3 +108,24 @@ tests:
         output:
           log:
             expect_ids: [953101]
+  - test_id: 6
+    desc: "Use a word boundary on 'The function' to reduce false alarms at PL-2"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          port: 80
+          headers:
+            Host: "localhost"
+            User-Agent: "OWASP CRS test agent"
+            Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+            Accept-Encoding: "gzip,deflate"
+            Accept-Language: "en-us,en;q=0.5"
+            Content-Type: "application/json"
+          method: "POST"
+          version: "HTTP/1.1"
+          uri: "/reflect"
+          data: |-
+            {"body": "Additional features to extend the functionality of W3 Total Cache|"}
+        output:
+          log:
+            no_expect_ids: [953101]

--- a/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953101.yaml
+++ b/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953101.yaml
@@ -125,7 +125,7 @@ tests:
           version: "HTTP/1.1"
           uri: "/reflect"
           data: |-
-            {"body": "Additional features to extend the functionality of W3 Total Cache|"}
+            {"body": "Additional features to extend the functionality of W3 Total Cache"}
         output:
           log:
             no_expect_ids: [953101]


### PR DESCRIPTION
This PR tries to reduce false positives with the PHP response rules at both PL-1 and 2 by moving false positive prone entries to PL-2 and using word boundaries where possible to reduce false positives.