### PR TITLE
chore: add crs-linter exceptions

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -427,6 +427,7 @@ SecRule TX:enforce_bodyproc_urlencoded "@eq 1" \
 # Leading zeros are not removed from the two-digit random number, and are
 # handled gracefullly by 901450
 
+#crs-linter:ignore:pass_nolog
 SecRule TX:sampling_percentage "@eq 100" \
     "id:901400,\
     phase:1,\

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -83,6 +83,7 @@ SecRule TX:REPORTING_LEVEL "@lt 4" "id:980051,phase:5,pass,nolog,tag:'OWASP_CRS'
 SecMarker "LOG-REPORTING"
 
 # Inbound and outbound - all requests
+#crs-linter:ignore:pass_nolog
 SecAction \
     "id:980170,\
     phase:5,\


### PR DESCRIPTION
## what

- add exceptions on rules that do `pass,nolog`

## why

- fix upcoming [crs-linter test](https://github.com/coreruleset/crs-linter/pull/137)