### PR TITLE
fix(956110): move rule to pl-2

### DIFF
--- a/rules/RESPONSE-956-DATA-LEAKAGES-RUBY.conf
+++ b/rules/RESPONSE-956-DATA-LEAKAGES-RUBY.conf
@@ -53,9 +53,15 @@ SecRule RESPONSE_BODY "@pmFromFile ruby-errors.data" \
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
 
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:956013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-956-DATA-LEAKAGES-RUBY"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:956014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-956-DATA-LEAKAGES-RUBY"
+
+
 # Detect the presence of the Ruby ERB templates "<%", "<%= " and slim interpolation "#{}" in output.
 #
 # To prevent false positives (due to the short "<%" sequences), we also check for [#=\s] after an opening tag.
+#
+# This rule is placed at PL-2 since it also matches common templating format with various JavaScript templating engines.
 #
 SecRule RESPONSE_BODY "@rx (?i)(?:<%[=#\s]|#\{[^}]+\})" \
     "id:956110,\
@@ -69,18 +75,13 @@ SecRule RESPONSE_BODY "@rx (?i)(?:<%[=#\s]|#\{[^}]+\})" \
     tag:'language-ruby',\
     tag:'platform-multi',\
     tag:'attack-disclosure',\
-    tag:'paranoia-level/1',\
+    tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-RUBY',\
     tag:'capec/1000/118/116',\
     ver:'OWASP_CRS/4.21.0-dev',\
     severity:'ERROR',\
-    setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
-
-
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:956013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-956-DATA-LEAKAGES-RUBY"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:956014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-956-DATA-LEAKAGES-RUBY"
-
+    setvar:'tx.outbound_anomaly_score_pl2=+%{tx.error_anomaly_score}'"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:956015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-956-DATA-LEAKAGES-RUBY"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:956016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-956-DATA-LEAKAGES-RUBY"


### PR DESCRIPTION
## Proposed changes

956110 is intended to match Ruby ERB templates within response bodies to detect data leakage, however this syntax also overlaps with some common JavaScript templating engines (Zabbix, WordPress, and Horde IMP). I don't see an way to modify this rule to prevent these false positives since the syntax is virtually identical so I'm moving this to level 2.

Closes #4343

## PR Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/CONTRIBUTING.md) doc
- [x] I have added positive tests proving my fix/feature works as intended.
- [x] I have added negative tests that prove my fix/feature considers common cases that might end in false positives
- [x] In case you changed a regular expression, you are not adding a ReDOS for pcre. You can check this using [regexploit](https://github.com/doyensec/regexploit)
- [x] My test use the `comment` field to write the expected behavior
- [x] I have added documentation for the rule or change (when appropriate)

## Further comments

N/A

## For the reviewer

<!-- Don't remove this part. Reviewers will use it as guidance for the review process. -->

- [ ] Positive and negative tests were added
- [ ] Tests cover the intended fix/feature properly
- [ ] No usage of dangerous constructs like `ctl:requestBodyAccess=Off` were used in the rule
- [ ] In case a regular expression was changed, [there is no ReDOS](https://github.com/coreruleset/coreruleset/wiki/Testing-for-Regular-Expresion-DoS)
- [ ] Documentation is clear for the rule/change
