### PR TITLE
chore(933151,933152,933153): cleaning useless variables

### DIFF
--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -586,7 +586,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|X
     capture,\
     t:none,\
     msg:'PHP Injection Attack: Medium-Risk PHP Function Name Found',\
-    logdata:'Matched Data: %{TX.0} found within %{TX.933151_MATCHED_VAR_NAME}: %{TX.933151_MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-php',\
     tag:'platform-multi',\
@@ -597,8 +597,6 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|X
     tag:'capec/1000/152/242',\
     ver:'OWASP_CRS/4.23.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.933151_matched_var=%{MATCHED_VAR}',\
-    setvar:'tx.933151_matched_var_name=%{MATCHED_VAR_NAME}',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
@@ -616,7 +614,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|X
     capture,\
     t:none,\
     msg:'PHP Injection Attack: Medium-Risk PHP Function Name Found',\
-    logdata:'Matched Data: %{TX.0} found within %{TX.933152_MATCHED_VAR_NAME}: %{TX.933152_MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-php',\
     tag:'platform-multi',\
@@ -627,8 +625,6 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|X
     tag:'capec/1000/152/242',\
     ver:'OWASP_CRS/4.23.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.933152_matched_var=%{MATCHED_VAR}',\
-    setvar:'tx.933152_matched_var_name=%{MATCHED_VAR_NAME}',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
@@ -646,7 +642,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|X
     capture,\
     t:none,\
     msg:'PHP Injection Attack: Medium-Risk PHP Function Name Found',\
-    logdata:'Matched Data: %{TX.0} found within %{TX.933153_MATCHED_VAR_NAME}: %{TX.933153_MATCHED_VAR}',\
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-php',\
     tag:'platform-multi',\
@@ -657,8 +653,6 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|X
     tag:'capec/1000/152/242',\
     ver:'OWASP_CRS/4.23.0-dev',\
     severity:'CRITICAL',\
-    setvar:'tx.933153_matched_var=%{MATCHED_VAR}',\
-    setvar:'tx.933153_matched_var_name=%{MATCHED_VAR_NAME}',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 


### PR DESCRIPTION
## Proposed changes

Hello, these variables are no longer useful either in the current state of the new rules.

<!-- Github Tip: adding the text 'Fixes #<issue>' or 'Closes #<issue>' will automatically close the mentioned issue. -->

## PR Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x ] I have read the [CONTRIBUTING](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/CONTRIBUTING.md) doc
- [ ] I have added positive tests proving my fix/feature works as intended.
- [ ] I have added negative tests that prove my fix/feature considers common cases that might end in false positives
- [ ] In case you changed a regular expression, you are not adding a ReDOS for pcre. You can check this using [regexploit](https://github.com/doyensec/regexploit)
- [ ] My test use the `comment` field to write the expected behavior
- [ ] I have added documentation for the rule or change (when appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... If there are no additional comments, you may remove this section. -->

## For the reviewer

<!-- Don't remove this part. Reviewers will use it as guidance for the review process. -->

- [ ] Positive and negative tests were added
- [ ] Tests cover the intended fix/feature properly
- [ ] No usage of dangerous constructs like `ctl:requestBodyAccess=Off` were used in the rule
- [ ] In case a regular expression was changed, [there is no ReDOS](https://github.com/coreruleset/coreruleset/wiki/Testing-for-Regular-Expresion-DoS)
- [ ] Documentation is clear for the rule/change
