### PR TITLE
refactor: create 941370 `.ra` file

### DIFF
--- a/regex-assembly/941370.ra
+++ b/regex-assembly/941370.ra
@@ -1,0 +1,44 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+##!
+##! Rule 941370: JavaScript global variable found
+##! Detects bypass of 941180 using JavaScript global variables
+##! with bracket notation or comment obfuscation.
+##! e.g. self["document"]["cookie"]
+##! e.g. document /*foo*/ . /*bar*/ cookie
+##! Reference: https://www.secjuice.com/bypass-xss-filters-using-javascript-global-variables/
+
+##! JS global variables
+##!> assemble
+  self
+  document
+  this
+  top
+  window
+  ##!=< js-globals
+##!<
+
+##! Opening delimiter: block comment or bracket/paren
+##!> assemble
+  /\*
+  [\[)]
+  ##!=< opener
+##!<
+
+##! Closing delimiter: bracket close or block comment close
+##!> assemble
+  \]
+  \*/
+  ##!=< closer
+##!<
+
+##!> assemble
+  ##!=> js-globals
+  \s*
+  ##!=> opener
+  .+?
+  ##!=> closer
+##!<

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -745,7 +745,12 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|X
 #    - /?search=/?a=";+alert(self["document"]["cookie"]);//
 #    - /?search=/?a=";+document+/*foo*/+.+/*bar*/+cookie;//
 #
-SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@rx (?:self|document|this|top|window)\s*(?:/\*|[\[)]).+?(?:\]|\*/)" \
+# Regular expression generated from regex-assembly/941370.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 941370
+#
+SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@rx (?:self|document|t(?:his|op)|window)[\s\x0b]*(?:/\*|[\)\[]).+?(?:\]|\*/)" \
     "id:941370,\
     phase:2,\
     block,\


### PR DESCRIPTION
## what

- create `regex-assembly/941370.ra` for JavaScript global variable bypass detection (bracket notation / comment obfuscation)
- add standard comment block to the rule in the conf file
- toolchain optimized `this|top` → `t(?:his|op)`, `\s` → `[\s\x0b]`, and reordered character class

## why

- improve maintainability by using regex-assembly format

## refs

- https://github.com/coreruleset/coreruleset/issues/4480