### PR TITLE
fix(lfi-os-files): add .dockerenv, .DS_Store, META-INF/, WEB-INF/

### DIFF
--- a/rules/lfi-os-files.data
+++ b/rules/lfi-os-files.data
@@ -988,7 +988,7 @@ wamp/bin/mysql
 wamp/bin/php
 wamp/logs
 web.config
-# Java servlet container sensitive paths
+# Java servlet container
 META-INF/
 WEB-INF/
 webpack.config.js

--- a/rules/lfi-os-files.data
+++ b/rules/lfi-os-files.data
@@ -41,8 +41,10 @@
 .dbus/
 .deployment-secrets.txt
 .docker/
+.dockerenv
 .dockerignore
 .drush/
+.DS_Store
 # .env
 .envrc
 .eslintignore
@@ -986,6 +988,9 @@ wamp/bin/mysql
 wamp/bin/php
 wamp/logs
 web.config
+# Java servlet container sensitive paths
+META-INF/
+WEB-INF/
 webpack.config.js
 windows/comsetup.log
 windows/debug/netsetup.log

--- a/rules/restricted-files.data
+++ b/rules/restricted-files.data
@@ -32,6 +32,7 @@
 .aiignore
 .cursorignore
 .docker/
+.dockerenv
 .dockerignore
 .drush/
 .env
@@ -425,6 +426,7 @@ weblogic.xml
 php_error.log
 php_errors.log
 # Java directory for non-public application data
+META-INF/
 WEB-INF/
 # Fortinet SSL VPN session file
 sslvpn_websession

--- a/rules/restricted-upload.data
+++ b/rules/restricted-upload.data
@@ -48,6 +48,7 @@ __pycache__/
 .deployment-secrets.txt
 .digrc
 .dockerignore
+.dockerenv
 .DS_Store
 .editorconfig
 .env
@@ -432,6 +433,7 @@ locks
 login.sql
 mdstat
 meminfo
+META-INF/
 module
 modules
 mounts
@@ -496,6 +498,7 @@ vmallocinfo
 vmstat
 Web.config
 weblogic.xml
+WEB-INF/
 webpack.config.js
 win.ini
 wp-config-


### PR DESCRIPTION
## What

Adds detection for Docker container files, macOS metadata leaks, and Java servlet container sensitive paths.

## Context

Part of CVE-derived payload research FN improvements. See tracking issue #4584 for full context.

Refs: #4584