### PR TITLE
fix(943110): remove generic session-id and session_id from PL1

### DIFF
--- a/regex-assembly/943110.ra
+++ b/regex-assembly/943110.ra
@@ -47,8 +47,9 @@ wlsession
 
 ##! Generic Session IDs (various platforms)
 ##! Common generic session parameter names used across multiple frameworks
-session_id
-session-id
+##! Note: generic 'session_id' and 'session-id' removed from PL1 to reduce FPs
+##! on applications using 'session_id' as a non-session parameter name.
+##! 'sessionid' (no separator) is specific enough to keep.
 sessionid
 _session_id
 

--- a/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
+++ b/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
@@ -60,7 +60,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\.
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 943110
 #
-SecRule ARGS_NAMES "@rx ^(?:j(?:se(?:ssionid|rvsession)|wsession)|(?:asp(?:\.net_)?session|zend_session_)id|p(?:hpsessi(?:on|d)|lay_session)|(?:(?:w(?:eblogic|l)|rack\.|laravel_)sessio|(?:next-auth\.session-|meteor_login_)toke)n|s(?:(?:ession[\-_]?|ails\.s)id|hiny-token)|_(?:session_id|(?:(?:flask|rails)_sessio|_(?:secure|host)-next-auth\.session-toke)n)|c(?:f(?:s?id|token)|onnect\.sid|akephp|i_session)|koa[\.:]sess)$" \
+SecRule ARGS_NAMES "@rx ^(?:j(?:se(?:ssionid|rvsession)|wsession)|(?:asp(?:\.net_)?session|zend_session_)id|p(?:hpsessi(?:on|d)|lay_session)|(?:(?:w(?:eblogic|l)|rack\.|laravel_)sessio|(?:next-auth\.session-|meteor_login_)toke)n|s(?:(?:ession|ails\.s)id|hiny-token)|_(?:session_id|(?:(?:flask|rails)_sessio|_(?:secure|host)-next-auth\.session-toke)n)|c(?:f(?:s?id|token)|onnect\.sid|akephp|i_session)|koa[\.:]sess)$" \
     "id:943110,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION/943110.yaml
+++ b/tests/regression/tests/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION/943110.yaml
@@ -372,7 +372,7 @@ tests:
           log:
             expect_ids: [943110]
   - test_id: 23
-    desc: "Session-id with hyphen notation"
+    desc: "Negative test: session-id with hyphen is too generic for PL1 (FP reduction)"
     stages:
       - input:
           dest_addr: 127.0.0.1
@@ -386,7 +386,7 @@ tests:
           version: HTTP/1.1
         output:
           log:
-            expect_ids: [943110]
+            no_expect_ids: [943110]
   - test_id: 24
     desc: "Mixed case PHPSESSID should match (t:lowercase transformation)"
     stages:

--- a/tests/regression/tests/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION/943110.yaml
+++ b/tests/regression/tests/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION/943110.yaml
@@ -675,3 +675,35 @@ tests:
         output:
           log:
             expect_ids: [943110]
+  - test_id: 42
+    desc: "Negative test: session_id with underscore is too generic for PL1 (FP reduction)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: myapp.com
+            Referer: "http://badactor.com/"
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/search?session_id=abc123&query=test"
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids: [943110]
+  - test_id: 43
+    desc: "Positive test: PHPSESSID still triggers at PL1 after generic session-id removal"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: phpapp.com
+            Referer: "https://attacker.example/"
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/login?PHPSESSID=fixated-session-value"
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [943110]


### PR DESCRIPTION
## What

Remove 'session-id' and 'session_id' (with separators) from PL1 session fixation. These generic parameter names cause FPs on applications using session_id as a non-session parameter. More specific 'sessionid' (no separator) and '_session_id' (Rails) are kept.

## Context

Part of CVE-derived payload research FP reductions. See tracking issue #4584 for full context.

Refs: #4584