### PR TITLE
docs: recommend mod_security2 minimum version 2.9.6

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -27,7 +27,7 @@
 #
 # -- [[ System Requirements ]] -------------------------------------------------
 #
-# CRS requires ModSecurity version 2.8.0 or above.
+# CRS requires ModSecurity version 2.9.6 or above.
 # The recommended minimum version of libmodsecurity3 is 3.0.10.
 # We recommend to always use the newest ModSecurity version.
 #


### PR DESCRIPTION
## what

* add mod_security2 2.9.6 as the recommended minimum version in `crs-setup.conf.example`

## why

CRS uses `MULTIPART_PART_HEADER` target in rule file `REQUEST-922-MULTIPART-ATTACK.conf`. This target was introduced in [v2.9.6](https://github.com/owasp-modsecurity/ModSecurity/releases/tag/v2.9.6) via [ModSecurity/#2797](https://github.com/owasp-modsecurity/ModSecurity/pull/2797).