### PR TITLE
chore: release v4.21.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,28 @@
   or the CRS Google Group at
 * https://groups.google.com/a/owasp.org/g/modsecurity-core-rule-set-project
 
-## Version 4.21.0-dev - 2025-MM-DD
+## Version 4.22.0-dev - 2025-MM-DD
+
+## Version 4.21.0 - 2025-12-01
+
+## What's Changed
+### 🆕 New features and detections 🎉
+* feat(931100): add IPv6 support / XML scan and SSH scheme. by @touchweb-vincent in https://github.com/coreruleset/coreruleset/pull/4321
+* feat(920440): add new restricted file extensions by @touchweb-vincent in https://github.com/coreruleset/coreruleset/pull/4322
+### 🧰 Other Changes
+* fix(942160): adding unit test for double comment by @touchweb-vincent in https://github.com/coreruleset/coreruleset/pull/4315
+* fix(920280, 920300, 920310, 920311, 920320, 920330): should be block by @touchweb-vincent in https://github.com/coreruleset/coreruleset/pull/4319
+* fix(942151,942152): wrong functions names by @touchweb-vincent in https://github.com/coreruleset/coreruleset/pull/4333
+* feat(942460): adding help for non-English folks by @touchweb-vincent in https://github.com/coreruleset/coreruleset/pull/4334
+* fix(932180): reduce substring false positives by @EsadCetiner in https://github.com/coreruleset/coreruleset/pull/4338
+* fix(942151,942152): wrong functions names by @touchweb-vincent in https://github.com/coreruleset/coreruleset/pull/4337
+* fix(920180): wrong unit test - content-type evasion bypass by @touchweb-vincent in https://github.com/coreruleset/coreruleset/pull/4339
+* fix(956110): move rule to pl-2 by @EsadCetiner in https://github.com/coreruleset/coreruleset/pull/4344
+* docs: comment on disabling `Expect` header in .Net by @theseion in https://github.com/coreruleset/coreruleset/pull/4348
+* fix: add missing capture action to affected rules by @airween in https://github.com/coreruleset/coreruleset/pull/4361
+
+
+**Full Changelog**: https://github.com/coreruleset/coreruleset/compare/v4.20.0...v4.21.0
 
 ## Version 4.20.0 - 2025-11-02
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,8 +11,8 @@ Along those lines, OWASP CRS team may not issue security notifications for unsup
 
 | Version   | Supported          |
 | --------- | ------------------ |
+| 4.21.z    | :white_check_mark: |
 | 4.20.z    | :white_check_mark: |
-| 4.19.z    | :white_check_mark: |
 | 4.y.z     | :x: |
 | 3.3.x     | :white_check_mark: |
 | 3.2.x     | :x:                |

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -181,7 +181,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    setvar:tx.blocking_paranoia_level=1"
 
 
@@ -209,7 +209,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    setvar:tx.detection_paranoia_level=1"
 
 
@@ -235,7 +235,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    setvar:tx.enforce_bodyproc_urlencoded=1"
 
 
@@ -270,7 +270,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    setvar:tx.critical_anomaly_score=5,\
 #    setvar:tx.error_anomaly_score=4,\
 #    setvar:tx.warning_anomaly_score=3,\
@@ -324,7 +324,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    setvar:tx.inbound_anomaly_score_threshold=5,\
 #    setvar:tx.outbound_anomaly_score_threshold=4"
 
@@ -385,7 +385,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    setvar:tx.reporting_level=4"
 
 
@@ -417,7 +417,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    setvar:tx.early_blocking=1"
 
 
@@ -438,7 +438,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    setvar:tx.enable_default_collections=1"
 
 
@@ -476,7 +476,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    setvar:'tx.allowed_methods=GET HEAD POST OPTIONS'"
 
 # Content-Types that a client is allowed to send in a request.
@@ -516,7 +516,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    chain"
 #    SecRule REQUEST_URI "@rx ^/foo/bar" \
 #        "t:none,\
@@ -535,7 +535,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |text/xml| |application/xml| |application/soap+xml| |application/json| |application/reports+json| |application/csp-report|'"
 
 # Allowed HTTP versions.
@@ -551,7 +551,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    setvar:'tx.allowed_http_versions=HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0 HTTP/3 HTTP/3.0'"
 
 # Forbidden file extensions.
@@ -575,7 +575,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    setvar:'tx.restricted_extensions=.ani/ .asa/ .asax/ .ascx/ .back/ .backup/ .bak/ .bck/ .bk/ .bkp/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .cnf/ .com/ .compositefont/ .config/ .conf/ .copy/ .crt/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dist/ .dll/ .dos/ .dpkg-dist/ .drv/ .gadget/ .hta/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .inf/ .ini/ .jse/ .key/ .licx/ .lnk/ .log/ .mdb/ .msc/ .ocx/ .old/ .pass/ .pdb/ .pfx/ .pif/ .pem/ .pol/ .prf/ .printer/ .pwd/ .rdb/ .rdp/ .reg/ .resources/ .resx/ .sav/ .save/ .scr/ .sct/ .sh/ .shs/ .sql/ .sqlite/ .sqlite3/ .swp/ .sys/ .temp/ .tlb/ .tmp/ .vb/ .vbe/ .vbs/ .vbproj/ .vsdisco/ .vxd/ .webinfo/ .ws/ .wsc/ .wsf/ .wsh/ .xsd/ .xsx/'"
 
 # Restricted request headers.
@@ -631,7 +631,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    setvar:'tx.restricted_headers_basic=/content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/ /x-middleware-subrequest/ /expect/'"
 #
 # [ Extended ]
@@ -657,7 +657,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    setvar:'tx.restricted_headers_extended=/accept-charset/'"
 
 # Content-Types charsets that a client is allowed to send in a request.
@@ -676,7 +676,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    setvar:'tx.allowed_request_content_type_charset=|utf-8| |iso-8859-1| |iso-8859-15| |windows-1252|'"
 
 #
@@ -702,7 +702,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    setvar:tx.max_num_args=255"
 
 # Block request if the length of any argument name is too high
@@ -716,7 +716,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    setvar:tx.arg_name_length=100"
 
 # Block request if the length of any argument value is too high
@@ -730,7 +730,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    setvar:tx.arg_length=400"
 
 # Block request if the total length of all combined arguments is too high
@@ -744,7 +744,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    setvar:tx.total_arg_length=64000"
 
 # Block request if the file size of any individual uploaded file is too high
@@ -758,7 +758,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    setvar:tx.max_file_size=1048576"
 
 # Block request if the total size of all combined uploaded files is too high
@@ -772,7 +772,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    setvar:tx.combined_file_sizes=1048576"
 
 
@@ -812,7 +812,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    pass,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    setvar:tx.sampling_percentage=100"
 
 
@@ -833,7 +833,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    setvar:tx.crs_validate_utf8_encoding=1"
 
 # -- [[ Skip Checking Responses ]] ------------------------------------------------
@@ -855,7 +855,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    t:none,\
 #    nolog,\
 #    tag:'OWASP_CRS',\
-#    ver:'OWASP_CRS/4.21.0-dev',\
+#    ver:'OWASP_CRS/4.21.0',\
 #    setvar:tx.crs_skip_response_analysis=1"
 
 #
@@ -876,5 +876,5 @@ SecAction \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:tx.crs_setup_version=4210"

--- a/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example
+++ b/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -26,7 +26,7 @@
 #
 # Ref: https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v2.x)#seccomponentsignature
 #
-SecComponentSignature "OWASP_CRS/4.21.0-dev"
+SecComponentSignature "OWASP_CRS/4.21.0"
 
 #
 # -=[ Default setup values ]=-
@@ -60,7 +60,7 @@ SecRule &TX:crs_setup_version "@eq 0" \
     auditlog,\
     msg:'CRS is deployed without configuration! Please copy the crs-setup.conf.example template to crs-setup.conf, and include the crs-setup.conf file in your webserver configuration before including the CRS rules. See the INSTALL file in the CRS directory for detailed instructions',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL'"
 
 
@@ -79,7 +79,7 @@ SecRule &TX:inbound_anomaly_score_threshold "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.inbound_anomaly_score_threshold=5'"
 
 # Default Outbound Anomaly Threshold Level (rule 900110 in crs-setup.conf)
@@ -89,7 +89,7 @@ SecRule &TX:outbound_anomaly_score_threshold "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.outbound_anomaly_score_threshold=4'"
 
 # Default Reporting Level (rule 900115 in crs-setup.conf)
@@ -99,7 +99,7 @@ SecRule &TX:reporting_level "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.reporting_level=4'"
 
 # Default Early Blocking (rule 900120 in crs-setup.conf)
@@ -109,7 +109,7 @@ SecRule &TX:early_blocking "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.early_blocking=0'"
 
 # Default Blocking Paranoia Level (rule 900000 in crs-setup.conf)
@@ -119,7 +119,7 @@ SecRule &TX:blocking_paranoia_level "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.blocking_paranoia_level=1'"
 
 # Default Detection Paranoia Level (rule 900001 in crs-setup.conf)
@@ -129,7 +129,7 @@ SecRule &TX:detection_paranoia_level "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.detection_paranoia_level=%{TX.blocking_paranoia_level}'"
 
 # Default Sampling Percentage (rule 900400 in crs-setup.conf)
@@ -139,7 +139,7 @@ SecRule &TX:sampling_percentage "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.sampling_percentage=100'"
 
 # Default Anomaly Scores (rule 900100 in crs-setup.conf)
@@ -149,7 +149,7 @@ SecRule &TX:critical_anomaly_score "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.critical_anomaly_score=5'"
 
 SecRule &TX:error_anomaly_score "@eq 0" \
@@ -158,7 +158,7 @@ SecRule &TX:error_anomaly_score "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.error_anomaly_score=4'"
 
 SecRule &TX:warning_anomaly_score "@eq 0" \
@@ -167,7 +167,7 @@ SecRule &TX:warning_anomaly_score "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.warning_anomaly_score=3'"
 
 SecRule &TX:notice_anomaly_score "@eq 0" \
