### PR TITLE
test: ensure very common user-agents are never blocked

### DIFF
--- a/tests/regression/tests/REQUEST-999-COMMON-EXCEPTIONS-AFTER/999999.yml
+++ b/tests/regression/tests/REQUEST-999-COMMON-EXCEPTIONS-AFTER/999999.yml
@@ -600,6 +600,7 @@ tests:
         output:
           log:
             expect_ids: [932237]
+            # Uncomment once `932237` FP is fixed to catch future FPs
             # no_match_regex: \[id "\d+"\]
   - test_id: 37
     desc: "Links2 Browser on Linux"


### PR DESCRIPTION
## Proposed changes

In PR https://github.com/coreruleset/coreruleset/pull/4476 a regression was introduced where virtually every user-agent was blocked above PL-2 resulting in most sites breaking completely for end users. Part of the problem that resulted in the regression with rule 942200 was the rule had very poor test coverage, the rule had zero negative tests to check for false positives and the quantitative tests only checks for natural language false positives at PL-1, not PL-2 and higher.

There are likely other rules that are poorly tested and are brittle enough where a similar issue could crop up, or even if new rules is introduced. This PR adds 25 tests for common User-Agents which are ran against all rules to ensure very basic web traffic is never blocked.

Having tests for real world traffic would be ideal, but since we don't have a good sample of test traffic this should be good enough to catch any repeats of `942200` blocking all user-agents.

refs: https://github.com/coreruleset/coreruleset/pull/4476
refs: https://github.com/coreruleset/coreruleset/pull/4525

<!-- Github Tip: adding the text 'Fixes #<issue>' or 'Closes #<issue>' will automatically close the mentioned issue. -->

## PR Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/CONTRIBUTING.md) doc
- [ ] I have added positive tests proving my fix/feature works as intended.
- [x] I have added negative tests that prove my fix/feature considers common cases that might end in false positives
- [ ] In case you changed a regular expression, you are not adding a ReDOS for pcre. You can check this using [regexploit](https://github.com/doyensec/regexploit)
- [x] My test use the `comment` field to write the expected behavior
- [ ] I have added documentation for the rule or change (when appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... If there are no additional comments, you may remove this section. -->

## For the reviewer

<!-- Don't remove this part. Reviewers will use it as guidance for the review process. -->

- [ ] Positive and negative tests were added
- [ ] Tests cover the intended fix/feature properly
- [ ] No usage of dangerous constructs like `ctl:requestBodyAccess=Off` were used in the rule
- [ ] In case a regular expression was changed, [there is no ReDOS](https://github.com/coreruleset/coreruleset/wiki/Testing-for-Regular-Expresion-DoS)
- [ ] Documentation is clear for the rule/change
