### PR TITLE
feat(921300): Query delimiter confusion

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -570,7 +570,7 @@ SecRule ARGS_NAMES "@rx (][^\]]+$|][^\]]+\[)" \
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
-# -=[ Path Delimiter Confusion ]=-
+# -=[ Query Delimiter Confusion ]=-
 #
 # [ Rule Logic ]
 # This rule detects requests where a query delimiter ("&") appears in the URI
@@ -610,8 +610,8 @@ SecRule REQUEST_URI "@rx ^/[^\?]*?&" \
     block,\
     capture,\
     log,\
-    msg:'Path Delimiter Confusion - ampersand in path may bypass ARGS parsing',\
-    logdata:'Path delimiter confusion in URI: %{REQUEST_URI}',\
+    msg:'Query Delimiter Confusion - ampersand in path may bypass ARGS parsing',\
+    logdata:'Query delimiter confusion in URI: %{REQUEST_URI}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -570,6 +570,61 @@ SecRule ARGS_NAMES "@rx (][^\]]+$|][^\]]+\[)" \
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
 
+# -=[ Path Delimiter Confusion ]=-
+#
+# [ Rule Logic ]
+# This rule detects requests where a query delimiter ("&") appears in the URI
+# before the start of a valid query string ("?").
+#
+# Such patterns are not compliant with standard URI syntax and may indicate an
+# attempt to exploit inconsistencies between front-end security controls and
+# backend request parsing.
+#
+# In particular, when rewrite rules are in place (e.g. "?url=$1"), portions of
+# the path containing "&" may later be interpreted as query string parameters
+# by the backend application.
+#
+# This behavior can neutralize the effectiveness of OWASP CRS rules relying on
+# ARGS inspection, as parameters injected via the path are not initially parsed
+# into ARGS collections during WAF evaluation.
+#
+# As a result, attackers may smuggle parameters through the path, bypassing
+# detection logic applied to standard query arguments.
+#
+# This rule blocks any URI containing a "&" character before a "?", as it
+# indicates a potential parsing ambiguity and argument injection vector.
+#
+# [ Payloads ]
+# /api_prestashop/configuration&ws_key=XXXX
+# /endpoint/resource&param=value
+# /index.php/foo&bar=baz
+#
+# [ False Positives ]
+# You may encounter false positives with this rule, as "&" can be a legitimate
+# character in filenames or path segments depending on the application context.
+#
+
+SecRule REQUEST_URI "@rx ^/[^\?]*?&" \
+    "id:921300,\
+    phase:1,\
+    block,\
+    capture,\
+    log,\
+    msg:'Path Delimiter Confusion - ampersand in path may bypass ARGS parsing',\
+    logdata:'Path delimiter confusion in URI: %{REQUEST_URI}'
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    tag:'paranoia-level/3',\
+    tag:'OWASP_CRS',\
+    tag:'OWASP_CRS/PROTOCOL-ATTACK',\
+    tag:'capec/1000/152/137/15/460',\
+    ver:'OWASP_CRS/4.25.0-dev',\
+    severity:'CRITICAL',\
+    setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
+
 
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:921017,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.25.0-dev',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 4" "id:921018,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.25.0-dev',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -604,11 +604,10 @@ SecRule ARGS_NAMES "@rx (][^\]]+$|][^\]]+\[)" \
 # character in filenames or path segments depending on the application context.
 #
 
-SecRule REQUEST_URI "@rx ^/[^\?]*?&" \
+SecRule REQUEST_URI "@rx ^/[^?]*&" \
     "id:921300,\
     phase:1,\
     block,\
-    capture,\
     log,\
     msg:'Query Delimiter Confusion - ampersand in path may bypass ARGS parsing',\
     logdata:'Query delimiter confusion in URI: %{REQUEST_URI}',\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -611,7 +611,7 @@ SecRule REQUEST_URI "@rx ^/[^\?]*?&" \
     capture,\
     log,\
     msg:'Path Delimiter Confusion - ampersand in path may bypass ARGS parsing',\
-    logdata:'Path delimiter confusion in URI: %{REQUEST_URI}'
+    logdata:'Path delimiter confusion in URI: %{REQUEST_URI}',\
     tag:'application-multi',\
     tag:'language-multi',\
     tag:'platform-multi',\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -619,7 +619,7 @@ SecRule REQUEST_URI "@rx ^/[^?]*&" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ATTACK',\
     tag:'capec/1000/152/137/15/460',\
-    ver:'OWASP_CRS/4.25.0-dev',\
+    ver:'OWASP_CRS/4.26.0-dev',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl3=+%{tx.critical_anomaly_score}'"

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921300.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921300.yaml
@@ -20,7 +20,7 @@ tests:
           log:
             expect_ids: [921300]
   - test_id: 2
