### PR TITLE
fix(920650): don't block on method override if it's not actually being overwritten

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1642,9 +1642,12 @@ SecRule TX:allow_method_override_parameter "@eq 0" \
     ver:'OWASP_CRS/4.24.0-dev',\
     severity:'CRITICAL',\
     chain"
-    SecRule ARGS:_method "@rx ^[a-z]{3,10}$" \
-        "t:none,t:urlDecodeUni,t:lowercase,\
-        setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+    SecRule REQUEST_METHOD "!@streq %{ARGS._method}" \
+        "t:none,t:lowercase,\
+        chain"
+        SecRule ARGS:_method "@rx ^[a-z]{3,10}$" \
+            "t:none,t:urlDecodeUni,t:lowercase,\
+            setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:920015,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.24.0-dev',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 3" "id:920016,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.24.0-dev',skipAfter:END-REQUEST-920-PROTOCOL-ENFORCEMENT"

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920650.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920650.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "fzipi"
+  author: "fzipi, Esad Cetiner"
   description: "Tests for HTTP method override via _method parameter detection (920650)"
 
 rule_id: 920650
@@ -599,3 +599,22 @@ tests:
         output:
           log:
             expect_ids: [920650]
+
+  - test_id: 36
+    desc: |
+      Logging out of GitLab, HTTP override method is same as actual request method.
+      This is usually harmless since no method is actually being overwritten.
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          port: 80
+          method: "POST"
+          uri: "/users/sign_out"
+          data: "_method=post&authenticity_token=something"
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: "localhost"
+            Accept: "*/*"
+        output:
+          log:
+            no_expect_ids: [920650]


### PR DESCRIPTION

## Proposed changes

GitLab, and possibly some other applications sometimes always sets the `_method` override even when the intent isn't actually to override a method. When signing out of GitLab, a POST request is sent to `/users/sign_out` with `_method=post` in the request body. This change should not have any security impact and make `920650` a bit easier to work with.

<!-- Github Tip: adding the text 'Fixes #<issue>' or 'Closes #<issue>' will automatically close the mentioned issue. -->

## PR Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/CONTRIBUTING.md) doc
- [ ] I have added positive tests proving my fix/feature works as intended.
- [x] I have added negative tests that prove my fix/feature considers common cases that might end in false positives
- [ ] In case you changed a regular expression, you are not adding a ReDOS for pcre. You can check this using [regexploit](https://github.com/doyensec/regexploit)
- [x] My test use the `comment` field to write the expected behavior
- [x] I have added documentation for the rule or change (when appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... If there are no additional comments, you may remove this section. -->

## For the reviewer

<!-- Don't remove this part. Reviewers will use it as guidance for the review process. -->

- [ ] Positive and negative tests were added
- [ ] Tests cover the intended fix/feature properly
- [ ] No usage of dangerous constructs like `ctl:requestBodyAccess=Off` were used in the rule
- [ ] In case a regular expression was changed, [there is no ReDOS](https://github.com/coreruleset/coreruleset/wiki/Testing-for-Regular-Expresion-DoS)
- [ ] Documentation is clear for the rule/change
