### PR TITLE
refactor(951210): convert maxDB leakage rule to regex-assembly

### DIFF
--- a/regex-assembly/951210.ra
+++ b/regex-assembly/951210.ra
@@ -1,0 +1,6 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##!+ i
+
+Warning.{1,10}maxdb[\(\)_a-z:]{1,26}:

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -266,7 +266,12 @@ SecRule RESPONSE_BODY "@rx (?i:<b>Warning</b>: ibase_|Unexpected end of command 
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
 
-SecRule RESPONSE_BODY "@rx (?i)Warning.{1,10}maxdb[\(\)_a-z:]{1,26}:" \
+# Regular expression generated from regex-assembly/951210.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 951210
+#
+SecRule RESPONSE_BODY "@rx (?i)Warning.{1,10}maxdb[\(\):_a-z]{1,26}:" \
     "id:951210,\
     phase:4,\
     block,\


### PR DESCRIPTION
## what

- add regex-assembly/951210.ra with the maxDB SQL information leakage pattern

## why

- enable crs-toolchain management
