### PR TITLE
feat: move 943100 to regex-assembly

### DIFF
--- a/regex-assembly/943100.ra
+++ b/regex-assembly/943100.ra
@@ -1,0 +1,25 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Detects session fixation via cookie manipulation:
+##! - JavaScript document.cookie with expires/domain attributes
+##! - HTML META http-equiv="Set-Cookie"
+
+##!+ i
+
+##!> assemble
+  ##! JS cookie manipulation: document.cookie = "foo=bar; expires=..."
+  ##!> assemble
+    \.cookie\b.*?;\W*?
+    ##!=>
+    ##!> assemble
+      expires
+      domain
+    ##!<
+    ##!=>
+    \W*?=
+    ##!=>
+  ##!<
+  ##! HTML META tag: <meta http-equiv="Set-Cookie" ...>
+  \bhttp-equiv\W+set-cookie\b
+##!<

--- a/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
+++ b/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
@@ -28,7 +28,12 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:943012,phase:2,pass,nolog,tag:'O
 # http://projects.webappsec.org/w/page/13246960/Session%20Fixation
 # http://capec.mitre.org/data/definitions/61.html
 #
-SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:\.cookie\b.*?;\W*?(?:expires|domain)\W*?=|\bhttp-equiv\W+set-cookie\b)" \
+# Regular expression generated from regex-assembly/943100.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 943100
+#
+SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\.cookie\b.*?;[^0-9A-Z_a-z]*?(?:expires|domain)[^0-9A-Z_a-z]*?=|\bhttp-equiv[^0-9A-Z_a-z]+set-cookie\b" \
     "id:943100,\
     phase:2,\
     block,\


### PR DESCRIPTION
## what
- create regex-assembly file for rule 943100 (session fixation via cookie manipulation)
- update rule regex with toolchain-generated version
- add standard "generated from regex-assembly" comment block

## why
- maintainability: `.ra` files make it easier to review and update patterns
- consistency: aligns with the ongoing effort to move rules to regex-assembly format

## refs
- https://github.com/coreruleset/coreruleset/issues/4480