### PR TITLE
refactor: create 921120 `.ra` file

### DIFF
--- a/regex-assembly/921120.ra
+++ b/regex-assembly/921120.ra
@@ -1,0 +1,21 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Detects HTTP Response Splitting by looking for CR/LF characters
+##! followed by HTTP response header names (content-type, content-length,
+##! set-cookie, location).
+
+##! HTTP response header names
+##!> assemble
+  content-type
+  content-length
+  set-cookie
+  location
+  ##!=< response-headers
+##!<
+
+##!> assemble
+  [\r\n]\W*?
+  ##!=> response-headers
+  :\s*\w
+##!<

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -64,7 +64,12 @@ SecRule ARGS_NAMES|ARGS|REQUEST_BODY|XML:/* "@rx (?:get|post|head|options|connec
 # [ References ]
 # http://projects.webappsec.org/HTTP-Response-Splitting
 #
-SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx [\r\n]\W*?(?:content-(?:type|length)|set-cookie|location):\s*\w" \
+# Regular expression generated from regex-assembly/921120.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 921120
+#
+SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx [\n\r][^0-9A-Z_a-z]*?(?:content-(?:type|length)|set-cookie|location):[\s\x0b]*[0-9A-Z_a-z]" \
     "id:921120,\
     phase:2,\
     block,\


### PR DESCRIPTION
## what
- create regex-assembly file for rule 921120 (HTTP Response Splitting detection)
- response header names decomposed into a named sub-assembly, composed with CR/LF prefix and colon suffix via sequence
- toolchain auto-optimizes `content-type`/`content-length` into `content-(?:type|length)`
- add standard "generated from regex-assembly" comment block

## why
- maintainability: `.ra` file makes it easy to add/remove response header names
- consistency: aligns with the ongoing effort to move rules to regex-assembly format

## refs
- https://github.com/coreruleset/coreruleset/issues/4480