### PR TITLE
fix: Update restricted files to include Perl subdirectories

### DIFF
--- a/rules/restricted-files.data
+++ b/rules/restricted-files.data
@@ -678,7 +678,9 @@ miniconda3/
 .perldb
 .perl_repl_history
 .perlhistory
-# perl/
+perl/lib
+perl/bin
+perl/etc
 # CPAN & Cpan+
 .cpan/
 .cpanplus/

--- a/rules/restricted-files.data
+++ b/rules/restricted-files.data
@@ -680,7 +680,6 @@ miniconda3/
 .perlhistory
 perl/lib
 perl/bin
-perl/etc
 # CPAN & Cpan+
 .cpan/
 .cpanplus/


### PR DESCRIPTION
# What?
Add perl/ common subdirs, like lib and bin and etc 
# Why?
Because perl/ alone can cause fps, in the previous pr perl/ caused FPs because of perl/syntaxes, but after that, That still detects probe is a cpan package installed or not while reducing those FPs, what do you think @EsadCetiner 
