### PR TITLE
fix(920539): prefer a bypass on a named rule rather than n+1 bypass

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1307,7 +1307,7 @@ SecRule REQBODY_PROCESSOR "@streq JSON" \
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
     ver:'OWASP_CRS/4.26.0-dev',\
-    skip:1"
+    ctl:ruleRemoveById=920540"
 
 #
 # Unicode character bypass check for non JSON requests

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1296,8 +1296,6 @@ SecRule REQUEST_HEADERS:Accept "!@rx ^(?:(?:\*|[^!\"\(\),/:-\?\[-\]\{\}]+)/(?:\*
 
 # This rule disables `920540` if the JSON body processor is not active. This
 # check is split into a different rule to allow for specific targets to be excluded.
-# Warning: There must be no rules between `920539` and `920540` or they
-# will be skipped. This rule must also be kept in the same phase as `920540`.
 SecRule REQBODY_PROCESSOR "@streq JSON" \
     "id:920539,\
     phase:2,\
@@ -1315,8 +1313,6 @@ SecRule REQBODY_PROCESSOR "@streq JSON" \
 # See reported bypass in issue:
 # https://github.com/coreruleset/coreruleset/issues/2512
 #
-# Warning: There must be no rules between `920539` and `920540` or they
-# will be skipped.
 SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@rx (?i)\x5cu[0-9a-f]{4}" \
     "id:920540,\
     phase:2,\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1306,8 +1306,9 @@ SecRule REQBODY_PROCESSOR "@streq JSON" \
     nolog,\
     tag:'OWASP_CRS',\
     tag:'OWASP_CRS/PROTOCOL-ENFORCEMENT',\
-    ver:'OWASP_CRS/4.26.0-dev',\
-    ctl:ruleRemoveById=920540"
+    ctl:ruleRemoveById=920540,\
+    ver:'OWASP_CRS/4.26.0-dev'"
+
 
 #
 # Unicode character bypass check for non JSON requests


### PR DESCRIPTION
## Proposed changes

Hello,

I find this idea https://github.com/coreruleset/coreruleset/pull/4405#issuecomment-3922823073 risky, and I’m sure it will cause us issues someday.

I therefore suggest naming the bypass as we usually do on a named rule using ctl:ruleRemoveById, rather than using skip:1.

What do you think ?

<!-- Github Tip: adding the text 'Fixes #<issue>' or 'Closes #<issue>' will automatically close the mentioned issue. -->

## PR Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/CONTRIBUTING.md) doc
- [ ] I have added positive tests proving my fix/feature works as intended.
- [ ] I have added negative tests that prove my fix/feature considers common cases that might end in false positives
- [ ] In case you changed a regular expression, you are not adding a ReDOS for pcre. You can check this using [regexploit](https://github.com/doyensec/regexploit)
- [ ] My test use the `comment` field to write the expected behavior
- [ ] I have added documentation for the rule or change (when appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... If there are no additional comments, you may remove this section. -->

## For the reviewer

<!-- Don't remove this part. Reviewers will use it as guidance for the review process. -->

- [ ] Positive and negative tests were added
- [ ] Tests cover the intended fix/feature properly
- [ ] No usage of dangerous constructs like `ctl:requestBodyAccess=Off` were used in the rule
- [ ] In case a regular expression was changed, [there is no ReDOS](https://github.com/coreruleset/coreruleset/wiki/Testing-for-Regular-Expresion-DoS)
- [ ] Documentation is clear for the rule/change
