### PR TITLE
refactor(951190): convert Ingres leakage rule to regex-assembly

### DIFF
--- a/regex-assembly/951190.ra
+++ b/regex-assembly/951190.ra
@@ -1,0 +1,8 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##!+ i
+
+Warning.*ingres_
+Ingres SQLSTATE
+Ingres\W.*Driver

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -224,7 +224,12 @@ SecRule RESPONSE_BODY "@rx (?i:An illegal character has been found in the statem
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
-SecRule RESPONSE_BODY "@rx (?i:Warning.*ingres_|Ingres SQLSTATE|Ingres\W.*Driver)" \
+# Regular expression generated from regex-assembly/951190.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 951190
+#
+SecRule RESPONSE_BODY "@rx (?i)Warning.*ingres_|Ingres(?: SQLSTATE|[^0-9A-Z_a-z].*Driver)" \
     "id:951190,\
     phase:4,\
     block,\


### PR DESCRIPTION
## what

- add regex-assembly/951190.ra with all 3 Ingres SQL information leakage patterns

## why

- enable crs-toolchain management