### PR TITLE
fix: update linter ignore directive in initialization config

### DIFF
--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -427,7 +427,6 @@ SecRule TX:enforce_bodyproc_urlencoded "@eq 1" \
 # Leading zeros are not removed from the two-digit random number, and are
 # handled gracefullly by 901450
 
-#crs-linter:ignore:pass_nolog
 SecRule TX:sampling_percentage "@eq 100" \
     "id:901400,\
     phase:1,\
@@ -460,7 +459,7 @@ SecRule UNIQUE_ID "@rx ^[a-f]*([0-9])[a-f]*([0-9])" \
 # SecRuleUpdateActionById 901450 "nolog"
 #
 
-
+#crs-linter:ignore:pass_nolog
 SecRule TX:sampling_rnd100 "!@lt %{tx.sampling_percentage}" \
     "id:901450,\
     phase:1,\


### PR DESCRIPTION
## what

- fix linter ignore to be in the correct rule

## why

- so it works properly