@@ -176,7 +176,7 @@ SecRule &TX:notice_anomaly_score "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.notice_anomaly_score=2'"
 
 # Default HTTP policy: allowed_methods (rule 900200 in crs-setup.conf)
@@ -186,7 +186,7 @@ SecRule &TX:allowed_methods "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.allowed_methods=GET HEAD POST OPTIONS'"
 
 # Default HTTP policy: allowed_request_content_type (rule 900220 in crs-setup.conf)
@@ -196,7 +196,7 @@ SecRule &TX:allowed_request_content_type "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |text/xml| |application/xml| |application/soap+xml| |application/json| |application/reports+json| |application/csp-report|'"
 
 # Default HTTP policy: allowed_request_content_type_charset (rule 900280 in crs-setup.conf)
@@ -206,7 +206,7 @@ SecRule &TX:allowed_request_content_type_charset "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.allowed_request_content_type_charset=|utf-8| |iso-8859-1| |iso-8859-15| |windows-1252|'"
 
 # Default HTTP policy: allowed_http_versions (rule 900230 in crs-setup.conf)
@@ -216,7 +216,7 @@ SecRule &TX:allowed_http_versions "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.allowed_http_versions=HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0 HTTP/3 HTTP/3.0'"
 
 # Default HTTP policy: restricted_extensions (rule 900240 in crs-setup.conf)
@@ -226,7 +226,7 @@ SecRule &TX:restricted_extensions "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.restricted_extensions=.ani/ .asa/ .asax/ .ascx/ .back/ .backup/ .bak/ .bck/ .bk/ .bkp/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .cnf/ .com/ .compositefont/ .config/ .conf/ .copy/ .crt/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dist/ .dll/ .dos/ .dpkg-dist/ .drv/ .gadget/ .hta/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .inf/ .ini/ .jse/ .key/ .licx/ .lnk/ .log/ .mdb/ .msc/ .ocx/ .old/ .pass/ .pdb/ .pfx/ .pif/ .pem/ .pol/ .prf/ .printer/ .pwd/ .rdb/ .rdp/ .reg/ .resources/ .resx/ .sav/ .save/ .scr/ .sct/ .sh/ .shs/ .sql/ .sqlite/ .sqlite3/ .swp/ .sys/ .temp/ .tlb/ .tmp/ .vb/ .vbe/ .vbs/ .vbproj/ .vsdisco/ .vxd/ .webinfo/ .ws/ .wsc/ .wsf/ .wsh/ .xsd/ .xsx/'"
 
 # Default HTTP policy: restricted_headers_basic (rule 900250 in crs-setup.conf)
@@ -236,7 +236,7 @@ SecRule &TX:restricted_headers_basic "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.restricted_headers_basic=/content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/ /x-middleware-subrequest/ /expect/'"
 
 # Default HTTP policy: restricted_headers_extended (rule 900255 in crs-setup.conf)
@@ -246,7 +246,7 @@ SecRule &TX:restricted_headers_extended "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.restricted_headers_extended=/accept-charset/'"
 
 # Default enforcing of body processor URLENCODED (rule 900010 in crs-setup.conf)
@@ -256,7 +256,7 @@ SecRule &TX:enforce_bodyproc_urlencoded "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.enforce_bodyproc_urlencoded=0'"
 
 # Default check for UTF8 encoding validation (rule 900950 in crs-setup.conf)
@@ -266,7 +266,7 @@ SecRule &TX:crs_validate_utf8_encoding "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.crs_validate_utf8_encoding=0'"
 
 # Default check for skipping response analysis (rule 900500 in crs-setup.conf)
@@ -276,7 +276,7 @@ SecRule &TX:crs_skip_response_analysis "@eq 0" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.crs_skip_response_analysis=0'"
 
 #
@@ -294,7 +294,7 @@ SecAction \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.blocking_inbound_anomaly_score=0',\
     setvar:'tx.detection_inbound_anomaly_score=0',\
     setvar:'tx.inbound_anomaly_score_pl1=0',\
@@ -336,7 +336,7 @@ SecRule &TX:ENABLE_DEFAULT_COLLECTIONS "@eq 1" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.ua_hash=%{REQUEST_HEADERS.User-Agent}',\
     chain"
     SecRule TX:ENABLE_DEFAULT_COLLECTIONS "@eq 1" \
@@ -362,7 +362,7 @@ SecRule REQBODY_PROCESSOR "!@rx (?:URLENCODED|MULTIPART|XML|JSON)" \
     msg:'Enabling body inspection',\
     tag:'OWASP_CRS',\
     ctl:forceRequestBodyVariable=On,\
-    ver:'OWASP_CRS/4.21.0-dev'"
+    ver:'OWASP_CRS/4.21.0'"
 
 # Force body processor URLENCODED
 SecRule TX:enforce_bodyproc_urlencoded "@eq 1" \
@@ -374,7 +374,7 @@ SecRule TX:enforce_bodyproc_urlencoded "@eq 1" \
     noauditlog,\
     msg:'Enabling forced body inspection for ASCII content',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     chain"
     SecRule REQBODY_PROCESSOR "!@rx (?:URLENCODED|MULTIPART|XML|JSON)" \
         "ctl:requestBodyProcessor=URLENCODED"
@@ -414,7 +414,7 @@ SecRule TX:sampling_percentage "@eq 100" \
     pass,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     skipAfter:END-SAMPLING"
 
 SecRule UNIQUE_ID "@rx ^[a-f]*([0-9])[a-f]*([0-9])" \
@@ -425,7 +425,7 @@ SecRule UNIQUE_ID "@rx ^[a-f]*([0-9])[a-f]*([0-9])" \
     t:sha1,t:hexEncode,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'TX.sampling_rnd100=%{TX.1}%{TX.2}'"
 
 #
@@ -450,7 +450,7 @@ SecRule TX:sampling_rnd100 "!@lt %{tx.sampling_percentage}" \
     msg:'Sampling: Disable the rule engine based on sampling_percentage %{TX.sampling_percentage} and random number %{TX.sampling_rnd100}',\
     tag:'OWASP_CRS',\
     ctl:ruleRemoveByTag=OWASP_CRS,\
-    ver:'OWASP_CRS/4.21.0-dev'"
+    ver:'OWASP_CRS/4.21.0'"
 
 SecMarker "END-SAMPLING"
 
@@ -469,4 +469,4 @@ SecRule TX:detection_paranoia_level "@lt %{tx.blocking_paranoia_level}" \
     log,\
     msg:'Detection paranoia level configured is lower than the paranoia level itself. This is illegal. Blocking request. Aborting',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev'"
+    ver:'OWASP_CRS/4.21.0'"

--- a/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
+++ b/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -25,7 +25,7 @@ SecRule REQUEST_LINE "@streq GET /" \
     tag:'platform-apache',\
     tag:'attack-generic',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     chain"
     SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
         "t:none,\
@@ -46,7 +46,7 @@ SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
     tag:'platform-apache',\
     tag:'attack-generic',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     chain"
     SecRule REQUEST_HEADERS:User-Agent "@endsWith (internal dummy connection)" \
         "t:none,\

--- a/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
+++ b/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:911011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:911012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:911011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:911012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -39,31 +39,31 @@ SecRule REQUEST_METHOD "!@within %{tx.allowed_methods}" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/METHOD-ENFORCEMENT',\
     tag:'capec/1000/210/272/220/274',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:911013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:911014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:911013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:911014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:911015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:911016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:911015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:911016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:911017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:911018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:911017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:911018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-911-METHOD-ENFORCEMENT"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-913-SCANNER-DETECTION.conf
+++ b/rules/REQUEST-913-SCANNER-DETECTION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:913011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:913012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:913011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:913012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -51,29 +51,29 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scanners-user-agents.data" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/SCANNER-DETECTION',\
     tag:'capec/1000/118/224/541/310',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:913013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:913014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:913013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:913014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:913015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:913016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:913015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:913016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:913017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:913018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:913017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:913018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-913-SCANNER-DETECTION"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -23,8 +23,8 @@
 #
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:920011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:920012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:920011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:920012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -65,7 +65,7 @@ SecRule REQUEST_LINE "!@rx (?i)^(?:get /[^#\?]*(?:\?[^\s\x0b#]*)?(?:#[^\s\x0b]*)
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
@@ -121,7 +121,7 @@ SecRule FILES|FILES_NAMES "!@rx (?i)^(?:&(?:(?:[acegilnorsuz]acut|[aeiou]grav|[a
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -151,7 +151,7 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^\d+$" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -186,7 +186,7 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     chain"
     SecRule REQUEST_HEADERS:Content-Length "!@rx ^0?$" \
@@ -212,7 +212,7 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     chain"
     SecRule &REQUEST_HEADERS:Transfer-Encoding "!@eq 0" \
@@ -253,7 +253,7 @@ SecRule REQUEST_PROTOCOL "!@within HTTP/2 HTTP/2.0 HTTP/3 HTTP/3.0" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_METHOD "@streq POST" \
@@ -284,7 +284,7 @@ SecRule &REQUEST_HEADERS:Transfer-Encoding "!@eq 0" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'WARNING',\
     chain"
     SecRule &REQUEST_HEADERS:Content-Length "!@eq 0" \
@@ -323,7 +323,7 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx (\d+)-(\d+)" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'WARNING',\
     chain"
     SecRule TX:2 "@lt %{tx.1}" \
@@ -356,7 +356,7 @@ SecRule REQUEST_HEADERS:Connection "@rx \b(?:keep-alive|close),\s?(?:keep-alive|
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
@@ -385,7 +385,7 @@ SecRule TX:CRS_VALIDATE_UTF8_ENCODING "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/255/153/267',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_FILENAME|ARGS|ARGS_NAMES "@validateUtf8Encoding" \
@@ -430,7 +430,7 @@ SecRule REQUEST_URI|REQUEST_BODY "@rx (?i)%uff[0-9a-f]{2}" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/255/153/267/72',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
@@ -487,7 +487,7 @@ SecRule REQUEST_URI_RAW|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 1-25
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -519,7 +519,7 @@ SecRule &REQUEST_HEADERS:Host "@eq 0" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     skipAfter:END-HOST-CHECK"
@@ -539,7 +539,7 @@ SecRule REQUEST_HEADERS:Host "@rx ^$" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -580,7 +580,7 @@ SecRule REQUEST_HEADERS:Accept "@rx ^$" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'NOTICE',\
     chain"
     SecRule REQUEST_METHOD "!@rx ^OPTIONS$" \
