### PR TITLE
chore(920240): remove obsolete comment

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1483,6 +1483,9 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
 #
 # Check URL encodings
 #
+# -=[ References ]=-
+# http://www.ietf.org/rfc/rfc1738.txt
+#
 SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)application/x-www-form-urlencoded" \
     "id:920240,\
     phase:2,\


### PR DESCRIPTION
Hello,

This rule no longer exists, so this comment must be removed.

Vincent