### PR TITLE
fix(920100): drop HTTP/0.9 GET support from request line validation

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -578,9 +578,11 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 
 # Allowed HTTP versions.
 # Default: HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0 HTTP/3 HTTP/3.0
-# Example for legacy clients: HTTP/0.9 HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0 HTTP/3 HTTP/3.0
 # Note that some web server versions use 'HTTP/2', some 'HTTP/2.0', so
 # we include both version strings by default.
+# HTTP/0.9 is obsolete per RFC 9110 and no longer supported; rule 920100
+# will block request lines that lack a protocol suffix regardless of this
+# setting.
 # Uncomment this rule to change the default.
 #SecAction \
 #    "id:900230,\

--- a/regex-assembly/920100.ra
+++ b/regex-assembly/920100.ra
@@ -3,10 +3,6 @@
 
 ##!+ i
 
-##! Cover the GET method
-##!  | Path |--- Query ---| Fragment |
-^get /[^?#]*(?:\?[^#\s]*)?(?:#[\S]*)?$
-
 ##! Cover the CONNECT method
 ##! Meth |----- IPv4 Address ------|- Port -| Protocol |
 ^connect (?:\d{1,3}\.){3}\d{1,3}\.?(?::\d+)?\s+[\w\./]+$

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -34,12 +34,11 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:920012,phase:2,pass,nolog,tag:'O
 #
 # -=[ Rule Logic ]=-
 #
-# Uses rule negation against the regex for positive security.   The regex specifies the proper
+# Uses rule negation against the regex for positive security. The regex specifies the proper
 # construction of URI request lines such as:
 #
 #   "http" "://" authority path-abempty [ "?" query ]
 #
-# It also outlines proper construction for CONNECT, OPTIONS and GET requests.
 #
 # Regular expression generated from regex-assembly/920100.ra.
 # To update the regular expression run the following shell script

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -50,7 +50,7 @@ SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:920012,phase:2,pass,nolog,tag:'O
 # https://www.rfc-editor.org/rfc/rfc9110.html#section-4.2.1
 # http://capec.mitre.org/data/definitions/272.html
 #
-SecRule REQUEST_LINE "!@rx (?i)^(?:get /[^#\?]*(?:\?[^\s\x0b#]*)?(?:#[^\s\x0b]*)?|(?:connect (?:(?:[0-9]{1,3}\.){3}[0-9]{1,3}\.?(?::[0-9]+)?|[\--9A-Z_a-z]+:[0-9]+)|options \*|[a-z]{3,10}[\s\x0b]+(?:[0-9A-Z_a-z]{3,7}?://[\--9A-Z_a-z]*(?::[0-9]+)?)?/[^#\?]*(?:\?[^\s\x0b#]*)?(?:#[^\s\x0b]*)?)[\s\x0b]+[\.-9A-Z_a-z]+)$" \
+SecRule REQUEST_LINE "!@rx (?i)^(?:connect (?:(?:[0-9]{1,3}\.){3}[0-9]{1,3}\.?(?::[0-9]+)?|[\--9A-Z_a-z]+:[0-9]+)|options \*|[a-z]{3,10}[\s\x0b]+(?:[0-9A-Z_a-z]{3,7}?://[\--9A-Z_a-z]*(?::[0-9]+)?)?/[^#\?]*(?:\?[^\s\x0b#]*)?(?:#[^\s\x0b]*)?)[\s\x0b]+[\.-9A-Z_a-z]+$" \
     "id:920100,\
     phase:1,\
     block,\


### PR DESCRIPTION
## what

- remove the GET-without-protocol alternative from `regex-assembly/920100.ra`
- regenerate the compiled regex in `rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf` (shorter, simpler)
- remove the misleading "HTTP/0.9 for legacy clients" example from `crs-setup.conf.example` and add a note that HTTP/0.9 is no longer supported

## why

- HTTP/0.9 is obsolete per RFC 9110
- the GET HTTP/0.9 branch was the only alternative that did not require a protocol suffix in the request line, leaving an inconsistency: rule 920430 already excludes HTTP/0.9 from `tx.allowed_http_versions` by default, but rule 920100 accepted HTTP/0.9 request-line syntax
- the `crs-setup.conf.example` legacy hint would have led users to a half-working configuration (HTTP/0.9 allowed at the protocol level, but blocked at the request-line level)
- GET requests with proper HTTP/1.x, HTTP/2, or HTTP/3 protocols remain covered by the generic method alternative

## refs

- RFC 9110 (HTTP Semantics)

## ai disclosure

- **tools used**: Claude (Opus 4.7)
- **assisted with**: analysis of the existing regex alternatives, identification of the HTTP/0.9 branch as removable given RFC 9110, drafting the `.ra` edit, regenerating the compiled regex via `crs-toolchain regex update 920100`, drafting the `crs-setup.conf.example` comment update, drafting this PR description
- **review performed**: verified the regex change manually (ran `crs-toolchain regex compare`/`generate`, inspected diff); confirmed all 16 existing regression tests for 920100 still pass; verified the removed HTTP/0.9 behavior manually by sending `GET /\r\n\r\n` via `nc` and confirming rule 920100 now fires (log entry present); cross-checked rule 920430's default `tx.allowed_http_versions` to confirm consistency; read RFC 9110 to verify HTTP/0.9 status