### PR TITLE
refactor: create 942511 .ra file

### DIFF
--- a/regex-assembly/942511.ra
+++ b/regex-assembly/942511.ra
@@ -1,0 +1,35 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Rule 942511: SQLi bypass attempt by ticks (single quotes) - PL3
+##!
+##! Detects SQL injection attempts using single-quote-enclosed content:
+##!   - SQL-like characters (2-29 chars) between quotes
+##!   - base64-encoded content between quotes
+##!
+##! Same pattern as 942510 (backticks, PL2) but with single quotes,
+##! which is more prone to false positives in natural text.
+
+##!> define b64 [A-Za-z0-9+/]
+
+##!^ '
+##!$ '
+
+##! base64 padding variants
+##!> assemble
+  {{b64}}{2}==
+  {{b64}}{3}=
+  ##!=< base64-padding
+##!<
+
+##!> assemble
+  ##! SQL-like characters (2-29 chars)
+  (?:[\w\s=_\-+{}()<@]){2,29}
+  ##! base64 blocks without padding
+  (?:{{b64}}{4})+
+  ##! base64 blocks with padding
+  ##!> assemble
+    (?:{{b64}}{4})+
+    ##!=> base64-padding
+  ##!<
+##!<

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1859,7 +1859,12 @@ SecRule ARGS "@rx \W{4}" \
 # false positives in natural text is still present but lower than this
 # rule.
 #
-SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?:'(?:(?:[\w\s=_\-+{}()<@]){2,29}|(?:[A-Za-z0-9+/]{4})+(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?)')" \
+# Regular expression generated from regex-assembly/942511.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 942511
+#
+SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx '(?:[\s\x0b\(\)\+\-0-9<=@-Z_a-\{\}]{2,29}|(?:[\+/-9A-Za-z]{4})+(?:(?:[\+/-9A-Za-z]{2}=|[\+/-9A-Za-z]{3})=)?)'" \
     "id:942511,\
     phase:2,\
     block,\


### PR DESCRIPTION
## what

- create regex-assembly file for rule 942511 (SQLi bypass via single-quote-enclosed content, PL3)
- add "generated from" comment block to the rule
- same decomposed structure as 942510 (backticks, PL2) with base64 padding alternation

## why

- improve maintainability by using regex-assembly format
- same pattern as 942510 but with single quotes; both `.ra` files share the same decomposition structure

## refs

- https://github.com/coreruleset/coreruleset/issues/4480