### PR TITLE
refactor: create 942250 .ra file

### DIFF
--- a/regex-assembly/942250.ra
+++ b/regex-assembly/942250.ra
@@ -1,0 +1,20 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Rule 942250: Detects MATCH AGAINST, MERGE and EXECUTE IMMEDIATE injections
+##!
+##! SQL injection patterns for:
+##!   - SQL MERGE...USING (ANSI SQL)
+##!   - EXECUTE IMMEDIATE with string literal (Oracle/PL/SQL)
+##!   - MySQL MATCH...AGAINST full-text search
+
+##!+ i
+
+##! SQL MERGE statement with USING clause
+merge.*?using\s*?\(
+
+##! Oracle EXECUTE IMMEDIATE with string delimiter
+execute\s*?immediate\s*?["'`]
+
+##! MySQL MATCH...AGAINST full-text search
+match\s*?[\w(),+-]+\s*?against\s*?\(

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -300,7 +300,12 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)al
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
-SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:merge.*?using\s*?\(|execute\s*?immediate\s*?[\"'`]|match\s*?[\w(),+-]+\s*?against\s*?\()" \
+# Regular expression generated from regex-assembly/942250.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 942250
+#
+SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)m(?:erge.*?using|atch[\s\x0b]*?[\(\)\+-\-0-9A-Z_a-z]+[\s\x0b]*?against)[\s\x0b]*?\(|execute[\s\x0b]*?immediate[\s\x0b]*?[\"'`]" \
     "id:942250,\
     phase:2,\
     block,\


### PR DESCRIPTION
## what

- create regex-assembly file for rule 942250 (MATCH AGAINST, MERGE, EXECUTE IMMEDIATE SQL injections)
- add "generated from" comment block to the rule
- toolchain factored out common `m` prefix from `merge`/`match` and their shared `\s*?\(` suffix

## why

- improve maintainability by using regex-assembly format
- the three SQL injection patterns are clearly documented per attack type in `.ra` format

## refs

- https://github.com/coreruleset/coreruleset/issues/4480