### PR TITLE
fix(920240, 920400): don't rely on content-type header

### DIFF
--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -909,7 +909,7 @@ SecRule &TX:MAX_FILE_SIZE "@eq 1" \
     ver:'OWASP_CRS/4.27.0-dev',\
     severity:'CRITICAL',\
     chain"
-    SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)multipart/form-data" \
+    SecRule REQBODY_PROCESSOR "@streq MULTIPART" \
         "chain"
         SecRule REQUEST_HEADERS:Content-Length "@gt %{tx.max_file_size}" \
             "t:none,\
@@ -1587,7 +1587,7 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
 # -=[ References ]=-
 # http://www.ietf.org/rfc/rfc1738.txt
 #
-SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)application/x-www-form-urlencoded" \
+SecRule REQBODY_PROCESSOR "@streq URLENCODED" \
     "id:920240,\
     phase:2,\
     block,\


### PR DESCRIPTION
## Proposed changes

Rules 920240 and 920400 relies on the Content Type header to perform urlencoding validation, and file size limits respectively. Some applications don't set content types correctly and will use something like `text/plain`.

The `REQBODY_PROCESSOR` variable contains the same information a Content Type would, and would support more exotic configurations where urlencoded data is sent with a `text/plain` content type. Assuming the end user switches on the correct body processor for `text/plain` and similar.

<!-- Github Tip: adding the text 'Fixes #<issue>' or 'Closes #<issue>' will automatically close the mentioned issue. -->

## PR Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/CONTRIBUTING.md) doc
- [ ] I have added positive tests proving my fix/feature works as intended.
- [ ] I have added negative tests that prove my fix/feature considers common cases that might end in false positives
- [ ] In case you changed a regular expression, you are not adding a ReDOS for pcre. You can check this using [regexploit](https://github.com/doyensec/regexploit)
- [ ] My test use the `comment` field to write the expected behavior
- [ ] I have added documentation for the rule or change (when appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... If there are no additional comments, you may remove this section. -->

## AI Disclosure

N/A

## For the reviewer

<!-- Don't remove this part. Reviewers will use it as guidance for the review process. -->

- [ ] Positive and negative tests were added
- [ ] Tests cover the intended fix/feature properly
- [ ] No usage of dangerous constructs like `ctl:requestBodyAccess=Off` were used in the rule
- [ ] In case a regular expression was changed, [there is no ReDOS](https://github.com/coreruleset/coreruleset/wiki/Testing-for-Regular-Expresion-DoS)
- [ ] Documentation is clear for the rule/change
- [ ] If a contribution shows signs of unreviewed AI generation (e.g., plausible-but-broken regex, generic boilerplate comments, hallucinated SecLang directives), reviewers should ask about AI usage regardless of what was checked.
