### PR TITLE
fix(933111): prevent whitespace padding bypass in PHP double-extension upload

### DIFF
--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -862,7 +862,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     phase:2,\
     block,\
     capture,\
-    t:none,t:lowercase,\
+    t:none,t:lowercase,t:removeWhitespace,\
     msg:'PHP Injection Attack: PHP Script File Upload Found',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\

--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933111.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933111.yaml
@@ -78,3 +78,69 @@ tests:
         output:
           log:
             expect_ids: [933111]
+  - test_id: 4
+    desc: "PHP .php.jpg upload with whitespace before extension via multipart"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: "localhost"
+            Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryoRWIb3busvBrbttO
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          uri: "/post"
+          port: 80
+          data: |
+            ------WebKitFormBoundaryoRWIb3busvBrbttO
+            Content-Disposition: form-data; name="file"; filename="test. php.jpg"
+            Content-Type: image/jpeg
+
+            please block me
+
+            ------WebKitFormBoundaryoRWIb3busvBrbttO--
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [933111]
+  - test_id: 5
+    desc: "PHP .phar.png upload with trailing whitespace before second extension via header"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            X-Filename: "test.phar .png"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          port: 80
+          uri: /upload
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [933111]
+  - test_id: 6
+    desc: "PHP .php5.gif upload with whitespace before extension via multipart"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: "localhost"
+            Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryoRWIb3busvBrbttO
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          uri: "/post"
+          port: 80
+          data: |
+            ------WebKitFormBoundaryoRWIb3busvBrbttO
+            Content-Disposition: form-data; name="file"; filename="test. php5.gif"
+            Content-Type: image/gif
+
+            please block me
+
+            ------WebKitFormBoundaryoRWIb3busvBrbttO--
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [933111]


### PR DESCRIPTION
## what

- add `t:removeWhitespace` transformation to rule 933111 (PL3 stricter sibling of 933110) to normalize filenames before regex evaluation
- add 3 regression tests covering whitespace bypass variants in double-extension filenames (e.g. `test. php.jpg`, `test.phar .png`)

## why

- rule 933111 can be bypassed by inserting whitespace in the filename before the PHP extension (e.g. `test. php.jpg`) because the regex requires the dot to be immediately followed by the extension, and only `t:lowercase` is applied
- same class of vulnerability as fixed in 933110

## refs

- coreruleset/security-tracker-private#37
- #4546