### PR TITLE
refactor: create 941250 `.ra` file

### DIFF
--- a/regex-assembly/941250.ra
+++ b/regex-assembly/941250.ra
@@ -1,0 +1,71 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Rule 941250: IE XSS Filters - detects XSS via META http-equiv attribute.
+##! Matches <META http-equiv="X"> where X starts with c (content-type),
+##! r (refresh), or s (set-cookie), including HTML entity encoded variants.
+
+##!+ i
+
+##! HTML entity codes for 'c'/'C': 67=C dec, 43=C hex, 99=c dec, 63=c hex
+##!> assemble
+  67
+  43
+  99
+  63
+  ##!=< c-entity-codes
+##!<
+
+##! HTML entity codes for 'r'/'R': 82=R dec, 52=R hex, 114=r dec, 72=r hex
+##!> assemble
+  82
+  52
+  114
+  72
+  ##!=< r-entity-codes
+##!<
+
+##! HTML entity codes for 's'/'S': 83=S dec, 53=S hex, 115=s dec, 73=s hex
+##!> assemble
+  83
+  53
+  115
+  73
+  ##!=< s-entity-codes
+##!<
+
+##! Main pattern: <META http-equiv="[c|r|s]..."
+##! Each letter (c, r, s) can appear literally or as an HTML entity
+##!> assemble
+  <META[\s/+].*?http-equiv[\s/+]*=[\s/+]*["'`]?
+  ##!=>
+  ##!> assemble
+    ##! Letter 'c' literal or as HTML entity
+    ##!> assemble
+      c
+      ##!> assemble
+        &#x?0*
+        ##!=> c-entity-codes
+        ;?
+      ##!<
+    ##!<
+    ##! Letter 'r' literal or as HTML entity
+    ##!> assemble
+      r
+      ##!> assemble
+        &#x?0*
+        ##!=> r-entity-codes
+        ;?
+      ##!<
+    ##!<
+    ##! Letter 's' literal or as HTML entity
+    ##!> assemble
+      s
+      ##!> assemble
+        &#x?0*
+        ##!=> s-entity-codes
+        ;?
+      ##!<
+    ##!<
+  ##!<
+##!<

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -467,7 +467,12 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|X
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@rx (?i:<META[\s/+].*?http-equiv[\s/+]*=[\s/+]*[\"'`]?(?:(?:c|&#x?0*(?:67|43|99|63);?)|(?:r|&#x?0*(?:82|52|114|72);?)|(?:s|&#x?0*(?:83|53|115|73);?)))" \
+# Regular expression generated from regex-assembly/941250.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 941250
+#
+SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@rx (?i)<META[\s\x0b\+/].*?http-equiv[\s\x0b\+/]*=[\s\x0b\+/]*[\"'`]?(?:[crs]|&#x?0*(?:6[37]|43|99|[578][23]|11[45]);?)" \
     "id:941250,\
     phase:2,\
     block,\


### PR DESCRIPTION
## what

- create `regex-assembly/941250.ra` for IE XSS filter detecting META http-equiv with content-type/refresh/set-cookie values
- add standard comment block to the rule in the conf file
- toolchain optimized three per-letter entity code groups into a single merged group and expanded `[\s/+]` to `[\s\x0b\+/]` for RE2 compatibility

## why

- improve maintainability by using regex-assembly format

## refs

- https://github.com/coreruleset/coreruleset/issues/4480