### PR TITLE
refactor: create 942510 .ra file

### DIFF
--- a/regex-assembly/942510.ra
+++ b/regex-assembly/942510.ra
@@ -1,0 +1,32 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Rule 942510: SQLi bypass attempt by ticks or backticks
+##!
+##! Detects SQL injection attempts using backtick-enclosed content:
+##!   - SQL-like characters (2-29 chars) between backticks
+##!   - base64-encoded content between backticks
+
+##!> define b64 [A-Za-z0-9+/]
+
+##!^ `
+##!$ `
+
+##! base64 padding variants
+##!> assemble
+  {{b64}}{2}==
+  {{b64}}{3}=
+  ##!=< base64-padding
+##!<
+
+##!> assemble
+  ##! SQL-like characters (2-29 chars)
+  (?:[\w\s=_\-+{}()<@]){2,29}
+  ##! base64 blocks without padding
+  (?:{{b64}}{4})+
+  ##! base64 blocks with padding
+  ##!> assemble
+    (?:{{b64}}{4})+
+    ##!=> base64-padding
+  ##!<
+##!<

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1438,7 +1438,12 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i:\b
 # ('if'). That rule runs in paranoia level 3 or higher since it is prone to
 # false positives in natural text.
 #
-SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:`(?:(?:[\w\s=_\-+{}()<@]){2,29}|(?:[A-Za-z0-9+/]{4})+(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?)`)" \
+# Regular expression generated from regex-assembly/942510.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 942510
+#
+SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx `(?:[\s\x0b\(\)\+\-0-9<=@-Z_a-\{\}]{2,29}|(?:[\+/-9A-Za-z]{4})+(?:(?:[\+/-9A-Za-z]{2}=|[\+/-9A-Za-z]{3})=)?)`" \
     "id:942510,\
     phase:2,\
     block,\


### PR DESCRIPTION
## what

- create regex-assembly file for rule 942510 (SQLi bypass via backtick-enclosed content)
- add "generated from" comment block to the rule
- toolchain normalized character classes and factored out trailing `=` from base64 padding alternatives

## why

- improve maintainability by using regex-assembly format
- the two detection patterns (SQL-like content and base64 between backticks) are clearly documented in `.ra` format

## refs

- https://github.com/coreruleset/coreruleset/issues/4480