### PR TITLE
chore: update SECRULES_PARSING_VERSION to 0.2.12

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,7 +16,7 @@ on:
 # Pin versions to not disrupt test pipelines
 env:
   CRS_TOOLCHAIN_VERSION: '2.3.4'
-  SECRULES_PARSING_VERSION: '0.2.11'
+  SECRULES_PARSING_VERSION: '0.2.12'
   CRS_LINTER_VERSION: '0.2.2'
 
 jobs:


### PR DESCRIPTION
We should change the version of `secrules_parsing` in our CI workflow. The new version contains some important fixes for #4305.
