### PR TITLE
refactor(951140): convert EMC leakage rule to regex-assembly

### DIFF
--- a/regex-assembly/951140.ra
+++ b/regex-assembly/951140.ra
@@ -1,0 +1,7 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##!+ i
+
+\[DM_QUERY_E_SYNTAX\]
+has occurred in the vicinity of:

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -119,7 +119,12 @@ SecRule RESPONSE_BODY "@rx (?i:DB2 SQL error:|\[IBM\]\[CLI Driver\]\[DB2/6000\]|
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
-SecRule RESPONSE_BODY "@rx (?i:\[DM_QUERY_E_SYNTAX\]|has occurred in the vicinity of:)" \
+# Regular expression generated from regex-assembly/951140.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 951140
+#
+SecRule RESPONSE_BODY "@rx (?i)\[DM_QUERY_E_SYNTAX\]|has occurred in the vicinity of:" \
     "id:951140,\
     phase:4,\
     block,\


### PR DESCRIPTION
## what

- add regex-assembly/951140.ra with both EMC SQL information leakage patterns

## why

- enable crs-toolchain management
