### PR TITLE
refactor: create 921160 `.ra` file

### DIFF
--- a/regex-assembly/921160.ra
+++ b/regex-assembly/921160.ra
@@ -1,0 +1,42 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Detects HTTP Header Injection via CR/LF followed by known
+##! header names in GET parameters.
+
+##! header names to detect after CR/LF
+##!> assemble
+  ##! whitespace (blank header)
+  \s
+  ##! standard response headers
+  location
+  refresh
+  ##! cookie headers
+  cookie
+  set-cookie
+  ##! proxy-related headers
+  forwarded-for
+  forwarded-host
+  forwarded-server
+  host
+  via
+  remote-ip
+  remote-addr
+  originating-IP
+  ##! x-prefixed proxy-related headers
+  x-forwarded-for
+  x-forwarded-host
+  x-forwarded-server
+  x-host
+  x-via
+  x-remote-ip
+  x-remote-addr
+  x-originating-IP
+  ##!=< header-names
+##!<
+
+##!> assemble
+  [\n\r]+
+  ##!=> header-names
+  \s*:
+##!<

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -172,7 +172,12 @@ SecRule ARGS_NAMES "@rx [\n\r]" \
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule ARGS_GET_NAMES|ARGS_GET "@rx [\n\r]+(?:\s|location|refresh|(?:set-)?cookie|(?:x-)?(?:forwarded-(?:for|host|server)|host|via|remote-ip|remote-addr|originating-IP))\s*:" \
+# Regular expression generated from regex-assembly/921160.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 921160
+#
+SecRule ARGS_GET_NAMES|ARGS_GET "@rx [\n\r]+(?:[\s\x0b]|location|re(?:fresh|mote-(?:ip|addr))|(?:set-)?cookie|forwarded-(?:(?:fo|serve)r|host)|host|via|originating-IP|x-(?:forwarded-(?:(?:fo|serve)r|host)|host|via|remote-(?:ip|addr)|originating-IP))[\s\x0b]*:" \
     "id:921160,\
     phase:1,\
     block,\


### PR DESCRIPTION
## what
- create regex-assembly file for rule 921160 (HTTP Header Injection via CR/LF)
- header names flattened (with and without `x-` prefix) into a named sub-assembly, composed with CR/LF prefix and colon suffix via sequence
- toolchain auto-optimizes common prefixes (e.g., `re(?:fresh|mote-(?:ip|addr))`, `(?:set-)?cookie`, `x-(?:forwarded-...|...)`)
- add standard "generated from regex-assembly" comment block

## why
- maintainability: `.ra` file makes it easy to add/remove header names
- consistency: aligns with the ongoing effort to move rules to regex-assembly format

## refs
- https://github.com/coreruleset/coreruleset/issues/4480