### PR TITLE
fix: don't block json variable names called `profile` on libmodsecurity3/coraza

### DIFF
--- a/rules/REQUEST-999-COMMON-EXCEPTIONS-AFTER.conf
+++ b/rules/REQUEST-999-COMMON-EXCEPTIONS-AFTER.conf
@@ -10,7 +10,8 @@
 
 # This file is used as an exception mechanism to remove common false positives
 # that may be encountered. This file does not contain any runtime rule-exclusions
-# and so it must loaded after all the request rules have been created.
+# and so it must loaded after all the request rules have been created. The tests for this
+# file can be found in `REQUEST-999-COMMON-EXCEPTIONS-AFTER/999999.yaml`
 
 # To have a standard order, please:
 #
@@ -97,3 +98,7 @@ SecRuleUpdateTargetById 942440 "!REQUEST_COOKIES:/^_pk_ref/"
 SecRuleUpdateTargetById 942450 "!REQUEST_COOKIES:/^_pk_ref/"
 SecRuleUpdateTargetById 942470 "!REQUEST_COOKIES:/^_pk_ref/"
 SecRuleUpdateTargetById 942480 "!REQUEST_COOKIES:/^_pk_ref/"
+
+# False positive with a json variable called `profile`, specifically happens on
+# libModSecurity3/Coraza only.
+SecRuleUpdateTargetById 930120 !ARGS_NAMES:json.profile

--- a/tests/regression/tests/REQUEST-999-COMMON-EXCEPTIONS-AFTER/999999.yml
+++ b/tests/regression/tests/REQUEST-999-COMMON-EXCEPTIONS-AFTER/999999.yml
@@ -178,3 +178,23 @@ tests:
         output:
           log:
             no_match_regex: \[id "\d+"\]
+  - test_id: 11
+    desc: |
+      libModSecurity3/Coraza false positive only
+      JSON variable called named `profile`
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          port: 80
+          headers:
+            Host: localhost
+            User-Agent: OWASP CRS test agent
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Content-Type: application/json
+          method: POST
+          version: HTTP/1.1
+          uri: /
+          data: '{"profile":"test"}'
+        output:
+          log:
+            no_expect_ids: 930120


### PR DESCRIPTION

## Proposed changes

When sending JSON data to libModSecurity3/Coraza, variable names are prefixed with `.json`. If the variable name is called `profile`, then that will translate to `ARGS_NAMES:json.profile` which matches one of the entries inside of `lfi-os-files.data` resulting in a false positive. This PR adds a configure-time rule exclusion to resolve this false positive.

closes: https://github.com/coreruleset/coreruleset/issues/4471

## PR Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/CONTRIBUTING.md) doc
- [ ] I have added positive tests proving my fix/feature works as intended.
- [x] I have added negative tests that prove my fix/feature considers common cases that might end in false positives
- [ ] In case you changed a regular expression, you are not adding a ReDOS for pcre. You can check this using [regexploit](https://github.com/doyensec/regexploit)
- [x] My test use the `comment` field to write the expected behavior
- [x] I have added documentation for the rule or change (when appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... If there are no additional comments, you may remove this section. -->

## For the reviewer

<!-- Don't remove this part. Reviewers will use it as guidance for the review process. -->

- [ ] Positive and negative tests were added
- [ ] Tests cover the intended fix/feature properly
- [ ] No usage of dangerous constructs like `ctl:requestBodyAccess=Off` were used in the rule
- [ ] In case a regular expression was changed, [there is no ReDOS](https://github.com/coreruleset/coreruleset/wiki/Testing-for-Regular-Expresion-DoS)
- [ ] Documentation is clear for the rule/change
