### PR TITLE
ci: harden workflows per zizmor audit

### DIFF
--- a/.github/workflows/check-pr-dependencies.yaml
+++ b/.github/workflows/check-pr-dependencies.yaml
@@ -1,4 +1,8 @@
 name: Check PR dependencies
+# Safe pull_request_target usage: this workflow does NOT check out PR code.
+# It only reads PR metadata via a pinned action and uses the default GITHUB_TOKEN
+# with `pull-requests: read`. No untrusted code executes in this job.
+# See .github/zizmor.yml for the corresponding zizmor ignore.
 on:
   pull_request_target:
     types:

--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -3,6 +3,10 @@ name: Check PR title
 # default token permissions: none
 permissions: {}
 
+# Safe pull_request_target usage: this workflow does NOT check out PR code.
+# It only validates the PR title via a pinned action and uses the default
+# GITHUB_TOKEN with `pull-requests: read`. No untrusted code executes in this job.
+# See .github/zizmor.yml for the corresponding zizmor ignore.
 on:
   pull_request_target:
     types:

--- a/.github/workflows/duty-scheduler.yaml
+++ b/.github/workflows/duty-scheduler.yaml
@@ -22,6 +22,7 @@ jobs:
           sparse-checkout: |
             scripts/generate-duty-report.sh
             docs/duty.html
+          persist-credentials: false
 
       - name: "Generate duty report"
         env:
@@ -30,9 +31,12 @@ jobs:
           ./scripts/generate-duty-report.sh ./docs/duty.html 1
 
       - name: "Commit and push"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add ./docs/duty.html
           git commit -m "Duty report - $(date -u +"%Y-%m-%d %H:%M:%S")"
-          git push
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${REPOSITORY}.git" HEAD:gh-pages

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Lint Yaml
         uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # v3.1.1

--- a/.github/workflows/quantitative-comment.yaml
+++ b/.github/workflows/quantitative-comment.yaml
@@ -1,0 +1,62 @@
+name: Quantitative tests - Post PR comment
+
+# This workflow runs in the base-repo context (with secrets) AFTER the
+# unprivileged `Quantitative tests` workflow finishes. It downloads the
+# `pr_comment.md` and `pr_number.txt` artifacts that workflow produced and
+# posts the comment on the originating PR. No PR-controlled code is executed
+# here — only the artifact contents (markdown + numeric PR id) are consumed.
+#
+# This pattern replaces a `pull_request_target` + PR-head checkout, which is
+# the classic "pwn request" antipattern.
+on:
+  workflow_run:
+    workflows: ["Quantitative tests"]
+    types:
+      - completed
+
+permissions: {}
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'skipped'
+    permissions:
+      pull-requests: write
+      actions: read
+    steps:
+      - name: "Download comment artifact"
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: quantitative-comment
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Read and validate PR number"
+        id: pr
+        run: |
+          PR_NUMBER=$(cat pr_number.txt)
+          # Strictly validate: must be only digits. The file came from an
+          # untrusted-context workflow run, so we treat its contents as input.
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "Invalid PR number in artifact: $PR_NUMBER"
+            exit 1
+          fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: "Comment PR (upsert by marker)"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          MARKER: "<!-- quantitative-tests-comment -->"
+        run: |
+          BODY=$(printf '%s\n\n%s\n' "$MARKER" "$(cat pr_comment.md)")
+          EXISTING=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" | head -n1)
+          if [ -n "$EXISTING" ]; then
+            gh api -X PATCH "repos/${REPO}/issues/comments/${EXISTING}" -f body="$BODY"
+          else
+            gh api -X POST "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="$BODY"
+          fi

--- a/.github/workflows/quantitative.yaml
+++ b/.github/workflows/quantitative.yaml
@@ -1,7 +1,12 @@
 name: Quantitative tests
 
+# Use the unprivileged `pull_request` trigger: this workflow checks out PR code
+# (potentially from a fork), so it must NOT have access to write tokens or
+# secrets. The companion workflow `quantitative-comment.yaml` runs on
+# `workflow_run` after this completes and posts the PR comment with the
+# elevated permissions required to write to PRs from forks.
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -26,12 +31,12 @@ jobs:
         size: ["10K"]
         paranoia_level: ["1"]
     permissions:
-      pull-requests: write
+      contents: read
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: "Checkout main repo"
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -39,12 +44,15 @@ jobs:
           repository: coreruleset/coreruleset
           ref: 'main'
           path: 'mainBranchFolder'
+          persist-credentials: false
+
       - name: "Install dependencies"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release download -R coreruleset/go-ftw "v${{ env.GO_FTW_VERSION }}" \
             -p "ftw_${{ env.GO_FTW_VERSION }}_linux_amd64.tar.gz" -O - | tar -xzvf - ftw
+
       - name: "Restore Cache"
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
@@ -54,19 +62,24 @@ jobs:
       - name: "Run tests for language: ${{ matrix.language }}, year: ${{ matrix.year}}, size: ${{ matrix.size }}, paranoia level: ${{ matrix.paranoia_level }}"
         id: quantitative
         continue-on-error: true
+        env:
+          LANGUAGE: ${{ matrix.language }}
+          YEAR: ${{ matrix.year }}
+          SIZE: ${{ matrix.size }}
+          PARANOIA_LEVEL: ${{ matrix.paranoia_level }}
         run: |
           ./ftw quantitative \
-            -L ${{ matrix.language }} \
-            -y ${{ matrix.year }} \
-            -s ${{ matrix.size }} \
-            -P ${{ matrix.paranoia_level }} \
+            -L "$LANGUAGE" \
+            -y "$YEAR" \
+            -s "$SIZE" \
+            -P "$PARANOIA_LEVEL" \
             -o json -f new_results.json
           ./ftw quantitative \
             -C ./mainBranchFolder \
-            -L ${{ matrix.language }} \
-            -y ${{ matrix.year }} \
-            -s ${{ matrix.size }} \
-            -P ${{ matrix.paranoia_level }} \
+            -L "$LANGUAGE" \
+            -y "$YEAR" \
+            -s "$SIZE" \
+            -P "$PARANOIA_LEVEL" \
             -o json -f old_results.json
           echo -e "\n📊 New Results"
           cat new_results.json | jq .
@@ -76,7 +89,7 @@ jobs:
           OLD_FALSE_POSITIVES=$(jq -r '.falsePositives' old_results.json)
           NEW_FALSE_POSITIVES=$(jq -r '.falsePositives' new_results.json)
 
-          echo -e "\n📊 Quantitative test results for language: \`${{ matrix.language }}\`, year: \`${{ matrix.year}}\`, size: \`${{ matrix.size }}\`, paranoia level: \`${{ matrix.paranoia_level }}\`:" > pr_comment.md
+          echo -e "\n📊 Quantitative test results for language: \`$LANGUAGE\`, year: \`$YEAR\`, size: \`$SIZE\`, paranoia level: \`$PARANOIA_LEVEL\`:" > pr_comment.md
           if [ "$NEW_FALSE_POSITIVES" -gt "$OLD_FALSE_POSITIVES" ]; then
             echo -e " ⚠️ Quantitative testing detected new false positives" >> pr_comment.md
             echo -e "📝 Total false positives: \`$OLD_FALSE_POSITIVES\` -> \`$NEW_FALSE_POSITIVES\`\n<details>\n" >> pr_comment.md
@@ -90,16 +103,28 @@ jobs:
             echo -e " 🚀 Quantitative testing did not detect new false positives" >> pr_comment.md
           fi
 