-    desc: Known false positive
+    desc: Known false positive - tagged as block expected.
     stages:
       - input:
           dest_addr: 127.0.0.1
@@ -34,3 +34,18 @@ tests:
         output:
           log:
             expect_ids: [921300]
+  - test_id: 3
+    desc: Common call with parameters
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+          method: POST
+          port: 80
+          uri: "/api/test?ws_key=test&order=ASC"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [921300]

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921300.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921300.yaml
@@ -1,0 +1,36 @@
+---
+meta:
+  author: "touchweb_vincent"
+  description: Detect ampersand in path before query string
+rule_id: 921300
+tests:
+  - test_id: 1
+    desc: Ampersand in path before query string
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/api/test&ws_key=123456"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [921300]
+  - test_id: 2
+    desc: Known false positive
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+          method: POST
+          port: 80
+          uri: "/friend&family.png"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [921300]


### PR DESCRIPTION
## Proposed changes

This PR introduces a new detection rule targeting a parsing ambiguity where an ampersand (&) appears in the URI path before the beginning of a valid query string (?).

While this pattern is not compliant with standard URI syntax, it is observed in real-world deployments where backend rewrite rules [(e.g. ?url=$1](https://github.com/PrestaShop/PrestaShop/blob/37dd056fd76d24a1f8a2bfc29357afe4d3f538c3/classes/Tools.php#L2241)) may reinterpret path segments as query parameters. In such cases, characters like & embedded in the path can be promoted to query delimiters after rewriting.

More concretely, if an `.htaccess` or vhost contains the following rule:

```
^api(?:/(.*))?$ index.php?url=$1
```

Then, if the following request is sent:

```
GET /api/test&payload=my_payload
```

The WAF does not interpret `payload` as a parameter.

However, since the rewrite rule transforms the URI into:

```
GET /index.php?url=api/test&payload=my_payload
```

The backend application does receive the `payload` parameter with the value `my_payload`.

This also introduces additional side effects - including the neutralization of potential `sanitiseMatched` instructions, effectively exposing parameters that should be obfuscated in clear text within the frontend access logs.

-----------

This behavior creates a discrepancy between how the WAF (CRS) and the backend application interpret the request. Since CRS relies on normalized query parsing to populate ARGS collections, parameters injected via the path are not analyzed during rule evaluation. As a result, this can effectively neutralize detection logic relying on ARGS and enable parameter smuggling.

~~You will likely point out that most rules do not only analyze ARGS but also inspect REQUEST_URI, which mitigates the severity of this bypass; however, it still seems important to take this behavior into account.~~ 

The proposed rule detects any occurrence of & in the URI before a ?, which is a strong indicator of such ambiguity and a potential bypass vector.

**This rule will inherently generate false positives**, as the & character can be a perfectly legitimate character in filenames or path segments depending on the application context. For this reason, it has been placed at Paranoia Level 3 (PL3), although placement at PL4 could also be considered.

This addition strengthens CRS coverage against parser confusion and rewrite-assisted parameter smuggling techniques, which are currently not explicitly addressed.

What do you think ?

P.S. PrestaShop is very likely not the only application affected by this kind of behavior in .htaccess rewrite rules.

<!-- Github Tip: adding the text 'Fixes #<issue>' or 'Closes #<issue>' will automatically close the mentioned issue. -->

## PR Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/CONTRIBUTING.md) doc
- [x] I have added positive tests proving my fix/feature works as intended.
- [ ] I have added negative tests that prove my fix/feature considers common cases that might end in false positives
- [ ] In case you changed a regular expression, you are not adding a ReDOS for pcre. You can check this using [regexploit](https://github.com/doyensec/regexploit)
- [ ] My test use the `comment` field to write the expected behavior
- [ ] I have added documentation for the rule or change (when appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... If there are no additional comments, you may remove this section. -->

## For the reviewer

<!-- Don't remove this part. Reviewers will use it as guidance for the review process. -->

- [ ] Positive and negative tests were added
- [ ] Tests cover the intended fix/feature properly
- [ ] No usage of dangerous constructs like `ctl:requestBodyAccess=Off` were used in the rule
- [ ] In case a regular expression was changed, [there is no ReDOS](https://github.com/coreruleset/coreruleset/wiki/Testing-for-Regular-Expresion-DoS)
- [ ] Documentation is clear for the rule/change
