### PR TITLE
refactor: create 941300 `.ra` file

### DIFF
--- a/regex-assembly/941300.ra
+++ b/regex-assembly/941300.ra
@@ -1,0 +1,21 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Rule 941300: IE XSS Filters - detects XSS via OBJECT tag attributes.
+##! Matches <OBJECT> tags with dangerous attributes: type, codetype, classid, code, data.
+
+##!+ i
+
+##!> assemble
+  <OBJECT[\s/+].*?
+  ##!=>
+  ##!> assemble
+    type
+    codetype
+    classid
+    code
+    data
+  ##!<
+  ##!=>
+  [\s/+]*=
+##!<

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -582,7 +582,12 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|X
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
-SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@rx (?i)<OBJECT[\s/+].*?(?:type|codetype|classid|code|data)[\s/+]*=" \
+# Regular expression generated from regex-assembly/941300.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 941300
+#
+SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@rx (?i)<OBJECT[\s\x0b\+/].*?(?:type|c(?:ode(?:type)?|lassid)|data)[\s\x0b\+/]*=" \
     "id:941300,\
     phase:2,\
     block,\


### PR DESCRIPTION
## what

- create `regex-assembly/941300.ra` for IE XSS filter detecting OBJECT tag with dangerous attributes (type, codetype, classid, code, data)
- add standard comment block to the rule in the conf file
- toolchain optimized common prefix extraction (`code`/`codetype`/`classid`) and expanded `[\s/+]` to `[\s\x0b\+/]` for RE2 compatibility

## why

- improve maintainability by using regex-assembly format

## refs

- https://github.com/coreruleset/coreruleset/issues/4480