### PR TITLE
refactor: add generated-from comment to 943110 rule

### DIFF
--- a/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
+++ b/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
@@ -50,6 +50,11 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:\.
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
+# Regular expression generated from regex-assembly/943110.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 943110
+#
 SecRule ARGS_NAMES "@rx ^(?:j(?:se(?:ssionid|rvsession)|wsession)|(?:asp(?:\.net_)?session|zend_session_)id|p(?:hpsessi(?:on|d)|lay_session)|(?:(?:w(?:eblogic|l)|rack\.|laravel_)sessio|(?:next-auth\.session-|meteor_login_)toke)n|s(?:(?:ession[\-_]?|ails\.s)id|hiny-token)|_(?:session_id|(?:(?:flask|rails)_sessio|_(?:secure|host)-next-auth\.session-toke)n)|c(?:f(?:s?id|token)|onnect\.sid|akephp|i_session)|koa[\.:]sess)$" \
     "id:943110,\
     phase:2,\


### PR DESCRIPTION
## what

- add the standard "generated from" comment block to rule 943110
- the `.ra` file already existed with matching regex output

## why

- ensure consistency: all rules with `.ra` files should have the standard comment block pointing to the source `.ra` file and update instructions

## refs

- https://github.com/coreruleset/coreruleset/issues/4480