### PR TITLE
feat: add rule 920442 on PL3 to detect more file extensions

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -591,7 +591,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.22.0-dev',\
 #    setvar:'tx.restricted_extensions_document=.doc/ .docm/ .docx/ .csv/ .odg/ .odp/ .ods/ .odt/ .oxps/ .pdf/ .pptm/ .pptx/ .xlf/ .xls/ .xlsm/ .xlsx/ .xsd/ .xslt/'"
 
 # Restricted request headers.

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -578,6 +578,22 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    ver:'OWASP_CRS/4.21.0-dev',\
 #    setvar:'tx.restricted_extensions=.ani/ .asa/ .asax/ .ascx/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .cnf/ .com/ .compositefont/ .config/ .conf/ .copy/ .crt/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dist/ .dll/ .dos/ .dpkg-dist/ .drv/ .gadget/ .hta/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .inf/ .ini/ .jse/ .key/ .licx/ .lnk/ .log/ .mdb/ .msc/ .ocx/ .old/ .pass/ .pdb/ .pfx/ .pif/ .pem/ .pol/ .prf/ .printer/ .pwd/ .rdb/ .rdp/ .reg/ .resources/ .resx/ .save/ .scr/ .sct/ .shs/ .sql/ .sqlite/ .sqlite3/ .swp/ .sys/ .temp/ .tlb/ .tmp/ .vb/ .vbe/ .vbs/ .vbproj/ .vsdisco/ .vxd/ .webinfo/ .ws/ .wsc/ .wsf/ .wsh/ .xsd/ .xsx/'"
 
+# Sensitive file extensions extended - be prepared to deal with many false positives.
+# Guards against data leaks from documents
+# Default: .doc/ .docm/ .docx/ .csv/ .odg/ .odp/ .ods/ .odt/ .oxps/ .pdf/ .pptm/ .pptx/ .xlf/ .xls/ .xlsm/ .xlsx/ .xsd/ .xslt/
+# Example : order_10.pdf | database_customer.csv | export_customer.xslx
+#
+# Uncomment this rule to change the default.
+#SecAction \
+#    "id:900242,\
+#    phase:1,\
+#    pass,\
+#    t:none,\
+#    nolog,\
+#    tag:'OWASP_CRS',\
+#    ver:'OWASP_CRS/4.21.0-dev',\
+#    setvar:'tx.restricted_extensions_document=.doc/ .docm/ .docx/ .csv/ .odg/ .odp/ .ods/ .odt/ .oxps/ .pdf/ .pptm/ .pptx/ .xlf/ .xls/ .xlsm/ .xlsx/ .xsd/ .xslt/'"
+
 # Restricted request headers.
 # The HTTP request headers that CRS restricts are split into two categories:
 # basic (always forbidden) and extended (may be forbidden). All header names

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -236,7 +236,7 @@ SecRule &TX:restricted_extensions_document "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.22.0-dev',\
     setvar:'tx.restricted_extensions_document=.doc/ .docm/ .docx/ .csv/ .odg/ .odp/ .ods/ .odt/ .oxps/ .pdf/ .pptm/ .pptx/ .xlf/ .xls/ .xlsm/ .xlsx/ .xsd/ .xslt/'"
 
 # Default HTTP policy: restricted_headers_basic (rule 900250 in crs-setup.conf)

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -229,6 +229,16 @@ SecRule &TX:restricted_extensions "@eq 0" \
     ver:'OWASP_CRS/4.21.0-dev',\
     setvar:'tx.restricted_extensions=.ani/ .asa/ .asax/ .ascx/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .cnf/ .com/ .compositefont/ .config/ .conf/ .copy/ .crt/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dist/ .dll/ .dos/ .dpkg-dist/ .drv/ .gadget/ .hta/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .inf/ .ini/ .jse/ .key/ .licx/ .lnk/ .log/ .mdb/ .msc/ .ocx/ .old/ .pass/ .pdb/ .pfx/ .pif/ .pem/ .pol/ .prf/ .printer/ .pwd/ .rdb/ .rdp/ .reg/ .resources/ .resx/ .save/ .scr/ .sct/ .shs/ .sql/ .sqlite/ .sqlite3/ .swp/ .sys/ .temp/ .tlb/ .tmp/ .vb/ .vbe/ .vbs/ .vbproj/ .vsdisco/ .vxd/ .webinfo/ .ws/ .wsc/ .wsf/ .wsh/ .xsd/ .xsx/'"
 
