### PR TITLE
feat: move 930110 to regex-assembly

### DIFF
--- a/regex-assembly/930110.ra
+++ b/regex-assembly/930110.ra
@@ -12,8 +12,8 @@
 ##!> define sep [\x5c/;]
 
 ##!> assemble
-^
-{{sep}}
+  ^
+  {{sep}}
 ##!<
 ##!=>
 \.{2,3}{{sep}}

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -70,7 +70,7 @@ SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|FILES|XML:
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 930110
 #
-SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|FILES|XML:/* "@rx (?:^|[/;\x5c])[/;\x5c]?\.{2,3}[/;\x5c]" \
+SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|FILES|XML:/* "@rx (?:^|[/;\x5c])\.{2,3}[/;\x5c]" \
     "id:930110,\
     phase:2,\
     block,\


### PR DESCRIPTION
## what
- create regex-assembly file for rule 930110 (path traversal attack)
- update rule regex with toolchain-generated version
- add standard "generated from regex-assembly" comment block

## why
- maintainability: `.ra` files make it easier to review and update patterns
- consistency: aligns with the ongoing effort to move rules to regex-assembly format

## refs

- #4480