### PR TITLE
fix(942560): missing capture keyword

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -580,6 +580,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)1\
     "id:942560,\
     phase:2,\
     block,\
+    capture,\
     t:none,t:urlDecodeUni,t:replaceComments,\
     msg:'MySQL Scientific Notation payload detected',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -609,6 +610,7 @@ SecRule REQUEST_FILENAME|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|X
     "id:942550,\
     phase:2,\
     block,\
+    capture,\
     t:none,t:urlDecodeUni,t:removeWhitespace,\
     msg:'JSON-Based SQL Injection',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\


### PR DESCRIPTION
Hello,

Quick fix

You cannot use %{TX.0} it capture is not defined.