### PR TITLE
refactor(951110): convert Access leakage rule to regex-assembly

### DIFF
--- a/regex-assembly/951110.ra
+++ b/regex-assembly/951110.ra
@@ -1,0 +1,8 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##!+ i
+
+JET Database Engine
+Access Database Engine
+\[Microsoft\]\[ODBC Microsoft Access Driver\]

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -51,7 +51,12 @@ SecRule RESPONSE_BODY "!@pmFromFile sql-errors.data" \
     ver:'OWASP_CRS/4.24.0-dev',\
     skipAfter:END-SQL-ERROR-MATCH-PL1"
 
-SecRule RESPONSE_BODY "@rx (?i:JET Database Engine|Access Database Engine|\[Microsoft\]\[ODBC Microsoft Access Driver\])" \
+# Regular expression generated from regex-assembly/951110.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 951110
+#
+SecRule RESPONSE_BODY "@rx (?i)(?:JET|Access) Database Engine|\[Microsoft\]\[ODBC Microsoft Access Driver\]" \
     "id:951110,\
     phase:4,\
     block,\


### PR DESCRIPTION
## what

- add regex-assembly/951110.ra with all 3 Microsoft Access SQL information leakage patterns 

## why 

- enable crs-toolchain management