+# Default HTTP policy: restricted_extensions_document (rule 900242 in crs-setup.conf)
+SecRule &TX:restricted_extensions_document "@eq 0" \
+    "id:901172,\
+    phase:1,\
+    pass,\
+    nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.21.0-dev',\
+    setvar:'tx.restricted_extensions_document=.doc/ .docm/ .docx/ .csv/ .odg/ .odp/ .ods/ .odt/ .oxps/ .pdf/ .pptm/ .pptx/ .xlf/ .xls/ .xlsm/ .xlsx/ .xsd/ .xslt/'"
+
 # Default HTTP policy: restricted_headers_basic (rule 900250 in crs-setup.conf)
 SecRule &TX:restricted_headers_basic "@eq 0" \
     "id:901165,\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1691,6 +1691,38 @@ SecRule REQUEST_HEADERS:Accept-Encoding "!@rx br|compress|deflate|(?:pack200-)?g
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
+#
+# Restrict file extension extended
+#
+# This rule captures Office documents and CSV files that may contain personal data under the GDPR.
+# Be prepared for potentially many false positives.
+#
+# You should read the warning in its sibling rule: 920441.
+#
+SecRule REQUEST_BASENAME "@rx \.([^.]+)$" \
+    "id:920442,\
+    phase:1,\
+    block,\
+    capture,\
+    t:none,t:urlDecodeUni,\
+    msg:'URL file extension is restricted by policy',\
+    logdata:'%{TX.0}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    tag:'paranoia-level/3',\
+    tag:'OWASP_CRS',\
+    tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
+    tag:'capec/1000/118/116',\
+    ver:'OWASP_CRS/4.21.0-dev',\
+    severity:'CRITICAL',\
+    setvar:'tx.extension=.%{tx.1}/',\
+    chain"
+    SecRule TX:EXTENSION "@within %{tx.restricted_extensions_document}" \
+        "t:none,t:lowercase,\
+        setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:920017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:920018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 #

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920442.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920442.yaml
@@ -1,0 +1,47 @@
+---
+meta:
+  author: "touchweb_vincent"
+rule_id: 920442
+tests:
+  - test_id: 1
+    desc: URL file extension is restricted by policy (920441)
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Accept-Encoding: gzip,deflate
+            Accept-Language: en-us,en;q=0.5
+            Host: localhost
+            Keep-Alive: "300"
+            Proxy-Connection: keep-alive
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/get/order_10.pdf"
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [920442]
+  - test_id: 2
+    desc: |
+      False Positive:
+      Don't block sound files
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Accept-Encoding: gzip,deflate
+            Accept-Language: en-us,en;q=0.5
+            Host: localhost
+            Keep-Alive: "300"
+            Proxy-Connection: keep-alive
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/sound.ogg"
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids: [920442]


### PR DESCRIPTION
Hello,

This new rule and its associated dataset aim to detect document file types that may contain personal or confidential information, in alignment with GDPR (General Data Protection Regulation) principles.

It extends the detection of restricted document extensions often used to store, share, or unintentionally expose sensitive business or customer data - such as invoices, exports, or internal reports - sometimes simply because a third party forgot that .htaccess files are not supported by Nginx.

Such data leaks are particularly common on e-commerce CMS platforms like PrestaShop or WordPress, where uploaded or cached files can sometimes be left publicly accessible.

Restricted_extensions_document block - PL3:
.doc, .docm, .docx, .csv, .odg, .odp, .ods, .odt, .oxps, .pdf, .pptm, .pptx, .xlf, .xls, .xlsm, .xlsx, .xsd, .xslt.

Given the likelihood of false positives in legitimate business workflows (for example, document-sharing modules or reporting exports), the rule is set at Paranoia Level 3 (PL3) for now, though PL4 might ultimately be more appropriate for production environments with stricter tolerance thresholds.

This addition strengthens ModSecurity’s coverage of data privacy and regulatory compliance, helping to reduce the risk of personal data exposure while maintaining an appropriate balance between protection and operational flexibility.