+      - name: "Save PR number for comment workflow"
+        if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo "$PR_NUMBER" > pr_number.txt
+
+      - name: "Upload comment artifact"
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: quantitative-comment
+          path: |
+            pr_comment.md
+            pr_number.txt
+          retention-days: 1
+
       - name: "Cache Corpus file"
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.ftw/*.txt
           key: ${{ matrix.language }}_news_${{ matrix.year }}_${{ matrix.size }}-sentences.txt
-      - name: "Comment PR"
-        uses: thollander/actions-comment-pull-request@65f9e5c9a1f2cd378bd74b2e057c9736982a8e74 # v3.0.1
-        with:
-          comment-tag: execution
-          file-path: pr_comment.md
 
   manual_approval:
     needs: regression

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          persist-credentials: false
 
       - name: "Install dependencies"
         env:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,14 @@
+rules:
+  dangerous-triggers:
+    ignore:
+      # Safe pull_request_target usage: these workflows do NOT check out PR
+      # code. They only read PR metadata via pinned actions with read-only
+      # token scopes. No untrusted code executes.
+      - check-pr-dependencies.yaml
+      - check-pr-title.yaml
+      # workflow_run is used here as the privileged half of the safe pattern
+      # that replaced pull_request_target + PR-head checkout in
+      # `quantitative.yaml`. This workflow consumes only artifact contents
+      # (markdown + numeric PR id, which is regex-validated) — it does not
+      # execute PR-supplied code.
+      - quantitative-comment.yaml


### PR DESCRIPTION
## what

- add `persist-credentials: false` to every `actions/checkout` call so the default `GITHUB_TOKEN` is not persisted into `.git/config` (`artipacked`). `duty-scheduler.yaml` now pushes via an explicit `https://x-access-token:${GH_TOKEN}@github.com/${REPOSITORY}` URL instead of relying on persisted creds.
- restructure `quantitative.yaml` to the safe two-workflow pattern. the test job now runs on `pull_request` (no secrets, read-only token, fork-safe) and writes `pr_comment.md` + a regex-validated `pr_number.txt` to an artifact. a new `quantitative-comment.yaml` triggers on `workflow_run` with `pull-requests: write`, downloads the artifact, and upserts the PR comment via `gh api` (marker `<!-- quantitative-tests-comment -->`). this eliminates the `pull_request_target` + PR-head checkout pwn-request antipattern (`dangerous-triggers`) and also drops the `thollander/actions-comment-pull-request` third-party dependency.
- matrix values in the test step moved to `env:` to avoid `${{ ... }}` interpolation inside `run:` bodies.
- new `.github/zizmor.yml` ignores the remaining safe findings with justification:
  - `check-pr-dependencies.yaml`, `check-pr-title.yaml` — `pull_request_target` is the standard pattern here; neither workflow checks out PR code, both consume only PR metadata via pinned actions with `pull-requests: read`.
  - `quantitative-comment.yaml` — `workflow_run` is the privileged half of the safe pattern; it consumes only artifact contents (markdown + numeric PR id) and never executes PR-supplied code.

## why

`zizmor` flagged 8 findings on this repo's workflows: 3 high-severity `dangerous-triggers` (`pull_request_target`) and 5 `artipacked` warnings. the `quantitative.yaml` finding is genuinely exploitable — `pull_request_target` runs with the base repo's secrets and `pull-requests: write`, and the workflow then checks out `${{ github.event.pull_request.head.sha }}` and operates on PR-controlled files. switching to the `pull_request` + `workflow_run` pattern keeps the same UX (a PR comment with the false-positive diff) while removing fork code from any privileged context.

after the changes, `zizmor` reports: `No findings to report. Good job! (3 ignored, 35 suppressed)`.

## refs

- zizmor — https://docs.zizmor.sh/audits/
- GitHub Security Lab "preventing pwn requests" — https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

## ai disclosure

- **tools used**: Claude (Opus 4.7, 1M context) via Claude Code
- **assisted with**: running `zizmor` on `.github/workflows/`, drafting the safe two-workflow split for `quantitative.yaml`, writing `.github/zizmor.yml` with per-rule justifications, replacing `thollander/actions-comment-pull-request` with a `gh api`-based marker upsert, looking up the `actions/download-artifact@v4.3.0` SHA via the GitHub API for pinning, drafting this PR description.
- **review performed**: re-ran `zizmor .github/workflows/` after each change and confirmed final state is clean (3 ignored, 35 suppressed); ran `actionlint` on all workflow files (no new findings introduced by these changes); confirmed all `actions/download-artifact` and `actions/checkout` SHAs match the documented tags; manually traced the `pull_request` → `workflow_run` data flow to confirm no PR-controlled code executes in the privileged half and that the `pr_number.txt` artifact is regex-validated (`^[0-9]+$`) before use in `gh api` paths.