### PR TITLE
chore: fix renovatebot config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>coreruleset/renovate-config",
+    "github>coreruleset/renovate-config",
     "schedule:weekly"
   ],
   "ignorePaths": [],


### PR DESCRIPTION
## what
- point to github instead of local

## why
- renovatebot should always derive from github common config