### PR TITLE
refactor: create 921110 `.ra` file

### DIFF
--- a/regex-assembly/921110.ra
+++ b/regex-assembly/921110.ra
@@ -1,0 +1,33 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Detects HTTP Request Smuggling by looking for HTTP/WebDAV method names
+##! followed by a URI and an HTTP version string (e.g., "GET /foo HTTP/1").
+
+##!> assemble
+  ##! HTTP methods
+  get
+  post
+  head
+  options
+  connect
+  put
+  delete
+  trace
+  track
+  patch
+  ##! WebDAV methods
+  propfind
+  propatch
+  mkcol
+  copy
+  move
+  lock
+  unlock
+  ##!=< http-methods
+##!<
+
+##!> assemble
+  ##!=> http-methods
+  \s+[^\s]+\s+http/\d
+##!<

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -31,7 +31,12 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:921012,phase:2,pass,nolog,tag:'O
 # [ References ]
 # http://projects.webappsec.org/HTTP-Request-Smuggling
 #
-SecRule ARGS_NAMES|ARGS|REQUEST_BODY|XML:/* "@rx (?:get|post|head|options|connect|put|delete|trace|track|patch|propfind|propatch|mkcol|copy|move|lock|unlock)\s+[^\s]+\s+http/\d" \
+# Regular expression generated from regex-assembly/921110.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 921110
+#
+SecRule ARGS_NAMES|ARGS|REQUEST_BODY|XML:/* "@rx (?:get|p(?:(?:os|u)t|atch|rop(?:find|atch))|head|options|co(?:nnect|py)|delete|trac[ek]|m(?:kcol|ove)|(?:un)?lock)[\s\x0b]+[^\s\x0b]+[\s\x0b]+http/[0-9]" \
     "id:921110,\
     phase:2,\
     block,\


### PR DESCRIPTION
## what
- create regex-assembly file for rule 921110 (HTTP Request Smuggling detection)
- HTTP/WebDAV method names decomposed into a named sub-assembly with shared suffix
- update rule regex with toolchain-optimized version (trie compression of method names)
- add standard "generated from regex-assembly" comment block

## why
- maintainability: `.ra` file makes it easy to add/remove HTTP methods
- consistency: aligns with the ongoing effort to move rules to regex-assembly format

## refs
- https://github.com/coreruleset/coreruleset/issues/4480