### PR TITLE
fix(933190): test of the rule 933190 to not trigger windows defender

### DIFF
--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933190.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933190.yaml
@@ -16,7 +16,7 @@ tests:
           method: POST
           port: 80
           uri: "/post"
-          data: 'file_test=<?php%20echo "test";%20?>&submit=1'
+          data: 'file_test=<?php%20echo%20"test";%20?>&submit=1'
           version: HTTP/1.1
         output:
           log:


### PR DESCRIPTION
# What
The test of the rule 933190 flagged by windows defender as malware
# Fix
i simplified the payload to just use a simple echo with a closing tag

Closes #3791