@@ -606,7 +606,7 @@ SecRule REQUEST_HEADERS:Accept "@rx ^$" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'NOTICE',\
     chain"
     SecRule REQUEST_METHOD "!@rx ^OPTIONS$" \
@@ -640,7 +640,7 @@ SecRule REQUEST_HEADERS:User-Agent "@rx ^$" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'NOTICE',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.notice_anomaly_score}'"
 
@@ -679,7 +679,7 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     chain"
     SecRule &REQUEST_HEADERS:Content-Type "@eq 0" \
@@ -724,7 +724,7 @@ SecRule REQUEST_HEADERS:Host "@rx (?:^([\d.]+|\[[\da-f:]+\]|[\da-f:]+)(:[\d]+)?$
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
@@ -757,7 +757,7 @@ SecRule &TX:MAX_NUM_ARGS "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     chain"
     SecRule &ARGS "@gt %{tx.max_num_args}" \
@@ -783,7 +783,7 @@ SecRule &TX:ARG_NAME_LENGTH "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     chain"
     SecRule ARGS_NAMES "@gt %{tx.arg_name_length}" \
@@ -811,7 +811,7 @@ SecRule &TX:ARG_LENGTH "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     chain"
     SecRule ARGS "@gt %{tx.arg_length}" \
@@ -836,7 +836,7 @@ SecRule &TX:TOTAL_ARG_LENGTH "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     chain"
     SecRule ARGS_COMBINED_SIZE "@gt %{tx.total_arg_length}" \
@@ -862,7 +862,7 @@ SecRule &TX:MAX_FILE_SIZE "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     chain"
     SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)multipart/form-data" \
@@ -889,7 +889,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     chain"
     SecRule FILES_COMBINED_SIZE "@gt %{tx.combined_file_sizes}" \
@@ -929,7 +929,7 @@ SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+*-]+(?:\s?;\s*(?:action|bounda
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/255/153',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -952,7 +952,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/255/153',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.content_type=|%{tx.0}|',\
     chain"
@@ -980,7 +980,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx charset\s*=\s*[\"']?([^;\"'\s]+)" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/255/153',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.content_type_charset=|%{tx.1}|',\
     chain"
@@ -1007,7 +1007,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx charset.*?charset" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/255/153',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -1029,7 +1029,7 @@ SecRule REQUEST_PROTOCOL "!@within %{tx.allowed_http_versions}" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -1052,7 +1052,7 @@ SecRule REQUEST_BASENAME "@rx \.([^.]+)$" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.extension=.%{tx.1}/',\
     chain"
@@ -1080,7 +1080,7 @@ SecRule REQUEST_FILENAME "@rx \.[^.~]+~(?:/.*|)$" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -1134,7 +1134,7 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.header_name_920450_%{tx.0}=/%{tx.0}/',\
     chain"
@@ -1168,7 +1168,7 @@ SecRule REQUEST_HEADERS:Accept-Encoding "@gt 100" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/255/153',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -1201,7 +1201,7 @@ SecRule REQUEST_HEADERS:Accept "!@rx ^(?:(?:\*|[^!\"\(\),/:-\?\[-\]\{\}]+)/(?:\*
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -1225,7 +1225,7 @@ SecRule REQBODY_PROCESSOR "!@streq JSON" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/255/153/267/72',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     chain"
     SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@rx (?i)\x5cu[0-9a-f]{4}" \
@@ -1250,7 +1250,7 @@ SecRule REQUEST_URI_RAW "@contains #" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -1283,13 +1283,13 @@ SecRule &REQUEST_HEADERS:Content-Type "@gt 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:920013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:920014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:920013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:920014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -1329,7 +1329,7 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_BASENAME "!@endsWith .pdf" \
@@ -1354,7 +1354,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d+)?-(?:\d+)?\s*,?\s*){63}" \
@@ -1376,7 +1376,7 @@ SecRule ARGS "@rx %[0-9a-fA-F]{2}" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/255/153/267/120',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.warning_anomaly_score}'"
 
@@ -1399,7 +1399,7 @@ SecRule REQUEST_URI_RAW|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 9,10
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
@@ -1426,7 +1426,7 @@ SecRule &REQUEST_HEADERS:User-Agent "@eq 0" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'NOTICE',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.notice_anomaly_score}'"
 
@@ -1449,7 +1449,7 @@ SecRule FILES_NAMES|FILES "@rx ['\";=\x5c]" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
@@ -1472,7 +1472,7 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.header_name_920451_%{tx.0}=/%{tx.0}/',\
     chain"
@@ -1500,7 +1500,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)application/x-www-form-urlencoded
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/255/153/267/72',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_BODY "@rx \x25" \
@@ -1508,8 +1508,8 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)application/x-www-form-urlencoded
         SecRule REQUEST_BODY "@validateUrlEncoding" \
             "setvar:'tx.inbound_anomaly_score_pl2=+%{tx.warning_anomaly_score}'"
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:920015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:920016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:920015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:920016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
@@ -1535,7 +1535,7 @@ SecRule REQUEST_URI_RAW|REQUEST_HEADERS|ARGS|ARGS_NAMES|REQUEST_BODY "@validateB
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
@@ -1569,7 +1569,7 @@ SecRule &REQUEST_HEADERS:Accept "@eq 0" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'NOTICE',\
     chain"
     SecRule REQUEST_METHOD "!@rx ^(?:OPTIONS|CONNECT)$" \
@@ -1603,7 +1603,7 @@ SecRule &REQUEST_HEADERS:x-up-devcap-post-charset "@ge 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     chain"
     SecRule REQUEST_HEADERS:User-Agent "@rx ^(?i)up" \
@@ -1657,7 +1657,7 @@ SecRule &REQUEST_HEADERS:Cache-Control "@gt 0" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     chain"
     SecRule REQUEST_HEADERS:Cache-Control "!@rx ^(?:(?:max-age=[0-9]+|min-fresh=[0-9]+|no-cache|no-store|no-transform|only-if-cached|max-stale(?:=[0-9]+)?)(?:\s*\,\s*|$)){1,7}$" \
@@ -1688,12 +1688,12 @@ SecRule REQUEST_HEADERS:Accept-Encoding "!@rx br|compress|deflate|(?:pack200-)?g
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/255/153',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:920017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:920018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:920017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:920018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
@@ -1717,7 +1717,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d+)?-(?:\d+)?\s*,?\s*){6}" \
@@ -1745,7 +1745,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteRange 38,44-46,48-58,61,65-90
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
 
@@ -1767,7 +1767,7 @@ SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!RE
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
 
@@ -1794,7 +1794,7 @@ SecRule REQUEST_HEADERS:Sec-Fetch-User|REQUEST_HEADERS:Sec-CH-UA-Mobile "!@rx ^(
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
 
