### PR TITLE
fix(933110): prevent whitespace padding bypass in PHP upload detection

### DIFF
--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -97,7 +97,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     phase:2,\
     block,\
     capture,\
-    t:none,t:lowercase,\
+    t:none,t:lowercase,t:removeWhitespace,\
     msg:'PHP Injection Attack: PHP Script File Upload Found',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\

--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933110.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933110.yaml
@@ -505,3 +505,115 @@ tests:
         output:
           log:
             no_expect_ids: [933110]
+  - test_id: 31
+    desc: "PHP .php upload with leading whitespace before extension via header"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            X-Filename: "photo. php"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          port: 80
+          uri: /upload
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [933110]
+  - test_id: 32
+    desc: "PHP .php upload with trailing whitespace via header"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            X-Filename: "photo.php "
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          port: 80
+          uri: /upload
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [933110]
+  - test_id: 33
+    desc: "PHP .php upload with whitespace padding via multipart"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          method: "POST"
+          port: 80
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: "localhost"
+            Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+            Content-Type: "multipart/form-data; boundary=--------397236876"
+          uri: "/post"
+          data: |
+            ----------397236876
+            Content-Disposition: form-data; name="fileRap"; filename="photo. php"
+            Content-Type: text/plain
+
+            please block me
+            ----------397236876--
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [933110]
+  - test_id: 34
+    desc: "PHP .phtml upload with whitespace before extension via header"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            X-Filename: "dangerous. phtml"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          port: 80
+          uri: /upload
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [933110]
+  - test_id: 35
+    desc: "PHP .phar upload with trailing whitespace via header"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            X-Filename: "dangerous.phar "
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          port: 80
+          uri: /upload
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [933110]
+  - test_id: 36
+    desc: "PHP .php upload with multiple spaces in filename via multipart"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          method: "POST"
+          port: 80
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: "localhost"
+            Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+            Content-Type: "multipart/form-data; boundary=--------397236876"
+          uri: "/post"
+          data: |
+            ----------397236876
+            Content-Disposition: form-data; name="fileRap"; filename="photo.php  "
+            Content-Type: application/x-httpd-php
+
+            <?php echo 'test'; ?>
+            ----------397236876--
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [933110]


### PR DESCRIPTION
## what

- add `t:removeWhitespace` transformation to rule 933110 so filenames with whitespace padding are normalized before regex evaluation
- add 6 regression tests covering whitespace bypass variants (leading space, trailing space, multipart uploads, different PHP extensions)

## why

- rule 933110 can be bypassed by inserting whitespace in the filename (e.g. `photo. php` or `photo.php `) because the regex requires the dot to be immediately followed by the extension, and only `t:lowercase` is applied
- some backends (especially on Windows) strip whitespace from filenames, so `photo.php ` could become `photo.php` and be executed as PHP

## refs

- coreruleset/security-tracker-private#37