### PR TITLE
feat: Add robots.txt to restricted upload rules

### DIFF
--- a/rules/restricted-upload.data
+++ b/rules/restricted-upload.data
@@ -508,3 +508,4 @@ yarn-debug.log
 yarn-error.log
 yarn.lock
 zoneinfo
+robots.txt


### PR DESCRIPTION
# What?
Add robots.txt, to restricted upload list
# Why?
An attacker can upload the file, to expose uploaded files, to search engines, which attackers use Google Dork for discover them
# Note
File Access itself still works, only uploading that file blocked, there a no legitimate reason, you will upload a **robots.txt** file