@@ -1839,7 +1839,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@rx (?:^|[^\x5c])\x5c[cdegh
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     tag:'capec/1000/153/267',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl4=+%{tx.critical_anomaly_score}'"

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:921011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:921012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:921011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:921012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -47,7 +47,7 @@ SecRule ARGS_NAMES|ARGS|REQUEST_BODY|XML:/* "@rx (?:get|post|head|options|connec
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ATTACK',\
     tag:'capec/1000/210/272/220/33',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -80,7 +80,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx [\r\n]
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ATTACK',\
     tag:'capec/1000/210/272/220/34',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -102,7 +102,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:\bh
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ATTACK',\
     tag:'capec/1000/210/272/220/34',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -137,7 +137,7 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@rx [\n\r]" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ATTACK',\
     tag:'capec/1000/210/272/220/273',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -166,7 +166,7 @@ SecRule ARGS_NAMES "@rx [\n\r]" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ATTACK',\
     tag:'capec/1000/210/272/220/33',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -188,7 +188,7 @@ SecRule ARGS_GET_NAMES|ARGS_GET "@rx [\n\r]+(?:\s|location|refresh|(?:set-)?cook
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ATTACK',\
     tag:'capec/1000/210/272/220/33',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -216,7 +216,7 @@ SecRule REQUEST_FILENAME "@rx [\n\r]" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ATTACK',\
     tag:'capec/1000/210/272/220/34',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -250,7 +250,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx ^[^:\(
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ATTACK',\
     tag:'capec/1000/152/248/136',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -283,7 +283,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^\s\x0b,;]+[\s\x0b,;].*?(?:applicati
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ATTACK',\
     tag:'capec/1000/255/153',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -310,7 +310,7 @@ SecRule REQUEST_URI_RAW "@rx unix:[^|]*\|" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ATTACK',\
     tag:'capec/1000/210/272/220/33',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -338,13 +338,13 @@ SecRule REQUEST_COOKIES:/\x22?\x24Version/ "@streq 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ATTACK',\
     tag:'capec/1000/210/272/220/33',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:921013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:921014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:921013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:921014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -372,7 +372,7 @@ SecRule ARGS_GET "@rx [\n\r]" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ATTACK',\
     tag:'capec/1000/210/272/220/33',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -408,13 +408,13 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^\s\x0b,;]+[\s\x0b,;].*?\b(?:((?:tex
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ATTACK',\
     tag:'capec/1000/255/153',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:921015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:921016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:921015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:921016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
@@ -445,7 +445,7 @@ SecRule &REQUEST_HEADERS:Range "@gt 0" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ATTACK',\
     tag:'capec/1000/210/272/220',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
@@ -483,7 +483,7 @@ SecRule ARGS_NAMES "@rx ." \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ATTACK',\
     tag:'capec/1000/152/137/15/460',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'TX.paramcounter_%{MATCHED_VAR_NAME}=+1'"
 
 SecRule TX:/paramcounter_.*/ "@gt 1" \
@@ -500,7 +500,7 @@ SecRule TX:/paramcounter_.*/ "@gt 1" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ATTACK',\
     tag:'capec/1000/152/137/15/460',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -544,15 +544,15 @@ SecRule ARGS_NAMES "@rx (][^\]]+$|][^\]]+\[)" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ATTACK',\
     tag:'capec/1000/152/137/15/460',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:921017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:921018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:921017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:921018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
@@ -595,7 +595,7 @@ SecRule ARGS_NAMES "@rx \[" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ATTACK',\
     tag:'capec/1000/152/137/15/460',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl4=+%{tx.critical_anomaly_score}'"

--- a/rules/REQUEST-922-MULTIPART-ATTACK.conf
+++ b/rules/REQUEST-922-MULTIPART-ATTACK.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -39,7 +39,7 @@ SecRule &MULTIPART_PART_HEADERS:_charset_ "!@eq 0" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/MULTIPART-ATTACK',\
     tag:'capec/1000/255/153',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.922100_charset=|%{ARGS._charset_}|',\
     chain"
@@ -72,7 +72,7 @@ SecRule MULTIPART_PART_HEADERS "@rx ^content-type\s*:\s*(.*)$" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/MULTIPART-ATTACK',\
     tag:'capec/272/220',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     chain"
     SecRule TX:1 "!@rx ^(?:(?:\*|[^!\"\(\),/:-\?\[-\]\{\}]+)/(?:\*|[^!\"\(\),/:-\?\[-\]\{\}]+)|\*)(?:[\s\x0b]*;[\s\x0b]*(?:charset[\s\x0b]*=[\s\x0b]*\"?(?:iso-8859-15?|utf-8|windows-1252)\b\"?|(?:[^\s\x0b-\"\(\),/:-\?\[-\]c\{\}]|c(?:[^!\"\(\),/:-\?\[-\]h\{\}]|h(?:[^!\"\(\),/:-\?\[-\]a\{\}]|a(?:[^!\"\(\),/:-\?\[-\]r\{\}]|r(?:[^!\"\(\),/:-\?\[-\]s\{\}]|s(?:[^!\"\(\),/:-\?\[-\]e\{\}]|e[^!\"\(\),/:-\?\[-\]t\{\}]))))))[^!\"\(\),/:-\?\[-\]\{\}]*[\s\x0b]*=[\s\x0b]*[^!\(\),/:-\?\[-\]\{\}]+);?)*(?:[\s\x0b]*,[\s\x0b]*(?:(?:\*|[^!\"\(\),/:-\?\[-\]\{\}]+)/(?:\*|[^!\"\(\),/:-\?\[-\]\{\}]+)|\*)(?:[\s\x0b]*;[\s\x0b]*(?:charset[\s\x0b]*=[\s\x0b]*\"?(?:iso-8859-15?|utf-8|windows-1252)\b\"?|(?:[^\s\x0b-\"\(\),/:-\?\[-\]c\{\}]|c(?:[^!\"\(\),/:-\?\[-\]h\{\}]|h(?:[^!\"\(\),/:-\?\[-\]a\{\}]|a(?:[^!\"\(\),/:-\?\[-\]r\{\}]|r(?:[^!\"\(\),/:-\?\[-\]s\{\}]|s(?:[^!\"\(\),/:-\?\[-\]e\{\}]|e[^!\"\(\),/:-\?\[-\]t\{\}]))))))[^!\"\(\),/:-\?\[-\]\{\}]*[\s\x0b]*=[\s\x0b]*[^!\(\),/:-\?\[-\]\{\}]+);?)*)*$" \
@@ -97,7 +97,7 @@ SecRule MULTIPART_PART_HEADERS "@rx content-transfer-encoding:(.*)" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/MULTIPART-ATTACK',\
     tag:'capec/272/220',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -121,6 +121,6 @@ SecRule MULTIPART_PART_HEADERS "@rx [^\x21-\x7E][\x21-\x39\x3B-\x7E]*:" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/MULTIPART-ATTACK',\
     tag:'capec/272/220',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:930011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:930012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:930011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:930012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -48,7 +48,7 @@ SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|FILES|XML:
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-LFI',\
     tag:'capec/1000/255/153/126',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}'"
@@ -81,7 +81,7 @@ SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|FILES|XML:
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-LFI',\
     tag:'capec/1000/255/153/126',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
@@ -112,7 +112,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pmFromFil
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-LFI',\
     tag:'capec/1000/255/153/126',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -139,15 +139,15 @@ SecRule REQUEST_FILENAME "@pmFromFile restricted-files.data" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-LFI',\
     tag:'capec/1000/255/153/126',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:930013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:930014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:930013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:930014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -177,22 +177,22 @@ SecRule REQUEST_HEADERS:Referer|REQUEST_HEADERS:User-Agent "@pmFromFile lfi-os-f
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-LFI',\
     tag:'capec/1000/255/153/126',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:930015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:930016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:930015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:930016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:930017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:930018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:930017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:930018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-930-APPLICATION-ATTACK-LFI"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
+++ b/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -17,8 +17,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:931011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:931012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:931011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:931012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -55,7 +55,7 @@ SecRule ARGS|XML:/* "@rx (?i)^(file|ftps?|https?|ssh)://(?:\[?[a-f0-9]+:[a-f0-9:
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RFI',\
     tag:'capec/1000/152/175/253',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -76,7 +76,7 @@ SecRule QUERY_STRING|REQUEST_BODY "@rx (?i)(?:\binclude\s*\([^)]*|mosConfig_abso
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RFI',\
     tag:'capec/1000/152/175/253',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -97,15 +97,15 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?).*?\?+$" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RFI',\
     tag:'capec/1000/152/175/253',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:931013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:931014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:931013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:931014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -137,7 +137,7 @@ SecRule ARGS "@rx (?i)(?:(?:url|jar):)?(?:a(?:cap|f[ps]|ttachment)|b(?:eshare|it
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RFI',\
     tag:'capec/1000/152/175/253',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_parameter_%{MATCHED_VAR_NAME}=.%{tx.1}',\
     chain"
@@ -168,7 +168,7 @@ SecRule REQUEST_FILENAME "@rx (?i)(?:(?:url|jar):)?(?:a(?:cap|f[ps]|ttachment)|b
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RFI',\
     tag:'capec/1000/152/175/253',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_parameter_%{MATCHED_VAR_NAME}=.%{tx.1}',\
     chain"
@@ -177,16 +177,16 @@ SecRule REQUEST_FILENAME "@rx (?i)(?:(?:url|jar):)?(?:a(?:cap|f[ps]|ttachment)|b
         setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:931015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:931016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:931015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:931016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:931017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:931018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:931017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:931018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-931-APPLICATION-ATTACK-RFI"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:932011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:932012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:932011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:932012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -135,7 +135,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -195,7 +195,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -228,7 +228,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pmFromFil
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -262,7 +262,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -306,7 +306,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \$(?:\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -353,7 +353,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \b(?:f
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -393,7 +393,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx ~[\+\-
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -427,7 +427,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \{[0-9
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -508,7 +508,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -567,7 +567,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -603,7 +603,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx !-\d" 
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -644,7 +644,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pmFromFil
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -675,7 +675,7 @@ SecRule REQUEST_HEADERS|REQUEST_LINE "@rx ^\(\s*\)\s+{" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -696,7 +696,7 @@ SecRule ARGS_NAMES|ARGS|FILES_NAMES "@rx ^\(\s*\)\s+{" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -738,7 +738,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \ba[\"
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -776,7 +776,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VARS "!@rx (?i)(?:\.boto|buddyinfo|mtrr|acpi|zoneinfo)\B" \
@@ -873,7 +873,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -910,14 +910,14 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:932013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:932014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:932013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:932014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -941,7 +941,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1000,7 +1000,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:b[\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1033,7 +1033,7 @@ SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer "@rx \$(?:\((?:.*|\(.
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1089,7 +1089,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx ['\*\?
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.932200_matched_var_name=%{matched_var_name}',\
     chain"
@@ -1128,7 +1128,7 @@ SecRule REQUEST_HEADERS:Referer "@rx ^[^#]+" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.932205_matched_var_name=%{matched_var_name}',\
     chain"
@@ -1171,7 +1171,7 @@ SecRule REQUEST_HEADERS:Referer "@rx ^[^\.]*?(?:['\*\?\x5c`][^\n/]+/|/[^/]+?['\*
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.932206_matched_var_name=%{matched_var_name}',\
     chain"
@@ -1213,7 +1213,7 @@ SecRule REQUEST_HEADERS:Referer "@rx #.*" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.932207_matched_var_name=%{matched_var_name}',\
     chain"
@@ -1253,7 +1253,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i).\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1316,7 +1316,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS|XML:/* "@rx (?i)[\-0-9_a-z]+(
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.932240_matched_var_name=%{matched_var_name}',\
     chain"
@@ -1355,7 +1355,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \{[^\s
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1393,7 +1393,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx ;[\s\x
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1429,7 +1429,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx ~[0-9]
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1471,7 +1471,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\r
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/137/134',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1504,7 +1504,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?is)\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/137/134',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1539,7 +1539,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?is)\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/137/134',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1601,7 +1601,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1663,7 +1663,7 @@ SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer "@rx (?i)(?:^|b[\"'\)
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1698,14 +1698,14 @@ SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer "@pmFromFile unix-she
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:932015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:932016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:932015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:932016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
@@ -1764,7 +1764,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:b[\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -1821,7 +1821,7 @@ SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer "@rx (?i)\b(?:7z(?:[\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -1878,7 +1878,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/*|REQUEST_HEA
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -1914,7 +1914,7 @@ SecRule ARGS "@rx /(?:[?*]+[a-z/]+|[a-z/]+[?*]+)" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -1949,7 +1949,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \r\n.*
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/137/134',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -1983,7 +1983,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?is)\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/137/134',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -2017,7 +2017,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx \r\n.*
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/137/134',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -2051,14 +2051,14 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx !(?:\d
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-RCE',\
     tag:'capec/1000/152/248/88',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:932017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:932018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:932017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:932018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-932-APPLICATION-ATTACK-RCE"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:933011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:933012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:933011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:933012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -60,7 +60,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)<\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-PHP',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -102,7 +102,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-PHP',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -132,7 +132,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\b
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-PHP',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.933120_matched_var=%{MATCHED_VAR}',\
     setvar:'tx.933120_matched_var_name=%{MATCHED_VAR_NAME}',\
@@ -159,7 +159,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pmFromFil
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-PHP',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -191,7 +191,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-PHP',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -228,7 +228,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)ph
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-PHP',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -265,7 +265,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:bzi
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-PHP',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -333,7 +333,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-PHP',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -386,7 +386,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-PHP',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -442,7 +442,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_HEADERS|ARGS_NAMES|ARGS|XM
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-PHP',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -498,7 +498,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-PHP',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -546,13 +546,13 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-PHP',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:933013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:933014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:933013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:933014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -597,7 +597,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-PHP',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.933151_matched_var=%{MATCHED_VAR}',\
     setvar:'tx.933151_matched_var_name=%{MATCHED_VAR_NAME}',\
@@ -627,7 +627,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-PHP',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.933152_matched_var=%{MATCHED_VAR}',\
     setvar:'tx.933152_matched_var_name=%{MATCHED_VAR_NAME}',\
@@ -657,7 +657,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-PHP',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.933153_matched_var=%{MATCHED_VAR}',\
     setvar:'tx.933153_matched_var_name=%{MATCHED_VAR_NAME}',\
@@ -665,8 +665,8 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|X
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:933015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:933016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:933015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:933016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
@@ -709,7 +709,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx AUTH_T
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-PHP',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -754,7 +754,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-PHP',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -797,7 +797,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-PHP',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -827,7 +827,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@pm ?>" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-PHP',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -863,14 +863,14 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-PHP',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:933017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:933018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:933017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:933018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-933-APPLICATION-ATTACK-PHP"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
+++ b/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:934011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:934012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:934011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:934012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -67,7 +67,7 @@ SecRule REQUEST_FILENAME|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-GENERIC',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
@@ -103,7 +103,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-GENERIC',\
     tag:'capec/1000/225/664',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -138,7 +138,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:__p
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-GENERIC',\
     tag:'capec/1/180/77',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
@@ -171,7 +171,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx Proces
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-GENERIC',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -203,7 +203,7 @@ SecRule REQUEST_FILENAME|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-GENERIC',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
@@ -234,13 +234,13 @@ SecRule REQUEST_FILENAME|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-GENERIC',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:934013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:934014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:934013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:934014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -263,7 +263,7 @@ SecRule REQUEST_FILENAME|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-GENERIC',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
@@ -316,7 +316,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-GENERIC',\
     tag:'capec/1000/225/664',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -349,7 +349,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx ^(?:[^
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-GENERIC',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -377,20 +377,20 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:{%[
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-GENERIC',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:934015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:934016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:934015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:934016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:934017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:934018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:934017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:934018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-934-APPLICATION-ATTACK-GENERIC"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:941011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:941012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:941011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:941012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -63,7 +63,7 @@ SecRule REQUEST_FILENAME "!@validateByteRange 20, 45-47, 48-57, 65-90, 95, 97-12
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     ctl:ruleRemoveTargetByTag=xss-perf-disable;REQUEST_FILENAME,\
-    ver:'OWASP_CRS/4.21.0-dev'"
+    ver:'OWASP_CRS/4.21.0'"
 
 
 #
@@ -96,7 +96,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|ARGS_NA
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -124,7 +124,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|REQUEST_HEADERS:U
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -155,7 +155,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|ARGS_NA
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -185,7 +185,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -219,7 +219,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -245,7 +245,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -273,7 +273,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -301,7 +301,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -324,7 +324,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -349,7 +349,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -372,7 +372,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -395,7 +395,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -418,7 +418,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -441,7 +441,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -464,7 +464,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -487,7 +487,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -510,7 +510,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -533,7 +533,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -556,7 +556,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -617,7 +617,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VARS "@rx (?:\xbc\s*/\s*[^\xbe>]*[\xbe>])|(?:<\s*/\s*[^\xbe]*\xbe)" \
@@ -647,7 +647,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -690,7 +690,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242/63',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -719,7 +719,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@rx 
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242/63',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -753,7 +753,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -784,14 +784,14 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:941013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:941014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:941013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:941014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -816,7 +816,7 @@ SecRule REQUEST_FILENAME|REQUEST_HEADERS:Referer "@detectXSS" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -851,7 +851,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -878,7 +878,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|ARGS_NA
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -907,7 +907,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -995,7 +995,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NA
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242/63',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1017,7 +1017,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NA
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1042,7 +1042,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NA
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1076,23 +1076,23 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-XSS',\
     tag:'capec/1000/152/242/63',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:941015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:941016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:941015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:941016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:941017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:941018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:941017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:941018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-941-APPLICATION-ATTACK-XSS"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:942011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:942012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:942011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:942012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -59,7 +59,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
