### PR TITLE
refactor: create 941400 `.ra` file

### DIFF
--- a/regex-assembly/941400.ra
+++ b/regex-assembly/941400.ra
@@ -1,0 +1,33 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+##!
+##! Rule 941400: XSS JavaScript function without parentheses
+##! Detects attempts to invoke JavaScript functions via tagged template literals
+##! without parentheses, using Array/Reflect method chaining.
+##! e.g. [].sort.call`${alert}1337`
+##! e.g. Reflect.apply.call`${navigation.navigate}${navigation}${[name]}`
+##! Reference: https://portswigger.net/research/the-seventh-way-to-call-a-javascript-function-without-parentheses
+
+##!> assemble
+  \[[^\]]*\][^.]*\.
+  Reflect[^.]*\.
+  ##!=< array-or-reflect
+##!<
+
+##!> assemble
+  map
+  sort
+  apply
+  ##!=< js-methods
+##!<
+
+##!> assemble
+  (
+  ##!=> array-or-reflect
+  ).*
+  ##!=> js-methods
+  [^.]*\..*call[^`]*`.*`
+##!<

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -809,7 +809,12 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|X
 # [].map.call`${eval}\\u{61}lert\x281337\x29`
 # Reflect.apply.call`${navigation.navigate}${navigation}${[name]}`
 #
-SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@rx ((?:\[[^\]]*\][^.]*\.)|Reflect[^.]*\.).*(?:map|sort|apply)[^.]*\..*call[^`]*`.*`" \
+# Regular expression generated from regex-assembly/941400.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 941400
+#
+SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@rx ((?:\[[^\]]*\]|Reflect)[^\.]*\.).*(?:map|sort|apply)[^\.]*\..*call[^`]*`.*`" \
     "id:941400,\
     phase:2,\
     block,\


### PR DESCRIPTION
## what

- create `regex-assembly/941400.ra` for XSS JavaScript function without parentheses (tagged template literal abuse)
- add standard comment block to the rule in the conf file
- toolchain optimized the alternation by extracting the common suffix `[^\.]*\.` from `\[[^\]]*\]` and `Reflect` branches

## why

- improve maintainability by using regex-assembly format

## refs

- https://github.com/coreruleset/coreruleset/issues/4480