### PR TITLE
refactor(951200): convert Interbase leakage rule to regex-assembly

### DIFF
--- a/regex-assembly/951200.ra
+++ b/regex-assembly/951200.ra
@@ -1,0 +1,7 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##!+ i
+
+<b>Warning</b>: ibase_
+Unexpected end of command in statement

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -245,7 +245,12 @@ SecRule RESPONSE_BODY "@rx (?i:Warning.*ingres_|Ingres SQLSTATE|Ingres\W.*Driver
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
-SecRule RESPONSE_BODY "@rx (?i:<b>Warning</b>: ibase_|Unexpected end of command in statement)" \
+# Regular expression generated from regex-assembly/951200.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 951200
+#
+SecRule RESPONSE_BODY "@rx (?i)<b>Warning</b>: ibase_|Unexpected end of command in statement" \
     "id:951200,\
     phase:4,\
     block,\


### PR DESCRIPTION
## what

- add regex-assembly/951200.ra with both Interbase SQL information leakage patterns

## why

- enable crs-toolchain management
