### PR TITLE
feat: whitelist application/csp-report content-type header

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -481,7 +481,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 
 # Content-Types that a client is allowed to send in a request.
 # Default: |application/x-www-form-urlencoded| |multipart/form-data| |text/xml|
-# |application/xml| |application/soap+xml| |application/json| |application/reports+json|
+# |application/xml| |application/soap+xml| |application/json| |application/reports+json| |application/csp-report|
 #
 # Please note, that the rule where CRS uses this variable (920420) evaluates it with operator
 # `@within`, which is case sensitive, but uses t:lowercase. You must add your whole custom
@@ -536,7 +536,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    nolog,\
 #    tag:'OWASP_CRS',\
 #    ver:'OWASP_CRS/4.19.0-dev',\
-#    setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |text/xml| |application/xml| |application/soap+xml| |application/json| |application/reports+json|'"
+#    setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |text/xml| |application/xml| |application/soap+xml| |application/json| |application/reports+json| |application/csp-report|'"
 
 # Allowed HTTP versions.
 # Default: HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0 HTTP/3 HTTP/3.0

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -197,7 +197,7 @@ SecRule &TX:allowed_request_content_type "@eq 0" \
     nolog,\
     tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.19.0-dev',\
-    setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |text/xml| |application/xml| |application/soap+xml| |application/json| |application/reports+json|'"
+    setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |text/xml| |application/xml| |application/soap+xml| |application/json| |application/reports+json| |application/csp-report|'"
 
 # Default HTTP policy: allowed_request_content_type_charset (rule 900280 in crs-setup.conf)
 SecRule &TX:allowed_request_content_type_charset "@eq 0" \


### PR DESCRIPTION
`application/reports+json` alone is not enough. Some browsers (like FF) don't support the `report-to` CSP header and still send CSP violation data with the `application/csp-report` content type

I propose we whitelist both

More about the topic:

- https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP
- https://caniuse.com/mdn-http_headers_content-security-policy_report-to
- https://caniuse.com/mdn-http_headers_content-security-policy_report-uri