### PR TITLE
fix(932180): prevent whitespace padding bypass in restricted file upload detection

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -840,7 +840,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     phase:2,\
     block,\
     capture,\
-    t:none,\
+    t:none,t:removeWhitespace,\
     msg:'Restricted File Upload Attempt',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932180.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932180.yaml
@@ -242,3 +242,61 @@ tests:
         output:
           log:
             expect_ids: [932180]
+  - test_id: 13
+    desc: "restricted upload with whitespace before extension via header"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            X-Filename: "settings. php"
+          method: GET
+          port: 80
+          uri: "/get"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [932180]
+  - test_id: 14
+    desc: "restricted upload with trailing whitespace via header"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            X-Filename: "config.yml "
+          method: GET
+          port: 80
+          uri: "/get"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [932180]
+  - test_id: 15
+    desc: "restricted upload with whitespace padding via multipart"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryABCDEFGIJKLMNOPQ
+          method: POST
+          port: 80
+          uri: "/post"
+          version: "HTTP/1.1"
+          data: |
+            ------WebKitFormBoundaryABCDEFGIJKLMNOPQ
+            Content-Disposition: form-data; name="config"; filename="wp-config. php"
+            Content-Type: text/plain
+
+            ... Some content ...
+            ------WebKitFormBoundaryABCDEFGIJKLMNOPQ--
+        output:
+          log:
+            expect_ids: [932180]


### PR DESCRIPTION
## what

- add `t:removeWhitespace` transformation to rule 932180 so filenames with whitespace padding are normalized before `@pmFromFile` matching
- add 3 regression tests covering whitespace bypass variants (leading space, trailing space, multipart upload)

## why

- rule 932180 can be bypassed by inserting whitespace in the filename (e.g. `settings. php` or `config.yml `) because the `@pmFromFile` substring matching won't find the entry from `restricted-upload.data` when whitespace is present
- same class of vulnerability as fixed in 933110

## refs

- coreruleset/security-tracker-private#37
- #4546