### PR TITLE
fix: false positive with parameter name `.history`

### DIFF
--- a/rules/lfi-os-files.data
+++ b/rules/lfi-os-files.data
@@ -66,7 +66,7 @@
 .gsutil/
 .hg/
 .hgignore
-.history
+/.history
 .hplip/hplip.conf
 .htaccess
 .htdigest

--- a/rules/restricted-files.data
+++ b/rules/restricted-files.data
@@ -56,7 +56,7 @@
 .gsutil/
 .hg/
 .hgignore
-#.history
+#/.history
 .hplip/hplip.conf
 .htaccess
 .htdigest

--- a/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930120.yaml
+++ b/tests/regression/tests/REQUEST-930-APPLICATION-ATTACK-LFI/930120.yaml
@@ -254,3 +254,38 @@ tests:
         output:
           log:
             expect_ids: [930120]
+  - test_id: 15
+    desc: |
+      True positive test.
+      Accessing history file, usually via directory traversal
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          method: "GET"
+          port: 80
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: "localhost"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          uri: "/get?code=../.history"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [930120]
+  - test_id: 16
+    desc: |
+      False Positive: matching `.history` in parameter name
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          method: "GET"
+          port: 80
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: "localhost"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          uri: "/get?history.history=test"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [930120]


### PR DESCRIPTION
## Proposed changes

Matching on the `.history` file can cause substring matches like with `history.history`. Usually `.history` will never be stored within webroot and so you must try and escape out of webroot via a directory traversal or similar to access it, adding an boundary to `.history` should fix that issue. Fixes a false positive reported in CRS dev chat.

<!-- Github Tip: adding the text 'Fixes #<issue>' or 'Closes #<issue>' will automatically close the mentioned issue. -->

## PR Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/CONTRIBUTING.md) doc
- [x] I have added positive tests proving my fix/feature works as intended.
- [x] I have added negative tests that prove my fix/feature considers common cases that might end in false positives
- [ ] In case you changed a regular expression, you are not adding a ReDOS for pcre. You can check this using [regexploit](https://github.com/doyensec/regexploit)
- [x] My test use the `comment` field to write the expected behavior
- [ ] I have added documentation for the rule or change (when appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... If there are no additional comments, you may remove this section. -->

## For the reviewer

<!-- Don't remove this part. Reviewers will use it as guidance for the review process. -->

- [ ] Positive and negative tests were added
- [ ] Tests cover the intended fix/feature properly
- [ ] No usage of dangerous constructs like `ctl:requestBodyAccess=Off` were used in the rule
- [ ] In case a regular expression was changed, [there is no ReDOS](https://github.com/coreruleset/coreruleset/wiki/Testing-for-Regular-Expresion-DoS)
- [ ] Documentation is clear for the rule/change
