### PR TITLE
feat: Add WhatWAF to the scanner list

### DIFF
--- a/rules/scanners-user-agents.data
+++ b/rules/scanners-user-agents.data
@@ -36,7 +36,7 @@ fimap
 # https://github.com/ffuf/ffuf
 fuzz faster
 
-# WhatWaf, a tool that detects the WAF and try to bypass it
+# WhatWaf, fingerprint and bypass WAFs
 # https://github.com/Ekultek/WhatWaf
 whatwaf
 


### PR DESCRIPTION
# What?
Add WhatWAF to the scanner user agent lists
# Why?
WhatWAF is a popular tool that detects the WAF and try to find bypasses for it 
# Refs
- https://medium.com/@allypetitt/5-ways-i-bypassed-your-web-application-firewall-waf-43852a43a1c2
- https://github.com/Ekultek/WhatWaf