### PR TITLE
fix: handle multi-byte UTF-8 chars in SQL special char detection

### DIFF
--- a/regex-assembly/942420.ra
+++ b/regex-assembly/942420.ra
@@ -1,0 +1,15 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Rule 942420: Restricted SQL Character Anomaly Detection (cookies)
+##! Matches when 8 or more special characters appear.
+##! See: https://github.com/coreruleset/coreruleset/issues/3325
+
+##!> include sql-special-chars-anomaly
+
+##!^ (
+##!$ {8})
+
+##!> assemble
+  ##!=> sql-special-chars-anomaly
+##!<

--- a/regex-assembly/942421.ra
+++ b/regex-assembly/942421.ra
@@ -1,0 +1,16 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Rule 942421: Restricted SQL Character Anomaly Detection (cookies)
+##! Stricter sibling of rule 942420 (PL4).
+##! Matches when 3 or more special characters appear.
+##! See: https://github.com/coreruleset/coreruleset/issues/3325
+
+##!> include sql-special-chars-anomaly
+
+##!^ (
+##!$ {3})
+
+##!> assemble
+  ##!=> sql-special-chars-anomaly
+##!<

--- a/regex-assembly/942430.ra
+++ b/regex-assembly/942430.ra
@@ -1,0 +1,15 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Rule 942430: Restricted SQL Character Anomaly Detection (args)
+##! Matches when 12 or more special characters appear.
+##! See: https://github.com/coreruleset/coreruleset/issues/3325
+
+##!> include sql-special-chars-anomaly
+
+##!^ (
+##!$ {12})
+
+##!> assemble
+  ##!=> sql-special-chars-anomaly
+##!<

--- a/regex-assembly/942431.ra
+++ b/regex-assembly/942431.ra
@@ -1,0 +1,17 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Rule 942431: Restricted SQL Character Anomaly Detection (args)
+##! Stricter sibling of rule 942430 (PL3).
+##! Matches when 6 or more special characters appear.
+##! Also triggered by: SAP CRM Java vulnerability CVE-2018-2380
+##! See: https://github.com/coreruleset/coreruleset/issues/3325
+
+##!> include sql-special-chars-anomaly
+
+##!^ (
+##!$ {6})
+
+##!> assemble
+  ##!=> sql-special-chars-anomaly
+##!<

--- a/regex-assembly/942432.ra
+++ b/regex-assembly/942432.ra
@@ -1,0 +1,17 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Rule 942432: Restricted SQL Character Anomaly Detection (args)
+##! Stricter sibling of rule 942430 (PL4).
+##! Matches when 2 or more special characters appear.
+##! Also triggered by: SAP CRM Java vulnerability CVE-2018-2380
+##! See: https://github.com/coreruleset/coreruleset/issues/3325
+
+##!> include sql-special-chars-anomaly
+
+##!^ (
+##!$ {2})
+
+##!> assemble
+  ##!=> sql-special-chars-anomaly
+##!<

--- a/regex-assembly/include/sql-special-chars-anomaly.ra
+++ b/regex-assembly/include/sql-special-chars-anomaly.ra
@@ -1,0 +1,38 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Shared definitions for the SQL special character anomaly detection rules
+##! (942420, 942421, 942430, 942431, 942432).
+##!
+##! These rules detect SQL injection attempts by counting special characters.
+##!
+##! UTF-8 multi-byte characters (U+00B4, U+2018, U+2019) are specified as
+##! alternations outside character classes to prevent byte-by-byte matching
+##! which causes false positives with non-Latin scripts.
+##! See: https://github.com/coreruleset/coreruleset/issues/3325
+
+##! ASCII special characters commonly used in SQL injection.
+##!> define ascii-special [~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'`<>]
+
+##! Negated ASCII class (multi-byte bytes pass through as non-special)
+##!> define non-special [^~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'`<>]
+
+##! Special character alternation: ASCII class plus UTF-8 quote-like chars
+##!   U+00B4 ACUTE ACCENT           -> \xC2\xB4
+##!   U+2018 LEFT SINGLE QUOTATION  -> \xE2\x80\x98
+##!   U+2019 RIGHT SINGLE QUOTATION -> \xE2\x80\x99
+##!> assemble
+  {{ascii-special}}
+  \xC2\xB4
+  \xE2\x80\x98
+  \xE2\x80\x99
+  ##!=< sql-special-chars
+##!<
+
+##! Full anomaly unit: one special char followed by any non-special chars
+##!> assemble
+  ##!=> sql-special-chars
+  ##!=>
+  {{non-special}}*?
+  ##!=< sql-special-chars-anomaly
+##!<

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1296,7 +1296,12 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_HEADERS|ARGS_NAMES|ARGS|XM
 # SecRuleUpdateTargetById 942430 "!ARGS:foo"
 #
 
-SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'´’‘`<>][^~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'´’‘`<>]*?){12})" \
+# Regular expression generated from regex-assembly/942430.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 942430
+#
+SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:(?:[!-\+\-:->@\[\]\^`\{-~]|\x{c2}\x{b4}|\x{e2}\x80[\x98\x99])[^!-\+\-:->@\[\]\^`\{-~]*?){12})" \
     "id:942430,\
     phase:2,\
     block,\
@@ -1725,7 +1730,12 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx [\"'`]
 # SecRuleUpdateTargetById 942420 "!REQUEST_COOKIES:foo_id"
 #
 
-SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'´’‘`<>][^~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'´’‘`<>]*?){8})" \
+# Regular expression generated from regex-assembly/942420.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 942420
+#
+SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES "@rx ((?:(?:[!-\+\-:->@\[\]\^`\{-~]|\x{c2}\x{b4}|\x{e2}\x80[\x98\x99])[^!-\+\-:->@\[\]\^`\{-~]*?){8})" \
     "id:942420,\
     phase:1,\
     block,\
@@ -1754,7 +1764,12 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\
 # [ SAP CRM Java vulnerability CVE-2018-2380 - Exploit tested: https://www.exploit-db.com/exploits/44292 ]
 #
 
-SecRule ARGS_NAMES|!ARGS_NAMES:/^[\w]+\[[\w\-]+\]\[[\w\-]*?\]$/|!ARGS_NAMES:/^[\w]+\[[\w\-]+\]\[[\w\-]+\]\[[\w\-]*?\]$/|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'´’‘`<>][^~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'´’‘`<>]*?){6})" \
+# Regular expression generated from regex-assembly/942431.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 942431
+#
+SecRule ARGS_NAMES|!ARGS_NAMES:/^[\w]+\[[\w\-]+\]\[[\w\-]*?\]$/|!ARGS_NAMES:/^[\w]+\[[\w\-]+\]\[[\w\-]+\]\[[\w\-]*?\]$/|ARGS|XML:/* "@rx ((?:(?:[!-\+\-:->@\[\]\^`\{-~]|\x{c2}\x{b4}|\x{e2}\x80[\x98\x99])[^!-\+\-:->@\[\]\^`\{-~]*?){6})" \
     "id:942431,\
     phase:2,\
     block,\
@@ -1907,7 +1922,12 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:942018,phase:2,pass,nolog,tag:'O
 # This is a stricter sibling of rule 942420.
 #
 
-SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'´’‘`<>][^~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'´’‘`<>]*?){3})" \
+# Regular expression generated from regex-assembly/942421.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 942421
+#
+SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES "@rx ((?:(?:[!-\+\-:->@\[\]\^`\{-~]|\x{c2}\x{b4}|\x{e2}\x80[\x98\x99])[^!-\+\-:->@\[\]\^`\{-~]*?){3})" \
     "id:942421,\
     phase:1,\
     block,\
@@ -1936,7 +1956,12 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\
 # [ SAP CRM Java vulnerability CVE-2018-2380 - Exploit tested: https://www.exploit-db.com/exploits/44292 ]
 #
 
-SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'´’‘`<>][^~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\|:;\"'´’‘`<>]*?){2})" \
+# Regular expression generated from regex-assembly/942432.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 942432
+#
+SecRule ARGS_NAMES|ARGS|XML:/* "@rx ((?:(?:[!-\+\-:->@\[\]\^`\{-~]|\x{c2}\x{b4}|\x{e2}\x80[\x98\x99])[^!-\+\-:->@\[\]\^`\{-~]*?){2})" \
     "id:942432,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942420.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942420.yaml
@@ -1,22 +1,203 @@
 ---
 meta:
-  author: "Christian S.J. Peron, azurit"
+  author: "Christian S.J. Peron, azurit, fzipitria"
+  description: "Tests for rule 942420 - SQL Character Anomaly Detection in cookies (8+ special chars)"
 rule_id: 942420
 tests:
   - test_id: 1
-    desc: "Restricted SQL Character Anomaly Detection (cookies): # of special characters exceeded (8)"
+    desc: "Basic SQL injection in cookie with 8+ special characters"
     stages:
       - input:
           dest_addr: 127.0.0.1
           headers:
             Host: localhost
-            Cookie: "ar=%7e%7e%7e%7e%7e%7e%7e%7e%7e&foo=var"
+            Cookie: "ar=~~~~~~~~~&foo=var"
             User-Agent: "OWASP CRS test agent"
             Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
           method: POST
           port: 80
           uri: "/post"
-          version: HTTP/1.1
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [942420]
+
+  - test_id: 2
+    desc: "SQL injection in cookie with various special characters (8+)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Cookie: "session=' OR '1'='x'--##"
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [942420]
+
+  - test_id: 3
+    desc: "SQL injection in cookie with UTF-8 right single quotation mark (U+2019)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Cookie: "id=\u2019 OR \u20191\u2019=\u2019x\u2019--##"
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [942420]
+
+  - test_id: 4
+    desc: "SQL injection in cookie with UTF-8 left single quotation mark (U+2018)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Cookie: "id=\u2018 OR \u20181\u2018=\u2018x\u2018--##"
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [942420]
+
+  - test_id: 5
+    desc: "Exactly 8 special characters in cookie (edge case - should match)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Cookie: "test=!@#$%^&*"
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [942420]
+
+  - test_id: 6
+    desc: "NEGATIVE: Only 7 special characters in cookie (just below threshold)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Cookie: "test=!@#$%^&"
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942420]
+
+  - test_id: 7
+    desc: "NEGATIVE: Chinese text in cookie (should not match - no false positives)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Cookie: "pref=你好世界"
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942420]
+
+  - test_id: 8
+    desc: "NEGATIVE: Japanese text in cookie (should not match - no false positives)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Cookie: "pref=こんにちは"
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942420]
+
+  - test_id: 9
+    desc: "NEGATIVE: Normal session token in cookie"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Cookie: "session=a1b2c3d4e5f6g7h8i9j0"
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942420]
+
+  - test_id: 10
+    desc: "NEGATIVE: JWT token in cookie"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Cookie: "token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942420]
+
+  - test_id: 11
+    desc: "Cookie name with special characters (should detect in names too)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Cookie: "'!@#$%^&*=value"
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          version: "HTTP/1.1"
         output:
           log:
             expect_ids: [942420]

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942421.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942421.yaml
@@ -1,10 +1,11 @@
 ---
 meta:
-  author: "Christian S.J. Peron, azurit"
+  author: "Christian S.J. Peron, azurit, fzipitria"
+  description: "Tests for rule 942421 - SQL Character Anomaly Detection in cookies (3+ special chars) - PL4"
 rule_id: 942421
 tests:
   - test_id: 1
-    desc: "Restricted SQL Character Anomaly Detection (cookies): # of special characters exceeded (3)"
+    desc: "Basic SQL injection in cookie with 3+ special characters"
     stages:
       - input:
           dest_addr: 127.0.0.1
@@ -16,7 +17,115 @@ tests:
           method: GET
           port: 80
           uri: "/get"
-          version: HTTP/1.1
+          version: "HTTP/1.1"
         output:
           log:
             expect_ids: [942421]
+
+  - test_id: 2
+    desc: "SQL injection in cookie with UTF-8 right single quotation mark (U+2019)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Cookie: "id=\u2019 #-"
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: GET
+          port: 80
+          uri: "/get"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [942421]
+
+  - test_id: 3
+    desc: "Exactly 3 special characters in cookie (edge case - should match)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Cookie: "test=!@#"
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: GET
+          port: 80
+          uri: "/get"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [942421]
+
+  - test_id: 4
+    desc: "NEGATIVE: Only 2 special characters in cookie (just below threshold)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Cookie: "test=!@"
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: GET
+          port: 80
+          uri: "/get"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942421]
+
+  - test_id: 5
+    desc: "NEGATIVE: Chinese text in cookie (should not match - no false positives)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Cookie: "pref=你好"
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: GET
+          port: 80
+          uri: "/get"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942421]
+
+  - test_id: 6
+    desc: "NEGATIVE: Japanese text in cookie (should not match - no false positives)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Cookie: "pref=こんにちは"
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: GET
+          port: 80
+          uri: "/get"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942421]
+
+  - test_id: 7
+    desc: "NEGATIVE: Normal alphanumeric cookie"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Cookie: "session=abc123def456"
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: GET
+          port: 80
+          uri: "/get"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942421]

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942430.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942430.yaml
@@ -1,10 +1,11 @@
 ---
 meta:
-  author: "Christian S.J. Peron, azurit"
+  author: "Christian S.J. Peron, azurit, fzipitria"
+  description: "Tests for rule 942430 - SQL Character Anomaly Detection (12+ special chars)"
 rule_id: 942430
 tests:
   - test_id: 1
-    desc: "Restricted SQL Character Anomaly Detection (args): # of special characters exceeded (12)"
+    desc: "Basic SQL injection with 12 special characters (parentheses)"
     stages:
       - input:
           dest_addr: 127.0.0.1
@@ -15,8 +16,278 @@ tests:
           method: POST
           port: 80
           uri: "/post"
-          data: "var=(((((())))))&var2=whatever"
-          version: HTTP/1.1
+          data: "var=%28%28%28%28%28%28%29%29%29%29%29%29&var2=whatever"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [942430]
+
+  - test_id: 2
+    desc: "SQL injection with various special characters (12+)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "id=1%27%20OR%20%271%27%3d%27x%27%23%3b%2d%2d%28%29%21"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [942430]
+
+  - test_id: 3
+    desc: "SQL injection with UTF-8 right single quotation mark (U+2019) and other special chars"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "id=1%E2%80%99%20OR%20%E2%80%991%E2%80%99%3d%E2%80%99x%E2%80%99%23%3b%2d%2d%28%29"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [942430]
+
+  - test_id: 4
+    desc: "SQL injection with UTF-8 left single quotation mark (U+2018) and special chars"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "id=1%E2%80%98%20OR%20%E2%80%981%E2%80%98%3d%E2%80%98x%E2%80%98%23%3b%2d%2d%28%29"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [942430]
+
+  - test_id: 5
+    desc: "SQL injection with UTF-8 acute accent (U+00B4) and special chars"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "id=1%C2%B4%20OR%20%C2%B41%C2%B4%3d%C2%B4x%C2%B4%23%3b%2d%2d%28%29"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [942430]
+
+  - test_id: 6
+    desc: "Exactly 12 special characters (edge case - should match)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "var=%21%40%23%24%25%5e%26%2a%28%29%2d%3d"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [942430]
+
+  - test_id: 7
+    desc: "NEGATIVE: Only 11 special characters (just below threshold)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "var=%21%40%23%24%25%5e%26%2a%28%29%2d"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942430]
+
+  - test_id: 8
+    desc: "NEGATIVE: Chinese text (should not match - no false positives)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "comment=%e4%bd%a0%e5%a5%bd%e4%b8%96%e7%95%8c%e8%bf%99%e6%98%af%e4%b8%80%e6%ae%b5%e4%b8%ad%e6%96%87%e6%96%87%e6%9c%ac"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942430]
+
+  - test_id: 9
+    desc: "NEGATIVE: Japanese text (should not match - no false positives)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "comment=%e3%81%93%e3%82%93%e3%81%ab%e3%81%a1%e3%81%af%e4%b8%96%e7%95%8c%e3%81%93%e3%82%8c%e3%81%af%e6%97%a5%e6%9c%ac%e8%aa%9e%e3%81%ae%e3%83%86%e3%82%ad%e3%82%b9%e3%83%88%e3%81%a7%e3%81%99"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942430]
+
+  - test_id: 10
+    desc: "NEGATIVE: Arabic text (should not match - no false positives)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "comment=%d8%a7%d9%84%d8%b3%d9%84%d8%a7%d9%85%20%d8%b9%d9%84%d9%8a%d9%83%d9%85%20%d9%87%d8%b0%d8%a7%20%d9%86%d8%b5%20%d8%b9%d8%b1%d8%a8%d9%8a"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942430]
+
+  - test_id: 11
+    desc: "NEGATIVE: Hebrew text (should not match - no false positives)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "comment=%d7%a9%d7%9c%d7%95%d7%9d%20%d7%a2%d7%95%d7%9c%d7%9d%20%d7%96%d7%94%20%d7%98%d7%a7%d7%a1%d7%98%20%d7%91%d7%a2%d7%91%d7%a8%d7%99%d7%aa"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942430]
+
+  - test_id: 12
+    desc: "NEGATIVE: Korean text (should not match - no false positives)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "comment=%ec%95%88%eb%85%95%ed%95%98%ec%84%b8%ec%9a%94%20%ec%84%b8%ea%b3%84%20%ec%9d%b4%ea%b2%83%ec%9d%80%20%ed%95%9c%ea%b5%ad%ec%96%b4%20%ed%85%8d%ec%8a%a4%ed%8a%b8%ec%9e%85%eb%8b%88%eb%8b%a4"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942430]
+
+  - test_id: 13
+    desc: "NEGATIVE: High-entropy base64 data (should not match)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "token=SGVsbG9Xb3JsZFRoaXNJc0FCYXNlNjRFbmNvZGVkU3RyaW5n"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942430]
+
+  - test_id: 14
+    desc: "NEGATIVE: SHA256 hash (should not match)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "hash=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942430]
+
+  - test_id: 15
+    desc: "NEGATIVE: Normal English text with some punctuation"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "comment=Hello%2c%20world%21%20This%20is%20a%20test."
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942430]
+
+  - test_id: 16
+    desc: "Mixed special characters typical in SQL injection"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "query=%27%3bSELECT%2a%40%40version%23%2d%2d%28%29%7b%7d"
+          version: "HTTP/1.1"
         output:
           log:
             expect_ids: [942430]

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942431.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942431.yaml
@@ -1,10 +1,11 @@
 ---
 meta:
-  author: "Christian S.J. Peron, azurit, touchweb_vincent"
+  author: "Christian S.J. Peron, azurit, touchweb_vincent, fzipitria"
+  description: "Tests for rule 942431 - SQL Character Anomaly Detection (6+ special chars) - PL3"
 rule_id: 942431
 tests:
   - test_id: 1
-    desc: "Restricted SQL Character Anomaly Detection (args): # of special characters exceeded (6)"
+    desc: "Basic SQL injection with 6+ special characters"
     stages:
       - input:
           dest_addr: 127.0.0.1
@@ -16,12 +17,13 @@ tests:
           port: 80
           uri: "/post"
           data: "var=-------------------&var2=whatever"
-          version: HTTP/1.1
+          version: "HTTP/1.1"
         output:
           log:
             expect_ids: [942431]
+
   - test_id: 2
-    desc: "Avoid blocking on three-dimensional arrays"
+    desc: "NEGATIVE: Avoid blocking on three-dimensional arrays"
     stages:
       - input:
           dest_addr: 127.0.0.1
@@ -32,13 +34,14 @@ tests:
           method: POST
           port: 80
           uri: "/post"
-          data: "order[filters][date_add][from]=1"
-          version: HTTP/1.1
+          data: "order%5bfilters%5d%5bdate_add%5d%5bfrom%5d=1"
+          version: "HTTP/1.1"
         output:
           log:
             no_expect_ids: [942431]
+
   - test_id: 3
-    desc: "Avoid blocking on bi-dimensional arrays"
+    desc: "NEGATIVE: Avoid blocking on bi-dimensional arrays"
     stages:
       - input:
           dest_addr: 127.0.0.1
@@ -49,8 +52,116 @@ tests:
           method: POST
           port: 80
           uri: "/post"
-          data: "order[add-to-cart][]=1"
-          version: HTTP/1.1
+          data: "order%5badd-to-cart%5d%5b%5d=1"
+          version: "HTTP/1.1"
         output:
           log:
             no_expect_ids: [942431]
+
+  - test_id: 4
+    desc: "SQL injection with UTF-8 right single quotation mark (U+2019)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "id=%E2%80%99%20OR%20%E2%80%991%3d1%23%3b%2d%2d"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [942431]
+
+  - test_id: 5
+    desc: "Exactly 6 special characters (edge case - should match)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "var=%21%40%23%24%25%5e"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [942431]
+
+  - test_id: 6
+    desc: "NEGATIVE: Only 5 special characters (just below threshold)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "var=%21%40%23%24%25"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942431]
+
+  - test_id: 7
+    desc: "NEGATIVE: Chinese text (should not match - no false positives)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "comment=%e4%bd%a0%e5%a5%bd%e4%b8%96%e7%95%8c"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942431]
+
+  - test_id: 8
+    desc: "NEGATIVE: Japanese text (should not match - no false positives)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "comment=%e3%81%93%e3%82%93%e3%81%ab%e3%81%a1%e3%81%af"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942431]
+
+  - test_id: 9
+    desc: "SQL injection with mixed special characters"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "q=%27%3b%40%40%23%2d%2d"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [942431]

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942432.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942432.yaml
@@ -1,10 +1,11 @@
 ---
 meta:
-  author: "Christian S.J. Peron, azurit"
+  author: "Christian S.J. Peron, azurit, fzipitria"
+  description: "Tests for rule 942432 - SQL Character Anomaly Detection (2+ special chars) - PL4"
 rule_id: 942432
 tests:
   - test_id: 1
-    desc: "Restricted SQL Character Anomaly Detection (args): # of special characters exceeded (2)"
+    desc: "Basic SQL injection with 2+ special characters"
     stages:
       - input:
           dest_addr: 127.0.0.1
@@ -15,8 +16,152 @@ tests:
           method: POST
           port: 80
           uri: "/post"
-          data: "var=;;dd foo bar"
-          version: HTTP/1.1
+          data: "var=%3b%3bdd%20foo%20bar"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [942432]
+
+  - test_id: 2
+    desc: "SQL injection with UTF-8 right single quotation mark (U+2019)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "id=%E2%80%99%20%23"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [942432]
+
+  - test_id: 3
+    desc: "SQL injection with UTF-8 left single quotation mark (U+2018)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "id=%E2%80%98%20%2d"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [942432]
+
+  - test_id: 4
+    desc: "Exactly 2 special characters (edge case - should match)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "var=%21%40"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [942432]
+
+  - test_id: 5
+    desc: "NEGATIVE: Only 1 special character (below threshold)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "var=%21"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942432]
+
+  - test_id: 6
+    desc: "NEGATIVE: Chinese text (should not match - no false positives)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "comment=%e4%bd%a0%e5%a5%bd"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942432]
+
+  - test_id: 7
+    desc: "NEGATIVE: Japanese text (should not match - no false positives)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "comment=%e3%81%93%e3%82%93"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942432]
+
+  - test_id: 8
+    desc: "NEGATIVE: Normal text with one punctuation"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "comment=Hello%2c%20world"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [942432]
+
+  - test_id: 9
+    desc: "SQL comment sequence"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "q=%27%2d%2d"
+          version: "HTTP/1.1"
         output:
           log:
             expect_ids: [942432]


### PR DESCRIPTION
## what

- Extract multi-byte UTF-8 characters (´ U+00B4, ' U+2018, ' U+2019) from regex character classes into alternations to prevent byte-by-byte matching that caused false positives with non-Latin scripts (Chinese, Japanese, Arabic, Korean, Hebrew)
- Affects rules: 942420, 942421, 942430, 942431, 942432
- Creates shared `regex-assembly/include/sql-special-chars-anomaly.ra` include file and composable `.ra` files for all 5 rules using named assemblies

## Test plan
- [x] All 52 regression tests pass across 5 rules (942420, 942421, 942430, 942431, 942432)
- [x] `crs-toolchain regex compare` confirms generated regex matches for all 5 rules
- [x] Tests cover: ASCII special chars, multi-byte UTF-8 special chars (´ ' '), and negative tests for non-Latin scripts (Chinese, Japanese, Arabic, Korean, Hebrew)
- [x] CI passes

## refs

- Fixes #3325