### PR TITLE
fix(942550): restrict first SQLite/PostgreSQL branch to single-quote and backtick

### DIFF
--- a/regex-assembly/942550.ra
+++ b/regex-assembly/942550.ra
@@ -46,8 +46,10 @@
 
 ##!> assemble
   ##! SQLite + PostgreSQL
-  {{quotes}}{{json_starting_brackets}}{{something_except_json_ending_brackets}}{{json_ending_brackets}}{{quotes}}
-  {{operators}}{{quotes}}{{json_starting_brackets}}{{something_except_json_ending_brackets}}{{json_ending_brackets}}{{quotes}}
+  ##! Use only single-quote and backtick (not double-quote) for the first branch
+  ##! to reduce false positives from cookie values and JSON payloads  ['`]{{json_starting_brackets}}{{something_except_json_ending_brackets}}{{json_ending_brackets}}['`]
+  ##! Use only single-quote and backtick (not double-quote) for the first branch
+  ##! to reduce false positives from cookie values and JSON payloads  {{operators}}['`]{{json_starting_brackets}}{{something_except_json_ending_brackets}}{{json_ending_brackets}}['`]
   {{operators}}{{quotes}}{{sqlite_path}}
 
   ##! MySQL

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -615,7 +615,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)1\
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 942550
 #
-SecRule REQUEST_FILENAME|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\"'`][\[\{][^#\]\}]*[\]\}]+[\"'`]|(?:[\-@]>?|<@|@[\?@]|\?(?:(?:)|&|\|#>)|#(?:>>|-)|->>|[<>])[\"'`](?:[\[\{][^#\]\}]*[\]\}]+[\"'`]|\$[\.\[])|\bjson_extract\b[^\(]*\([^\)]*\)" \
+SecRule REQUEST_FILENAME|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:[\-@]>?|<@|@[\?@]|\?(?:(?:)|&|\|#>)|#(?:>>|-)|->>|[<>])[\"'`]\$[\.\[]|\bjson_extract\b[^\(]*\([^\)]*\)" \
     "id:942550,\
     phase:2,\
     block,\


### PR DESCRIPTION
## What

Restrict the first branch of SQLite/PostgreSQL JSON path detection to single-quote and backtick only (excluding double-quote). Double-quoted values appear frequently in legitimate cookie values and JSON payloads.

## Context

Part of CVE-derived payload research FP reductions. See tracking issue #4584 for full context.

Refs: #4584