### PR TITLE
docs: add prerequisites section for new contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ The OWASP CRS is a set of generic attack detection rules for use with ModSecurit
 
 Please see the [OWASP CRS page](https://coreruleset.org/) to get introduced to CRS and view resources on installation, configuration, and working with CRS. There you can also find a [list of projects related to CRS](https://coreruleset.org/) and a [list of tools](https://coreruleset.org/docs/6-development/6-6-useful_tools/) for both developers and users.
 
-## Prerequisites
+## Prerequisites for Code and Rule Contributors
 
-Before contributing to OWASP CRS, please ensure you have:
+Before contributing code or rules to OWASP CRS, please ensure you have:
 
 - Git installed
 - Basic familiarity with the command line
 - Docker installed (recommended for local testing)
-- General understanding of web application security concepts (helpful but not mandatory)
+- - General understanding of web application security concepts (helpful but not mandatory; not required for reporting issues or participating in discussions)
 
 ## Contributing to CRS
 


### PR DESCRIPTION
Adds a prerequisites section to the README to help first-time contributors understand the basic requirements for contributing to OWASP CRS.

## Proposed changes

This pull request adds a small "Prerequisites" section to the README to improve onboarding for new contributors.

<!-- Github Tip: adding the text 'Fixes #<issue>' or 'Closes #<issue>' will automatically close the mentioned issue. -->

## PR Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/CONTRIBUTING.md) doc
- [ ] I have added positive tests proving my fix/feature works as intended.
- [ ] I have added negative tests that prove my fix/feature considers common cases that might end in false positives
- [ ] In case you changed a regular expression, you are not adding a ReDOS for pcre. You can check this using [regexploit](https://github.com/doyensec/regexploit)
- [ ] My test use the `comment` field to write the expected behavior
- [x] I have added documentation for the rule or change (when appropriate)

## Further comments

This is a documentation-only change intended to make it easier for new contributors to get started.

## For the reviewer

<!-- Don't remove this part. Reviewers will use it as guidance for the review process. -->

- [ ] Positive and negative tests were added
- [ ] Tests cover the intended fix/feature properly
- [ ] No usage of dangerous constructs like `ctl:requestBodyAccess=Off` were used in the rule
- [ ] In case a regular expression was changed, [there is no ReDOS](https://github.com/coreruleset/coreruleset/wiki/Testing-for-Regular-Expresion-DoS)
- [ ] Documentation is clear for the rule/change