@@ -90,7 +90,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\b
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -123,7 +123,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\b
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -167,7 +167,7 @@ SecRule REQUEST_FILENAME|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -193,7 +193,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -219,7 +219,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -243,7 +243,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx ^(?i:-
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -269,7 +269,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -295,7 +295,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)al
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -316,7 +316,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:me
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -337,7 +337,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)un
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -363,7 +363,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -389,7 +389,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\[
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -418,7 +418,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)cr
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -444,7 +444,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)cr
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -483,7 +483,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\b
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -524,7 +524,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)/\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -561,7 +561,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx ^(?:[^
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'paranoia-level/1',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -591,7 +591,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)1\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -621,14 +621,14 @@ SecRule REQUEST_FILENAME|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|X
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:942013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:942014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:942013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:942014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -661,7 +661,7 @@ SecRule ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@rx (?i)[!=]=|&&|\|\||->|>[=>]|
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -702,7 +702,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\x0b\"'-\)`]*?\b([0-9A-Z_a-z]+)\b[\s\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.942130_matched_var_name=%{matched_var_name}',\
     chain"
@@ -738,7 +738,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\s\x0b\"'-\)`]*?\b([0-9A-Z_a-z]+)\b[\s\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.942131_matched_var_name=%{matched_var_name}',\
@@ -775,7 +775,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\b
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -818,7 +818,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -847,7 +847,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -876,7 +876,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -902,7 +902,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -928,7 +928,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\)
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -954,7 +954,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -988,7 +988,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1017,7 +1017,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)in
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1042,7 +1042,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:^[
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1072,7 +1072,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1104,7 +1104,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:Referer|REQUEST_HE
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1130,7 +1130,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NA
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1156,7 +1156,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NA
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1182,7 +1182,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NA
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1213,7 +1213,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NA
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1242,7 +1242,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NA
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1271,7 +1271,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|REQUEST
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1312,7 +1312,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"
@@ -1331,7 +1331,7 @@ SecRule ARGS_GET:fbclid "@rx [a-zA-Z0-9_-]{61,61}" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     ctl:ruleRemoveTargetById=942440;ARGS:fbclid,\
-    ver:'OWASP_CRS/4.21.0-dev'"
+    ver:'OWASP_CRS/4.21.0'"
 
 #
 # -=[ Exclusion rule for 942440 ]=-
@@ -1347,7 +1347,7 @@ SecRule ARGS_GET:gclid "@rx [a-zA-Z0-9_-]{91,91}" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     ctl:ruleRemoveTargetById=942440;ARGS:gclid,\
-    ver:'OWASP_CRS/4.21.0-dev'"
+    ver:'OWASP_CRS/4.21.0'"
 
 #
 # -=[ Detect SQL Comment Sequences ]=-
@@ -1401,7 +1401,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NA
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VARS "!@rx ^ey[\-0-9A-Z_a-z]+\.ey[\-0-9A-Z_a-z]+\.[\-0-9A-Z_a-z]+$" \
@@ -1432,7 +1432,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NA
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1479,7 +1479,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:`(?
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1506,7 +1506,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1539,7 +1539,7 @@ SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.942521_matched_var_name=%{matched_var_name}',\
     chain"
@@ -1567,7 +1567,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ^.*?\x5c['\"`](?:.*?['\"`])?\s*(?:and|or)\b"
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1605,7 +1605,7 @@ SecRule REQUEST_BASENAME|REQUEST_FILENAME "@detectSQLi" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1637,7 +1637,7 @@ SecRule REQUEST_HEADERS:Referer|REQUEST_HEADERS:User-Agent "@rx (?i)\b(?:a(?:dd(
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1667,15 +1667,15 @@ SecRule REQUEST_HEADERS:Referer|REQUEST_HEADERS:User-Agent "@rx (?i)create[\s\x0
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:942015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:942016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:942015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:942016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
@@ -1707,7 +1707,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\W
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -1731,7 +1731,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx [\"'`]
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -1771,7 +1771,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES "@rx ((
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"
@@ -1800,7 +1800,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"
@@ -1842,7 +1842,7 @@ SecRule ARGS "@rx \W{4}" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'WARNING',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.warning_anomaly_score}'"
@@ -1890,7 +1890,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:'(?
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -1919,14 +1919,14 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx ';" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:942017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:942018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:942017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:942018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-942-APPLICATION-ATTACK-SQLI"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
@@ -1953,7 +1953,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES "@rx ((
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl4=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"
@@ -1982,7 +1982,7 @@ SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'Â´â
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SQLI',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'WARNING',\
     setvar:'tx.inbound_anomaly_score_pl4=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"

--- a/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
+++ b/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -14,8 +14,8 @@
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:943011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:943012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:943011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:943012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -44,7 +44,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:\.
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SESSION-FIXATION',\
     tag:'capec/1000/225/21/593/61',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.session_fixation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -66,7 +66,7 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SESSION-FIXATION',\
     tag:'capec/1000/225/21/593/61',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.943110_matched_var_name=%{matched_var_name}',\
     chain"
@@ -94,7 +94,7 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-SESSION-FIXATION',\
     tag:'capec/1000/225/21/593/61',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.943120_matched_var_name=%{matched_var_name}',\
     chain"
@@ -105,24 +105,24 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:943013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:943014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:943013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:943014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:943015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:943016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:943015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:943016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:943017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:943018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:943017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:943018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -13,8 +13,8 @@
 #
 # Many rules check request bodies, use "SecRequestBodyAccess On" to enable it on main modsecurity configuration file.
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:944011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:944012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:944011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:944012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -46,7 +46,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUE
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-JAVA',\
     tag:'capec/1000/152/137/6',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -78,7 +78,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUE
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-JAVA',\
     tag:'capec/1000/152/248',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VARS|XML:/*|XML://@* "@rx (?i)(?:unmarshaller|base64data|java\.)" \
@@ -103,7 +103,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUE
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-JAVA',\
     tag:'capec/1000/152/248',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VARS "@rx (?:runtime|processbuilder)" \
@@ -135,7 +135,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUE
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-JAVA',\
     tag:'capec/1000/152/248',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -174,7 +174,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-JAVA',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -222,14 +222,14 @@ SecRule REQUEST_LINE|ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUE
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-JAVA',\
     tag:'capec/1000/152/137/6',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:944013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:944014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:944013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:944014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -260,7 +260,7 @@ SecRule REQUEST_LINE|ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUE
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-JAVA',\
     tag:'capec/1000/152/137/6',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -292,7 +292,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUE
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-JAVA',\
     tag:'capec/1000/152/248',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -313,7 +313,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUE
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-JAVA',\
     tag:'capec/1000/152/248',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -334,7 +334,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUE
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-JAVA',\
     tag:'capec/1000/152/248',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -358,7 +358,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUE
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-JAVA',\
     tag:'capec/1000/152/248',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -383,14 +383,14 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUE
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-JAVA',\
     tag:'capec/1000/152/248',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:944015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:944016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:944015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:944016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
@@ -417,14 +417,14 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUE
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-JAVA',\
     tag:'capec/1000/152/248',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:944017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:944018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:944017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:944018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-944-APPLICATION-ATTACK-JAVA"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #
@@ -453,7 +453,7 @@ SecRule REQUEST_LINE|ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUE
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/ATTACK-JAVA',\
     tag:'capec/1000/152/137/6',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl4=+%{tx.critical_anomaly_score}'"

--- a/rules/REQUEST-949-BLOCKING-EVALUATION.conf
+++ b/rules/REQUEST-949-BLOCKING-EVALUATION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -24,7 +24,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 1" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl1}'"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 1" \
@@ -34,7 +34,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 1" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl1}'"
 
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
@@ -44,7 +44,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl2}'"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 2" \
@@ -54,7 +54,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 2" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl2}'"
 
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
@@ -64,7 +64,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl3}'"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 3" \
@@ -74,7 +74,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 3" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl3}'"
 
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
@@ -84,7 +84,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl4}'"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
@@ -94,7 +94,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl4}'"
 
 # at start of phase 2, we reset the aggregate scores to 0 to prevent duplicate counting of per-PL scores
