### PR TITLE
fix: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/check-pr-dependencies.yaml
+++ b/.github/workflows/check-pr-dependencies.yaml
@@ -7,6 +7,8 @@ on:
       - edited
       - synchronize
 
+permissions: {}
+
 jobs:
   check_dependencies:
     runs-on: ubuntu-latest
@@ -14,6 +16,6 @@ jobs:
     permissions:
       pull-requests: read # Reason: To check PRs for dependencies.
     steps:
-      - uses: gregsdennis/dependencies-action@main
+      - uses: gregsdennis/dependencies-action@ae6e0529ef70f1366a21972f40b1ad0e1b5e3218 # v1.4.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,6 +13,9 @@ on:
       - v3.3/master
   merge_group:
 
+permissions:
+  contents: read
+
 # Pin versions to not disrupt test pipelines
 env:
   CRS_TOOLCHAIN_VERSION: '2.6.0'
@@ -48,18 +51,23 @@ jobs:
           secrules-parser -c --output-type github -f rules/*.conf
 
       - name: Fetch upstream tags for version detection in next step
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
           git remote add upstream https://github.com/coreruleset/coreruleset
           git fetch --tags upstream
           git fetch upstream main
-          if [ -n "${{ github.base_ref }}" ]; then
-            echo "Fetching '${{ github.base_ref }}' from 'upstream'"
-            git fetch upstream "${{ github.base_ref }}"
+          if [ -n "$BASE_REF" ]; then
+            echo "Fetching '$BASE_REF' from 'upstream'"
+            git fetch upstream "$BASE_REF"
           else
             echo "Base ref is empty, skip fetching fro 'upstream'"
           fi
 
       - name: "Check CRS formatting"
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           pip install -U setuptools
           pip install crs-linter==${{ env.CRS_LINTER_VERSION }}
@@ -72,8 +80,8 @@ jobs:
             -T 'tests/regression/tests/' \
             -E 'tests/TESTS_EXCLUSIONS' \
             -d "$(pwd)" \
-            --head-ref '${{ github.head_ref }}' \
-            --commit-message '${{ github.event.head_commit.message }}'
+            --head-ref "$HEAD_REF" \
+            --commit-message "$COMMIT_MESSAGE"
 
       - name: "Install crs-toolchain ${{ env.CRS_TOOLCHAIN_VERSION }}"
         env:

--- a/.github/workflows/quantitative.yaml
+++ b/.github/workflows/quantitative.yaml
@@ -46,7 +46,7 @@ jobs:
           gh release download -R coreruleset/go-ftw "v${{ env.GO_FTW_VERSION }}" \
             -p "ftw_${{ env.GO_FTW_VERSION }}_linux_amd64.tar.gz" -O - | tar -xzvf - ftw
       - name: "Restore Cache"
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.ftw/*.txt
           key: ${{ matrix.language }}_news_${{ matrix.year }}_${{ matrix.size }}-sentences.txt
@@ -91,12 +91,12 @@ jobs:
           fi
 
       - name: "Cache Corpus file"
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.ftw/*.txt
           key: ${{ matrix.language }}_news_${{ matrix.year }}_${{ matrix.size }}-sentences.txt
       - name: "Comment PR"
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@65f9e5c9a1f2cd378bd74b2e057c9736982a8e74 # v3.0.1
         with:
           comment-tag: execution
           file-path: pr_comment.md

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,10 @@ on:
   schedule:
   - cron: "0 0 * * *"
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,9 @@ on:
       - '.github/**'
   merge_group:
 
+permissions:
+  contents: read
+
 # Pin tool versions to prevent problems
 env:
   GO_FTW_VERSION: '2.1.0'


### PR DESCRIPTION
## what

- pin all third-party actions to commit SHAs instead of mutable tags
- add explicit minimal `permissions` blocks to all workflows missing them
- move user-controlled GitHub context values (`github.base_ref`, `github.head_ref`, `github.event.head_commit.message`) from inline `${{ }}` interpolation to `env:` blocks to prevent script injection in `lint.yaml`

## why

several workflows had security gaps that could be exploited by bots or malicious contributors:

- **supply chain risk**: `gregsdennis/dependencies-action@main`, `thollander/actions-comment-pull-request@v3`, and `actions/cache@v4` were pinned to mutable refs (branches/tags) instead of immutable commit SHAs. a compromised upstream could inject arbitrary code into CI runs
- **overly broad permissions**: `test.yml`, `lint.yaml`, and `stale.yml` relied on default `GITHUB_TOKEN` permissions (which can be broad depending on org settings) instead of declaring the minimum required
- **script injection**: `lint.yaml` interpolated user-controlled values (`github.head_ref`, `github.event.head_commit.message`) directly into `run:` shell scripts via `${{ }}`, which expands before the shell sees the value — a crafted branch name or commit message could break out of quoting and execute arbitrary commands

## refs

- [GitHub docs: security hardening for GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions)
- [GitHub docs: using third-party actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)