### PR TITLE
chore: remove spaces between op args

### DIFF
--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -54,7 +54,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:941012,phase:2,pass,nolog,tag:'O
 # target list and to add it on a case to case base, but the rule language does not
 # support this feature at runtime.
 #
-SecRule REQUEST_FILENAME "!@validateByteRange 20, 45-47, 48-57, 65-90, 95, 97-122" \
+SecRule REQUEST_FILENAME "!@validateByteRange 20,45-47,48-57,65-90,95,97-122" \
     "id:941010,\
     phase:1,\
     pass,\


### PR DESCRIPTION
## Proposed changes

This PR removes unnecessary spaces between operator arguments in case of `@validateByteRanges` at rule [941010](https://github.com/airween/coreruleset/blob/5ae01cc58b578589f43b4b24c42f8916edc99708/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf#L57).

## For the reviewer

See other occurrences:
* [920271](https://github.com/airween/coreruleset/blob/5ae01cc58b578589f43b4b24c42f8916edc99708/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf#L1387)
* [920272](https://github.com/airween/coreruleset/blob/5ae01cc58b578589f43b4b24c42f8916edc99708/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf#L1523)
* [920273](https://github.com/airween/coreruleset/blob/5ae01cc58b578589f43b4b24c42f8916edc99708/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf#L1733)
* [920274](https://github.com/airween/coreruleset/blob/5ae01cc58b578589f43b4b24c42f8916edc99708/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf#L1755)