### PR TITLE
fix(942160): adding unit test for double comment

### DIFF
--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942160.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942160.yaml
@@ -437,7 +437,7 @@ tests:
             expect_ids: [942160]
   - test_id: 26
     desc: |
-      SQL Injection Attack: Time-Based Payload Detected via Sleep Function - double comment to check t:replaceComments
+      SQL Injection Attack: Time-Based Payload Detected via Sleep Function with comments
       decoded payload: selEct(/*te"$%st*/sleep(/*te'e*st2*/10));
     stages:
       - input:


### PR DESCRIPTION
Hello,

There is very likely a unit test on mod_security2 itself to ensure that the t:replaceComments transformation is resilient to bypass attempts, but I think it’s missing one specifically for this rule.

I would understand if you don’t find it useful.