### PR TITLE
fix: remove Request-Range Header from rules

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -307,7 +307,7 @@ SecRule &REQUEST_HEADERS:Transfer-Encoding "!@eq 0" \
 # https://datatracker.ietf.org/doc/html/rfc7233
 # https://seclists.org/fulldisclosure/2011/Aug/175
 #
-SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx (\d+)-(\d+)" \
+SecRule REQUEST_HEADERS:Range "@rx (\d+)-(\d+)" \
     "id:920190,\
     phase:1,\
     block,\
@@ -1361,7 +1361,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:920014,phase:2,pass,nolog,tag:'O
 # https://httpd.apache.org/security/CVE-2011-3192.txt
 
 
-SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d+)?-(?:\d+)?\s*,?\s*){6}" \
+SecRule REQUEST_HEADERS:Range "@rx ^bytes=(?:(?:\d+)?-(?:\d+)?\s*,?\s*){6}" \
     "id:920200,\
     phase:1,\
     block,\
@@ -1404,7 +1404,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     ver:'OWASP_CRS/4.23.0-dev',\
     severity:'WARNING',\
     chain"
-    SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d+)?-(?:\d+)?\s*,?\s*){63}" \
+    SecRule REQUEST_HEADERS:Range "@rx ^bytes=(?:(?:\d+)?-(?:\d+)?\s*,?\s*){63}" \
         "setvar:'tx.inbound_anomaly_score_pl2=+%{tx.warning_anomaly_score}'"
 
 
@@ -1816,7 +1816,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     ver:'OWASP_CRS/4.23.0-dev',\
     severity:'WARNING',\
     chain"
-    SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d+)?-(?:\d+)?\s*,?\s*){6}" \
+    SecRule REQUEST_HEADERS:Range "@rx ^bytes=(?:(?:\d+)?-(?:\d+)?\s*,?\s*){6}" \
         "setvar:'tx.inbound_anomaly_score_pl4=+%{tx.warning_anomaly_score}'"
 
 

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920190.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920190.yaml
@@ -40,20 +40,3 @@ tests:
         output:
           log:
             expect_ids: [920190]
-  - test_id: 3
-    desc: "Status Page Test - Request-Range header field with range end less than range start"
-    stages:
-      - input:
-          dest_addr: "127.0.0.1"
-          method: "GET"
-          port: 80
-          headers:
-            User-Agent: "OWASP CRS test agent"
-            Host: "localhost"
-            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            Request-Range: bytes=64-0
-          uri: "/"
-          version: "HTTP/1.1"
-        output:
-          log:
-            expect_ids: [920190]

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920200.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920200.yaml
@@ -18,23 +18,7 @@ tests:
         output:
           log:
             expect_ids: [920200]
-  - # Sample taken from https://github.com/alienwithin/php-utilities/blob/master/apache-byte-range-server-dos/apache_byte_range_server_dos.php
-    test_id: 2
-    stages:
-      - input:
-          dest_addr: "127.0.0.1"
-          port: 80
-          headers:
-            User-Agent: "OWASP CRS test agent"
-            Host: "localhost"
-            Request-Range: "bytes=5-0,1-1,2-2,3-3,4-4,5-5,6-6,7-7,8-8,9-9,10-10,11-11"
-            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-          uri: "/"
-          version: "HTTP/1.1"
-        output:
-          log:
-            expect_ids: [920200]
-  - test_id: 3
+  - test_id: 2
     stages:
       - input:
           dest_addr: "127.0.0.1"
@@ -49,7 +33,7 @@ tests:
         output:
           log:
             no_expect_ids: [920200]
-  - test_id: 4
+  - test_id: 3
     stages:
       - input:
           dest_addr: "127.0.0.1"
@@ -64,7 +48,7 @@ tests:
         output:
           log:
             expect_ids: [920200]
-  - test_id: 5
+  - test_id: 4
     stages:
       - input:
           dest_addr: "127.0.0.1"
@@ -79,7 +63,7 @@ tests:
         output:
           log:
             expect_ids: [920200]
-  - test_id: 6
+  - test_id: 5
     desc: 'Range: Too many fields (920200) from old modsec regressions'
     stages:
       - input:
@@ -100,7 +84,7 @@ tests:
         output:
           log:
             expect_ids: [920200]
-  - test_id: 7
+  - test_id: 6
     desc: This should PASS (PL2)
     stages:
       - input:
@@ -117,7 +101,7 @@ tests:
         output:
           log:
             no_expect_ids: [920200]
-  - test_id: 8
+  - test_id: 7
     desc: "This should FAIL with rule 920200 (PL2)"
     stages:
       - input:
@@ -134,7 +118,7 @@ tests:
         output:
           log:
             expect_ids: [920200]
-  - test_id: 9
+  - test_id: 8
     desc: This should PASS (PL2)
     stages:
       - input:
@@ -151,7 +135,7 @@ tests:
         output:
           log:
             no_expect_ids: [920200]
-  - test_id: 10
+  - test_id: 9
     desc: This should PASS (PL2)
     stages:
       - input:


### PR DESCRIPTION
# What
* Removing Obsolete Request-Range Header

# Why
* The Request-Range header is a legacy/non-standard HTTP header that dates back to Netscape Navigator 2-3 and MSIE 3 (~1996-1997). It was never part of any HTTP RFC and has no legitimate use in modern web traffic.