### PR TITLE
fix: add missing capture action to affected rules

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1068,6 +1068,7 @@ SecRule REQUEST_FILENAME "@rx \.[^.~]+~(?:/.*|)$" \
     "id:920500,\
     phase:1,\
     block,\
+    capture,\
     t:none,t:urlDecodeUni,\
     msg:'Attempt to access a backup or working file',\
     logdata:'%{TX.0}',\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -204,6 +204,7 @@ SecRule REQUEST_FILENAME "@rx [\n\r]" \
     "id:921190,\
     phase:1,\
     block,\
+    capture,\
     t:none,t:urlDecodeUni,\
     msg:'HTTP Splitting (CR/LF in request filename detected)',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -531,6 +532,7 @@ SecRule ARGS_NAMES "@rx (][^\]]+$|][^\]]+\[)" \
     "id:921210,\
     phase:2,\
     block,\
+    capture,\
     log,\
     msg:'HTTP Parameter Pollution after detecting bogus char after parameter array',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
@@ -581,6 +583,7 @@ SecRule ARGS_NAMES "@rx \[" \
     "id:921220,\
     phase:2,\
     block,\
+    capture,\
     log,\
     msg:'HTTP Parameter Pollution possible via array notation',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\


### PR DESCRIPTION
## Proposed changes

This PR adds missing `capture` actions to rules which uses `TX:N` variable.

## Further comments

See [#crs-linter/87](https://github.com/coreruleset/crs-linter/pull/87)
