### PR TITLE
fix(933111): tests of the rule 933111 not trigger windows defender

### DIFF
--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933111.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933111.yaml
@@ -21,7 +21,7 @@ tests:
             Content-Disposition: form-data; name="file"; filename="test.php.jpg"
             Content-Type: image/jpeg
 
-            <?php @eval($_POST["hacker"]); ?>
+            <?php echo "test"; ?>
 
             ------WebKitFormBoundaryoRWIb3busvBrbttO--
           version: HTTP/1.1


### PR DESCRIPTION
# What
The tests of the rule 933111 flagged by windows defender as malware
# Fix
i simplified the payload to just use a simple echo with a closing tag

Closes #3791