### PR TITLE
feat(ci): Duty page updater

### DIFF
--- a/.github/workflows/duty-scheduler.yaml
+++ b/.github/workflows/duty-scheduler.yaml
@@ -14,16 +14,18 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: "Checkout gh-pages branch"
+      - name: "Checkout gh-pages branch (sparse, only the files related to duty report)"
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           ref: 'gh-pages'
+          sparse-checkout: |
+            scripts/generate-duty-report.sh
+            docs/duty.html
 
       - name: "Generate duty report"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          chmod +x scripts/generate-duty-report.sh
           ./scripts/generate-duty-report.sh ./docs/duty.html 1
 
       - name: "Commit and push"


### PR DESCRIPTION
Automates Max’s idea from https://github.com/coreruleset/coreruleset/wiki/Dev-on-Duty#keeping-track-of-github
 by providing a ci job that periodically runs the required gh commands and displays the output as static HTML.
The page is available at: https://coreruleset.github.io/coreruleset/duty.html
The current HTML file was manually generated and pushed to show how the final result looks.
Warning: very agentic.