### PR TITLE
refactor: create 944120 .ra file

### DIFF
--- a/regex-assembly/944120.ra
+++ b/regex-assembly/944120.ra
@@ -1,0 +1,28 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Rule 944120: Java serialization RCE (CVE-2015-4852)
+##!
+##! Detects Java deserialization class/method names commonly abused
+##! in remote code execution attacks via Apache Commons Collections
+##! and related libraries.
+##!
+##! Note: This rule uses t:lowercase transformation, so all patterns
+##! are in lowercase.
+
+##! Apache Commons Collections gadget classes
+clonetransformer
+forclosure
+instantiatefactory
+instantiatetransformer
+invokertransformer
+prototypeclonefactory
+prototypeserializationfactory
+whileclosure
+
+##! Java property/IO classes used in exploitation chains
+getproperty
+filewriter
+
+##! XML deserialization
+xmldecoder

--- a/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -87,8 +87,13 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUE
 
 # Magic bytes detected and payload included possibly RCE vulnerable classes detected and process execution methods detected
 # anomaly score set to critical as all conditions indicate the request try to perform RCE.
+# Regular expression generated from regex-assembly/944120.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 944120
+#
 SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \
-    "@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)" \
+    "@rx (?:clonetransform|xmldecod)er|f(?:orclosure|ilewriter)|in(?:stantiate(?:factory|transformer)|vokertransformer)|(?:prototype(?:clone|serialization)factor|getpropert)y|whileclosure" \
     "id:944120,\
     phase:2,\
     block,\


### PR DESCRIPTION
## what

- create regex-assembly file for rule 944120 (Java serialization RCE, CVE-2015-4852)
- add "generated from" comment block to the rule
- toolchain trie-optimized the flat alternation of 11 class/method names

## why

- improve maintainability by using regex-assembly format
- the flat list of Java deserialization class names is easier to read and update in `.ra` format

## refs

- https://github.com/coreruleset/coreruleset/issues/4480