### PR TITLE
chore: 920190 bypass

### DIFF
--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920190.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920190.yaml
@@ -58,7 +58,7 @@ tests:
           log:
             expect_ids: [920190]
   - test_id: 4
-    desc: 'Range: Invalid Last Byte Value (920190)
+    desc: 'Range: Invalid Last Byte Value (920190)'
     stages:
       - input:
           dest_addr: 127.0.0.1


### PR DESCRIPTION
Hello,

I failed to find a solution for this bypass. If someone has an idea, it would be greatly appreciated.
multiMatch does not act as expected when I try to use it in the rule.

Also, it could be nice to allow a minimal range length restriction.

Vincent