### PR TITLE
refactor(951180): convert Informix leakage rule to regex-assembly

### DIFF
--- a/regex-assembly/951180.ra
+++ b/regex-assembly/951180.ra
@@ -1,0 +1,8 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##!+ i
+
+An illegal character has been found in the statement
+com\.informix\.jdbc
+Exception.*Informix

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -203,7 +203,12 @@ SecRule RESPONSE_BODY "@rx (?i)org\.hsqldb\.jdbc" \
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
-SecRule RESPONSE_BODY "@rx (?i:An illegal character has been found in the statement|com\.informix\.jdbc|Exception.*Informix)" \
+# Regular expression generated from regex-assembly/951180.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 951180
+#
+SecRule RESPONSE_BODY "@rx (?i)An illegal character has been found in the statement|com\.informix\.jdbc|Exception.*Informix" \
     "id:951180,\
     phase:4,\
     block,\


### PR DESCRIPTION
## what

- add regex-assembly/951180.ra with all 3 Informix SQL information leakage patterns

## why

- enable crs-toolchain management
