### PR TITLE
feat: add base64 decode to `921140` and detect cpanel CVE-2026-41940

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -136,7 +136,7 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@rx [\n\r]" \
     phase:1,\
     block,\
     capture,\
-    t:none,t:base64decode,t:urlDecodeUni,\
+    t:none,t:base64Decode,t:urlDecodeUni,\
     msg:'HTTP Header Injection Attack via headers',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -136,7 +136,7 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@rx [\n\r]" \
     phase:1,\
     block,\
     capture,\
-    t:none,t:urlDecodeUni,\
+    t:none,t:base64decode,t:urlDecodeUni,\
     msg:'HTTP Header Injection Attack via headers',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921140.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921140.yaml
@@ -21,7 +21,7 @@ tests:
         output:
           status: 400
           log:
-            expect_ids: [921140]
+            no_expect_ids: [921140]
   - test_id: 2
     desc: "HTTP Header Injection Attack via headers"
     stages:

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921140.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921140.yaml
@@ -39,7 +39,7 @@ tests:
         output:
           log:
             expect_ids: [921140]
-  - test_id: 4
+  - test_id: 3
     desc: |
       HTTP Header Injection Attack via headers: Cpanel Auth bypass CVE-2026-41940
       decoded payload: root:x\nsuccessful_internal_auth_with_timestamp=999
@@ -58,7 +58,7 @@ tests:
         output:
           log:
             expect_ids: [921140]
-  - test_id: 5
+  - test_id: 4
     desc: |
       HTTP Header Injection Attack via headers: Cpanel Auth bypass CVE-2026-41940
       decoded payload: 9999999\nuser=root\ntfa_verified=1\nhasroot=1

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921140.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921140.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "Christian S.J. Peron, azurit"
+  author: "Christian S.J. Peron, azurit, Esad Cetiner"
   description: "Tests for protocol based attacks"
 rule_id: 921140
 tests:

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921140.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921140.yaml
@@ -21,7 +21,7 @@ tests:
         output:
           status: 400
           log:
-            no_expect_ids: [921140]
+            expect_ids: [921140]
   - test_id: 2
     desc: "HTTP Header Injection Attack via headers"
     stages:
@@ -32,6 +32,44 @@ tests:
           headers:
             Host: "localhost"
             SomeHeader: "Headerdata%0dInjectedHeader: response_splitting_code"
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          uri: "/"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [921140]
+  - test_id: 4
+    desc: |
+      HTTP Header Injection Attack via headers: Cpanel Auth bypass CVE-2026-41940
+      decoded payload: root:x\nsuccessful_internal_auth_with_timestamp=999
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          method: "GET"
+          port: 80
+          headers:
+            Host: "localhost"
+            Authorization: cm9vdDp4DQpzdWNjZXNzZnVsX2ludGVybmFsX2F1dGhfd2l0aF90aW1lc3RhbXA9OTk5
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          uri: "/"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [921140]
+  - test_id: 5
+    desc: |
+      HTTP Header Injection Attack via headers: Cpanel Auth bypass CVE-2026-41940
+      decoded payload: 9999999\nuser=root\ntfa_verified=1\nhasroot=1
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          method: "GET"
+          port: 80
+          headers:
+            Host: "localhost"
+            Authorization: OTk5OTk5OQ0KdXNlcj1yb290DQp0ZmFfdmVyaWZpZWQ9MQ0KaGFzcm9vdD0x
             User-Agent: "OWASP CRS test agent"
             Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
           uri: "/"


### PR DESCRIPTION
## Proposed changes

Cpanel CVE-2026-41940 is an authentication bypass that allows attackers to gain full RCE. It involves sending a base64 encoded authorization header with `\n` or `\r` characters.

<!-- Github Tip: adding the text 'Fixes #<issue>' or 'Closes #<issue>' will automatically close the mentioned issue. -->

## PR Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/CONTRIBUTING.md) doc
- [x] I have added positive tests proving my fix/feature works as intended.
- [ ] I have added negative tests that prove my fix/feature considers common cases that might end in false positives
- [ ] In case you changed a regular expression, you are not adding a ReDOS for pcre. You can check this using [regexploit](https://github.com/doyensec/regexploit)
- [x] My test use the `comment` field to write the expected behavior
- [ ] I have added documentation for the rule or change (when appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... If there are no additional comments, you may remove this section. -->

## AI Disclosure

AI wasn't used for this PR.

## For the reviewer

<!-- Don't remove this part. Reviewers will use it as guidance for the review process. -->

- [ ] Positive and negative tests were added
- [ ] Tests cover the intended fix/feature properly
- [ ] No usage of dangerous constructs like `ctl:requestBodyAccess=Off` were used in the rule
- [ ] In case a regular expression was changed, [there is no ReDOS](https://github.com/coreruleset/coreruleset/wiki/Testing-for-Regular-Expresion-DoS)
- [ ] Documentation is clear for the rule/change
- [ ] If a contribution shows signs of unreviewed AI generation (e.g., plausible-but-broken regex, generic boilerplate comments, hallucinated SecLang directives), reviewers should ask about AI usage regardless of what was checked.
