### PR TITLE
chore: update go-ftw

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ permissions:
 
 # Pin tool versions to prevent problems
 env:
-  GO_FTW_VERSION: '2.1.2'
+  GO_FTW_VERSION: '2.3.0'
 
 jobs:
   regression:
@@ -67,7 +67,8 @@ jobs:
             -d tests/regression/tests \
             --log-file "tests/logs/${{ matrix.modsec_version }}/error.log" \
             --overrides tests/regression/${{ matrix.modsec_version == 'modsec2-apache' && 'httpd' || 'nginx' }}-overrides.yaml \
-            --show-failures-only
+            --show-failures-only \
+            --store-failure-waf-logs
 
       - name: "Change permissions of artifacts for upload"
         if: failure()


### PR DESCRIPTION
Update go-ftw and use the new `--store-failure-waf-logs` flag