@@ -106,7 +106,7 @@ SecAction \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.blocking_inbound_anomaly_score=0'"
 
 SecAction \
@@ -116,7 +116,7 @@ SecAction \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.detection_inbound_anomaly_score=0'"
 
 # Summing up the blocking and detection anomaly scores in phase 2
@@ -128,7 +128,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 1" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl1}'"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 1" \
@@ -138,7 +138,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 1" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl1}'"
 
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
@@ -148,7 +148,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl2}'"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 2" \
@@ -158,7 +158,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 2" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl2}'"
 
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
@@ -168,7 +168,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl3}'"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 3" \
@@ -178,7 +178,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 3" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl3}'"
 
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
@@ -188,7 +188,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.blocking_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl4}'"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
@@ -198,7 +198,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.detection_inbound_anomaly_score=+%{tx.inbound_anomaly_score_pl4}'"
 
 
@@ -217,7 +217,7 @@ SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_thresh
     msg:'Inbound Anomaly Score Exceeded in phase 1 (Total Score: %{TX.BLOCKING_INBOUND_ANOMALY_SCORE})',\
     tag:'anomaly-evaluation',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     chain"
     SecRule TX:EARLY_BLOCKING "@eq 1"
 
@@ -230,34 +230,34 @@ SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_thresh
     msg:'Inbound Anomaly Score Exceeded (Total Score: %{TX.BLOCKING_INBOUND_ANOMALY_SCORE})',\
     tag:'anomaly-evaluation',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev'"
+    ver:'OWASP_CRS/4.21.0'"
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:949011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:949012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:949011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:949012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:949013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:949014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:949013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:949014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:949015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:949016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:949015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:949016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:949017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:949018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:949017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:949018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REQUEST-949-BLOCKING-EVALUATION"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -29,7 +29,7 @@ SecRule TX:crs_skip_response_analysis "@eq 1" \
     nolog,\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
 
 # Skip all rules if RESPONSE_BODY is compressed.
@@ -40,11 +40,11 @@ SecRule RESPONSE_HEADERS:Content-Encoding "@pm gzip compress deflate br zstd" \
     nolog,\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:950011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:950012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:950011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:950012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -68,7 +68,7 @@ SecRule RESPONSE_BODY "@rx (?:<(?:TITLE>Index of.*?<H|title>Index of.*?<h)1>Inde
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES',\
     tag:'capec/1000/118/116/54/127',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
@@ -100,7 +100,7 @@ SecRule RESPONSE_BODY "@rx ^#\!\s?/" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES',\
     tag:'capec/1000/118/116',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
@@ -123,13 +123,13 @@ SecRule RESPONSE_BODY "@pmFromFile asp-dotnet-errors.data" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES',\
     tag:'capec/1000/118/116/54/127',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:950013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:950014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:950013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:950014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -153,22 +153,22 @@ SecRule RESPONSE_STATUS "@rx ^5\d{2}$" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES',\
     tag:'capec/1000/152',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl2=+%{tx.error_anomaly_score}'"
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:950015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:950016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:950015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:950016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:950017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:950018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:950017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:950018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-950-DATA-LEAKAGES"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -20,11 +20,11 @@ SecRule RESPONSE_HEADERS:Content-Encoding "@pm gzip compress deflate br zstd" \
     nolog,\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-SQL',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:951011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:951012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:951011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:951012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -48,7 +48,7 @@ SecRule RESPONSE_BODY "!@pmFromFile sql-errors.data" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-SQL',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     skipAfter:END-SQL-ERROR-MATCH-PL1"
 
 SecRule RESPONSE_BODY "@rx (?i:JET Database Engine|Access Database Engine|\[Microsoft\]\[ODBC Microsoft Access Driver\])" \
@@ -67,7 +67,7 @@ SecRule RESPONSE_BODY "@rx (?i:JET Database Engine|Access Database Engine|\[Micr
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-SQL',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -93,7 +93,7 @@ SecRule RESPONSE_BODY "@rx (?i)\bORA-[0-9][0-9][0-9][0-9][0-9]:|java\.sql\.SQLEx
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-SQL',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -114,7 +114,7 @@ SecRule RESPONSE_BODY "@rx (?i:DB2 SQL error:|\[IBM\]\[CLI Driver\]\[DB2/6000\]|
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-SQL',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -135,7 +135,7 @@ SecRule RESPONSE_BODY "@rx (?i:\[DM_QUERY_E_SYNTAX\]|has occurred in the vicinit
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-SQL',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -156,7 +156,7 @@ SecRule RESPONSE_BODY "@rx (?i)Dynamic SQL Error" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-SQL',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -177,7 +177,7 @@ SecRule RESPONSE_BODY "@rx (?i)Exception (?:condition )?\d+\. Transaction rollba
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-SQL',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -198,7 +198,7 @@ SecRule RESPONSE_BODY "@rx (?i)org\.hsqldb\.jdbc" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-SQL',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -219,7 +219,7 @@ SecRule RESPONSE_BODY "@rx (?i:An illegal character has been found in the statem
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-SQL',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -240,7 +240,7 @@ SecRule RESPONSE_BODY "@rx (?i:Warning.*ingres_|Ingres SQLSTATE|Ingres\W.*Driver
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-SQL',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -261,7 +261,7 @@ SecRule RESPONSE_BODY "@rx (?i:<b>Warning</b>: ibase_|Unexpected end of command 
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-SQL',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -282,7 +282,7 @@ SecRule RESPONSE_BODY "@rx (?i:SQL error.*POS[0-9]+.*|Warning.*maxdb.*)" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-SQL',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -303,7 +303,7 @@ SecRule RESPONSE_BODY "@rx (?i)(?:System\.Data\.OleDb\.OleDbException|\[Microsof
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-SQL',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -329,7 +329,7 @@ SecRule RESPONSE_BODY "@rx (?i)(?:supplied argument is not a valid |SQL syntax.*
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-SQL',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -355,7 +355,7 @@ SecRule RESPONSE_BODY "@rx (?i)P(?:ostgreSQL(?: query failed:|.{1,20}ERROR)|G::[
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-SQL',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -376,7 +376,7 @@ SecRule RESPONSE_BODY "@rx (?i)(?:Warning.*sqlite_|Warning.*SQLite3::|SQLite/JDB
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-SQL',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -397,7 +397,7 @@ SecRule RESPONSE_BODY "@rx (?i)(?:Sybase message:|Warning.{2,20}sybase|Sybase.*S
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-SQL',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -405,24 +405,24 @@ SecRule RESPONSE_BODY "@rx (?i)(?:Sybase message:|Warning.{2,20}sybase|Sybase.*S
 SecMarker "END-SQL-ERROR-MATCH-PL1"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:951013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:951014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:951013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:951014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:951015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:951016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:951015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:951016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:951017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:951018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:951017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:951018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-951-DATA-LEAKAGES-SQL"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
+++ b/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -20,11 +20,11 @@ SecRule RESPONSE_HEADERS:Content-Encoding "@pm gzip compress deflate br zstd" \
     nolog,\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-JAVA',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:952011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:952012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:952011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:952012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -50,30 +50,30 @@ SecRule RESPONSE_BODY "@rx (?i)\b(?:java[\.a-z]+E(?:xception|rror)|(?:org|com)\.
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-JAVA',\
     tag:'capec/1000/118/116',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:952013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:952014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:952013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:952014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:952015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:952016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:952015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:952016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:952017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:952018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:952017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:952018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-952-DATA-LEAKAGES-JAVA"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -20,11 +20,11 @@ SecRule RESPONSE_HEADERS:Content-Encoding "@pm gzip compress deflate br zstd" \
     nolog,\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-PHP',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:953011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:953012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:953011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:953012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -48,7 +48,7 @@ SecRule RESPONSE_BODY "@pmFromFile php-errors.data" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-PHP',\
     tag:'capec/1000/118/116',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
@@ -73,7 +73,7 @@ SecRule RESPONSE_BODY "@rx (?:\b(?:f(?:tp_(?:nb_)?f?(?:ge|pu)t|get(?:s?s|c)|scan
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-PHP',\
     tag:'capec/1000/118/116',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
@@ -99,13 +99,13 @@ SecRule RESPONSE_BODY "@rx (?i)<\?(?:=|php)?\s+" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-PHP',\
     tag:'capec/1000/118/116',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:953013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:953014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:953013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:953014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -133,21 +133,21 @@ SecRule RESPONSE_BODY "@rx (?i)Empty string|F(?:ile size is|reeing memory)|Heade
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-PHP',\
     tag:'capec/1000/118/116',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl2=+%{tx.error_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:953015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:953016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:953015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:953016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:953017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:953018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:953017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:953018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-953-DATA-LEAKAGES-PHP"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+++ b/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -20,11 +20,11 @@ SecRule RESPONSE_HEADERS:Content-Encoding "@pm gzip compress deflate br zstd" \
     nolog,\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-IIS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:954011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:954012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:954011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:954012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -48,7 +48,7 @@ SecRule RESPONSE_BODY "@rx (?i)[a-z]:[\x5c/]inetpub\b" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-IIS',\
     tag:'capec/1000/118/116',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
@@ -69,7 +69,7 @@ SecRule RESPONSE_BODY "@rx (?:Microsoft OLE DB Provider for SQL Server(?:</font>
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-IIS',\
     tag:'capec/1000/118/116',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
@@ -93,7 +93,7 @@ SecRule RESPONSE_BODY "@pmFromFile iis-errors.data" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-IIS',\
     tag:'capec/1000/118/116',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
@@ -115,7 +115,7 @@ SecRule RESPONSE_STATUS "!@rx ^404$" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-IIS',\
     tag:'capec/1000/118/116',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'ERROR',\
     chain"
     SecRule RESPONSE_BODY "@rx \bServer Error in.{0,50}?\bApplication\b" \
@@ -125,8 +125,8 @@ SecRule RESPONSE_STATUS "!@rx ^404$" \
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:954013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:954014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:954013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:954014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -151,21 +151,21 @@ SecRule RESPONSE_BODY "@rx (?i)[\x5c/]inetpub\b" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-IIS',\
     tag:'capec/1000/118/116',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl2=+%{tx.error_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:954015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:954016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:954015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:954016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:954017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:954018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:954017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:954018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-954-DATA-LEAKAGES-IIS"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-955-WEB-SHELLS.conf
+++ b/rules/RESPONSE-955-WEB-SHELLS.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. (not) All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -20,11 +20,11 @@ SecRule RESPONSE_HEADERS:Content-Encoding "@pm gzip compress deflate br zstd" \
     nolog,\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     skipAfter:END-RESPONSE-955-WEB-SHELLS"
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:955011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:955012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:955011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:955012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-955-WEB-SHELLS"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -46,7 +46,7 @@ SecRule RESPONSE_BODY "@pmFromFile web-shells-php.data" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -66,7 +66,7 @@ SecRule RESPONSE_BODY "@rx <title>r57 Shell Version [0-9.]+</title>|<title>r57 s
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -86,7 +86,7 @@ SecRule RESPONSE_BODY "@rx ^<html><head><meta http-equiv='Content-Type' content=
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -106,7 +106,7 @@ SecRule RESPONSE_BODY "@rx B4TM4N SH3LL</title>[^<]*<meta name='author' content=
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -126,7 +126,7 @@ SecRule RESPONSE_BODY "@rx <title>Mini Shell</title>[^D]*Developed By LameHacker
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -146,7 +146,7 @@ SecRule RESPONSE_BODY "@rx <title>\.:: [^~]*~ Ashiyane V [0-9.]+ ::\.</title>" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -166,7 +166,7 @@ SecRule RESPONSE_BODY "@rx <title>Symlink_Sa [0-9.]+</title>" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -186,7 +186,7 @@ SecRule RESPONSE_BODY "@rx <title>CasuS [0-9.]+ by MafiABoY</title>" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -206,7 +206,7 @@ SecRule RESPONSE_BODY "@rx ^<html>\r\n<head>\r\n<title>GRP WebShell [0-9.]+ " \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -226,7 +226,7 @@ SecRule RESPONSE_BODY "@rx <small>NGHshell [0-9.]+ by Cr4sh</body></html>\n$" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -246,7 +246,7 @@ SecRule RESPONSE_BODY "@rx <title>SimAttacker - (?:Version|Vrsion) : [0-9.]+ - "
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -266,7 +266,7 @@ SecRule RESPONSE_BODY "@rx ^<!DOCTYPE html>\n<html>\n<!-- By Artyum [^<]*<title>
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -286,7 +286,7 @@ SecRule RESPONSE_BODY "@rx <title>lama's'hell v. [0-9.]+</title>" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -306,7 +306,7 @@ SecRule RESPONSE_BODY "@rx ^ *<html>\n[ ]+<head>\n[ ]+<title>lostDC - " \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -326,7 +326,7 @@ SecRule RESPONSE_BODY "@rx ^<title>PHP Web Shell</title>\r\n<html>\r\n<body>\r\n
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -346,7 +346,7 @@ SecRule RESPONSE_BODY "@rx ^<html>\n<head>\n<div align=\"left\"><font size=\"1\"
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -368,7 +368,7 @@ SecRule RESPONSE_BODY "@rx ^<html>\n<head>\n<title>Ru24PostWebShell " \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -388,7 +388,7 @@ SecRule RESPONSE_BODY "@rx <title>s72 Shell v[0-9.]+ Codinf by Cr@zy_King</title
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -408,7 +408,7 @@ SecRule RESPONSE_BODY "@rx ^<html>\r\n<head>\r\n<meta http-equiv=\"Content-Type\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -428,7 +428,7 @@ SecRule RESPONSE_BODY "@rx ^ <html>\n\n<head>\n\n<title>g00nshell v[0-9.]+ " \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -450,7 +450,7 @@ SecRule RESPONSE_BODY "@contains <title>punkholicshell</title>" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -470,7 +470,7 @@ SecRule RESPONSE_BODY "@rx ^<html>\n      <head>\n             <title>azrail [0-
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -490,7 +490,7 @@ SecRule RESPONSE_BODY "@rx >SmEvK_PaThAn Shell v[0-9]+ coded by <a href=" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -510,7 +510,7 @@ SecRule RESPONSE_BODY "@rx ^<html>\n<title>[^~]*~ Shell I</title>\n<head>\n<styl
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -530,7 +530,7 @@ SecRule RESPONSE_BODY "@rx ^ <html><head><title>:: b374k m1n1 [0-9.]+ ::</title>
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -550,14 +550,14 @@ SecRule RESPONSE_BODY "@pmFromFile web-shells-asp.data" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:955013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:955014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:955013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:955014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-955-WEB-SHELLS"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
@@ -579,13 +579,13 @@ SecRule RESPONSE_BODY "@contains <h1 style=\"margin-bottom: 0\">webadmin.php</h1
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/WEB-SHELLS',\
     tag:'capec/1000/225/122/17/650',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'CRITICAL',\
     setvar:'tx.outbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:955015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:955016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:955015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:955016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-955-WEB-SHELLS"
 
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
@@ -593,8 +593,8 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:955016,phase:4,pass,nolog,tag:'O
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:955017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:955018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:955017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-955-WEB-SHELLS"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:955018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-955-WEB-SHELLS"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-956-DATA-LEAKAGES-RUBY.conf
+++ b/rules/RESPONSE-956-DATA-LEAKAGES-RUBY.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -20,11 +20,11 @@ SecRule RESPONSE_HEADERS:Content-Encoding "@pm gzip compress deflate br zstd" \
     nolog,\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-RUBY',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     skipAfter:END-RESPONSE-956-DATA-LEAKAGES-RUBY"
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:956011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-956-DATA-LEAKAGES-RUBY"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:956012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-956-DATA-LEAKAGES-RUBY"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:956011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-956-DATA-LEAKAGES-RUBY"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:956012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-956-DATA-LEAKAGES-RUBY"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
@@ -48,13 +48,13 @@ SecRule RESPONSE_BODY "@pmFromFile ruby-errors.data" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-RUBY',\
     tag:'capec/1000/118/116',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}'"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:956013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-956-DATA-LEAKAGES-RUBY"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:956014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-956-DATA-LEAKAGES-RUBY"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:956013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-956-DATA-LEAKAGES-RUBY"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:956014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-956-DATA-LEAKAGES-RUBY"
 
 
 # Detect the presence of the Ruby ERB templates "<%", "<%= " and slim interpolation "#{}" in output.
@@ -79,20 +79,20 @@ SecRule RESPONSE_BODY "@rx (?i)(?:<%[=#\s]|#\{[^}]+\})" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/DATA-LEAKAGES-RUBY',\
     tag:'capec/1000/118/116',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl2=+%{tx.error_anomaly_score}'"
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:956015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-956-DATA-LEAKAGES-RUBY"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:956016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-956-DATA-LEAKAGES-RUBY"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:956015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-956-DATA-LEAKAGES-RUBY"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:956016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-956-DATA-LEAKAGES-RUBY"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:956017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-956-DATA-LEAKAGES-RUBY"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:956018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-956-DATA-LEAKAGES-RUBY"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:956017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-956-DATA-LEAKAGES-RUBY"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:956018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-956-DATA-LEAKAGES-RUBY"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
+++ b/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -35,7 +35,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 1" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl1}'"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 1" \
@@ -45,7 +45,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 1" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl1}'"
 
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
@@ -55,7 +55,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl2}'"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 2" \
@@ -65,7 +65,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 2" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl2}'"
 
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
@@ -75,7 +75,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl3}'"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 3" \
@@ -85,7 +85,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 3" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl3}'"
 
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
@@ -95,7 +95,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl4}'"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
@@ -105,7 +105,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl4}'"
 
 # at start of phase 4, we reset the aggregate scores to 0 to prevent duplicate counting of per-PL scores
@@ -117,7 +117,7 @@ SecAction \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.blocking_outbound_anomaly_score=0'"
 
 SecAction \
@@ -127,7 +127,7 @@ SecAction \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.detection_outbound_anomaly_score=0'"
 
 SecMarker "EARLY_BLOCKING_ANOMALY_SCORING"
@@ -141,7 +141,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 1" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl1}'"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 1" \
@@ -151,7 +151,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 1" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl1}'"
 
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
@@ -161,7 +161,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 2" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl2}'"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 2" \
@@ -171,7 +171,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 2" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl2}'"
 
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
@@ -181,7 +181,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 3" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl3}'"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 3" \
@@ -191,7 +191,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 3" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl3}'"
 
 SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
@@ -201,7 +201,7 @@ SecRule TX:BLOCKING_PARANOIA_LEVEL "@ge 4" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.blocking_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl4}'"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
@@ -211,7 +211,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@ge 4" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.detection_outbound_anomaly_score=+%{tx.outbound_anomaly_score_pl4}'"
 
 #
@@ -227,7 +227,7 @@ SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_thre
     msg:'Outbound Anomaly Score Exceeded in phase 3 (Total Score: %{tx.blocking_outbound_anomaly_score})',\
     tag:'anomaly-evaluation',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     chain"
     SecRule TX:EARLY_BLOCKING "@eq 1"
 
@@ -240,34 +240,34 @@ SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_thre
     msg:'Outbound Anomaly Score Exceeded (Total Score: %{tx.blocking_outbound_anomaly_score})',\
     tag:'anomaly-evaluation',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev'"
+    ver:'OWASP_CRS/4.21.0'"
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:959011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:959012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:959011,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:959012,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:959013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:959014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:959013,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:959014,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:959015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:959016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:959015,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:959016,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:959017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:959018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:959017,phase:3,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:959018,phase:4,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-959-BLOCKING-EVALUATION"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
@@ -28,7 +28,7 @@ SecAction \
     nolog,\
     noauditlog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev',\
+    ver:'OWASP_CRS/4.21.0',\
     setvar:'tx.blocking_anomaly_score=%{tx.blocking_inbound_anomaly_score}',\
     setvar:'tx.blocking_anomaly_score=+%{tx.blocking_outbound_anomaly_score}',\
     setvar:'tx.detection_anomaly_score=%{tx.detection_inbound_anomaly_score}',\
@@ -41,33 +41,33 @@ SecAction \
 #
 
 # -= Reporting Level 0 =- (Skip over reporting when tx.reporting_level is 0)
-SecRule TX:REPORTING_LEVEL "@eq 0" "id:980041,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REPORTING"
+SecRule TX:REPORTING_LEVEL "@eq 0" "id:980041,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REPORTING"
 
 # -= Reporting Level 5 =- (Jump to reporting rule immediately when tx.reporting_level is 5 or greater)
-SecRule TX:REPORTING_LEVEL "@ge 5" "id:980042,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:LOG-REPORTING"
+SecRule TX:REPORTING_LEVEL "@ge 5" "id:980042,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:LOG-REPORTING"
 
 # -= Zero detection score =- (Skip over reporting when sum of inbound and outbound detection score is equal to 0)
-SecRule TX:DETECTION_ANOMALY_SCORE "@eq 0" "id:980043,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REPORTING"
+SecRule TX:DETECTION_ANOMALY_SCORE "@eq 0" "id:980043,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REPORTING"
 
 # -= Blocking score exceeds threshold =- (Jump to reporting rule immediately if a blocking score exceeds a threshold)
-SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" "id:980044,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:LOG-REPORTING"
-SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" "id:980045,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:LOG-REPORTING"
+SecRule TX:BLOCKING_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" "id:980044,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:LOG-REPORTING"
+SecRule TX:BLOCKING_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" "id:980045,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:LOG-REPORTING"
 
 # -= Reporting Level 2 =- (Skip over reporting when tx.reporting_level is less than 2)
-SecRule TX:REPORTING_LEVEL "@lt 2" "id:980046,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REPORTING"
+SecRule TX:REPORTING_LEVEL "@lt 2" "id:980046,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REPORTING"
 
 # -= Detection score exceeds threshold =- (Jump to reporting rule immediately if a detection score exceeds a threshold)
-SecRule TX:DETECTION_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" "id:980047,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:LOG-REPORTING"
-SecRule TX:DETECTION_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" "id:980048,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:LOG-REPORTING"
+SecRule TX:DETECTION_INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" "id:980047,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:LOG-REPORTING"
+SecRule TX:DETECTION_OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" "id:980048,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:LOG-REPORTING"
 
 # -= Reporting Level 3 =- (Skip over reporting when tx.reporting_level is less than 3)
-SecRule TX:REPORTING_LEVEL "@lt 3" "id:980049,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REPORTING"
+SecRule TX:REPORTING_LEVEL "@lt 3" "id:980049,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REPORTING"
 
 # -= Blocking score greater than zero =- (Jump to reporting rule immediately when sum of inbound and outbound blocking score is greater than zero)
-SecRule TX:BLOCKING_ANOMALY_SCORE "@gt 0" "id:980050,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:LOG-REPORTING"
+SecRule TX:BLOCKING_ANOMALY_SCORE "@gt 0" "id:980050,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:LOG-REPORTING"
 
 # -= Reporting Level 4 =- (Skip over reporting when tx.reporting_level is less than 4)
-SecRule TX:REPORTING_LEVEL "@lt 4" "id:980051,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-REPORTING"
+SecRule TX:REPORTING_LEVEL "@lt 4" "id:980051,phase:5,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-REPORTING"
 
 # At this point, the reporting level is 4 and there's a non-zero detection
 # score (already established by rule 980043) so fall through to the reporting
@@ -95,37 +95,37 @@ SecAction \
 (SQLI=%{tx.sql_injection_score}, XSS=%{tx.xss_score}, RFI=%{tx.rfi_score}, LFI=%{tx.lfi_score}, RCE=%{tx.rce_score}, PHPI=%{tx.php_injection_score}, HTTP=%{tx.http_violation_score}, SESS=%{tx.session_fixation_score}, COMBINED_SCORE=%{tx.anomaly_score})',\
     tag:'reporting',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/4.21.0-dev'"
+    ver:'OWASP_CRS/4.21.0'"
 
 SecMarker "END-REPORTING"
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:980011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-980-CORRELATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:980012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:980011,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:980012,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-980-CORRELATION"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.detection_paranoia_level is sufficiently high: 1 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:980013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-980-CORRELATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:980014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:980013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:980014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-980-CORRELATION"
 #
 # -= Paranoia Level 2 =- (apply only when tx.detection_paranoia_level is sufficiently high: 2 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:980015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-980-CORRELATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:980016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:980015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:980016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-980-CORRELATION"
 #
 # -= Paranoia Level 3 =- (apply only when tx.detection_paranoia_level is sufficiently high: 3 or higher)
 #
 
 
 
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:980017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-980-CORRELATION"
-SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:980018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0-dev',skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:980017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-980-CORRELATION"
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:980018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.21.0',skipAfter:END-RESPONSE-980-CORRELATION"
 #
 # -= Paranoia Level 4 =- (apply only when tx.detection_paranoia_level is sufficiently high: 4 or higher)
 #

--- a/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf.example
+++ b/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf.example
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP CRS ver.4.21.0-dev
+# OWASP CRS ver.4.21.0
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2025 CRS project. All rights reserved.
 #


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### 🆕 New features and detections 🎉
* feat(931100): add IPv6 support / XML scan and SSH scheme. by @touchweb-vincent in https://github.com/coreruleset/coreruleset/pull/4321
* feat(920440): add new restricted file extensions by @touchweb-vincent in https://github.com/coreruleset/coreruleset/pull/4322
### 🧰 Other Changes
* fix(942160): adding unit test for double comment by @touchweb-vincent in https://github.com/coreruleset/coreruleset/pull/4315
* fix(920280, 920300, 920310, 920311, 920320, 920330): should be block by @touchweb-vincent in https://github.com/coreruleset/coreruleset/pull/4319
* fix(942151,942152): wrong functions names by @touchweb-vincent in https://github.com/coreruleset/coreruleset/pull/4333
* feat(942460): adding help for non-English folks by @touchweb-vincent in https://github.com/coreruleset/coreruleset/pull/4334
* fix(932180): reduce substring false positives by @EsadCetiner in https://github.com/coreruleset/coreruleset/pull/4338
* fix(942151,942152): wrong functions names by @touchweb-vincent in https://github.com/coreruleset/coreruleset/pull/4337
* fix(920180): wrong unit test - content-type evasion bypass by @touchweb-vincent in https://github.com/coreruleset/coreruleset/pull/4339
* fix(956110): move rule to pl-2 by @EsadCetiner in https://github.com/coreruleset/coreruleset/pull/4344
* docs: comment on disabling `Expect` header in .Net by @theseion in https://github.com/coreruleset/coreruleset/pull/4348
* fix: add missing capture action to affected rules by @airween in https://github.com/coreruleset/coreruleset/pull/4361


**Full Changelog**: https://github.com/coreruleset/coreruleset/compare/v4.20.0...v4.21.0