### PR TITLE
feat: enable crs_validate_utf8_encoding by default

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -860,7 +860,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #
 # -- [[ Check UTF-8 encoding ]] ------------------------------------------------
 #
-# The CRS validates request parameters (REQUEST_FILENAME, ARGS, ARGS_NAMES)
+# CRS validates request parameters (REQUEST_FILENAME, ARGS, ARGS_NAMES)
 # for invalid UTF-8 encoding. Only UTF-8 is checked; other encodings
 # (e.g. UTF-16) are not validated.
 #

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -860,11 +860,14 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #
 # -- [[ Check UTF-8 encoding ]] ------------------------------------------------
 #
-# The CRS can optionally check request contents for invalid UTF-8 encoding.
-# We only want to apply this check if UTF-8 encoding is actually used by the
-# site; otherwise it will result in false positives.
+# The CRS validates request parameters (REQUEST_FILENAME, ARGS, ARGS_NAMES)
+# for invalid UTF-8 encoding. Only UTF-8 is checked; other encodings
+# (e.g. UTF-16) are not validated.
 #
-# Uncomment this rule to use this feature:
+# This check is _enabled_ by default.
+#
+# If your site sends request parameters in a non-UTF-8 encoding, this check
+# can cause false positives. Uncomment this rule to _disable_ the feature:
 #
 #SecAction \
 #    "id:900950,\
@@ -874,7 +877,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #    nolog,\
 #    tag:'OWASP_CRS',\
 #    ver:'OWASP_CRS/4.28.0-dev',\
-#    setvar:tx.crs_validate_utf8_encoding=1"
+#    setvar:tx.crs_validate_utf8_encoding=0"
 
 # -- [[ Skip Checking Responses ]] ------------------------------------------------
 #

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -286,7 +286,7 @@ SecRule &TX:crs_validate_utf8_encoding "@eq 0" \
     nolog,\
     tag:'OWASP_CRS',\
     ver:'OWASP_CRS/4.28.0-dev',\
-    setvar:'tx.crs_validate_utf8_encoding=0'"
+    setvar:'tx.crs_validate_utf8_encoding=1'"
 
 # Default check for skipping response analysis (rule 900500 in crs-setup.conf)
 SecRule &TX:crs_skip_response_analysis "@eq 0" \

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -16,7 +16,6 @@ x-common-env: &common-env
   MODSEC_RULE_ENGINE: DetectionOnly
   MODSEC_TMP_DIR: "/tmp"
   PORT: "8080"
-  VALIDATE_UTF8_ENCODING: 1
 
 x-apache-env: &apache-env
   <<: *common-env

--- a/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920250.yaml
+++ b/tests/regression/tests/REQUEST-920-PROTOCOL-ENFORCEMENT/920250.yaml
@@ -3,7 +3,7 @@ meta:
   author: "csanders-git, azurit"
 rule_id: 920250
 tests:
-  - # crs-setup.conf needs to have CRS_VALIDATE_UTF8_ENCODING set
+  - # crs_validate_utf8_encoding is enabled by default (rule 901169)
     # Taken from existing modsec regression
     test_id: 1
     stages:


### PR DESCRIPTION
## what

enables UTF-8 encoding validation (rule 920250) by default on `main`.

- `rules/REQUEST-901-INITIALIZATION.conf` (901169): default `tx.crs_validate_utf8_encoding` to `1` instead of `0`
- `crs-setup.conf.example`: documents the check as enabled by default; the `SecAction` (900950) now serves as the opt-out (sets the variable to `0`) for sites that send request parameters in a non-UTF-8 encoding. wording also clarifies that only UTF-8 is validated (UTF-16 and other encodings are not checked by `@validateUtf8Encoding`)
- `tests/docker-compose.yml`: removes the `VALIDATE_UTF8_ENCODING: 1` override so the regression suite exercises the new default rather than forcing it on
- `tests/.../920250.yaml`: updates the now-outdated comment

## why

per the decision recorded in the monthly chat (#4646): we don't have data either way on the false-positive impact, so we enable it by default on `main`, gather feedback from users, and decide on an LTS backport later.

`@validateUtf8Encoding` runs against `REQUEST_FILENAME|ARGS|ARGS_NAMES`. per the WHATWG URL standard and RFC 3986 convention, URLs and query strings are UTF-8 (non-ASCII is percent-encoded as UTF-8 bytes), so raw non-UTF-8 parameters are non-standard and the false-positive surface for legitimate traffic is small. sites that genuinely use a non-UTF-8 parameter encoding can opt out via 900950.

verification: full regression suite run with the new default. all `920250` tests pass driven solely by the default (env override removed). the only two failing tests (`920360-1`, `920380-1`) fail identically on the unmodified baseline and are unrelated to this change (they depend on arg-length/arg-count limits not applied by the test entrypoint).

## refs

- #4646

## ai disclosure

- **tools used**: Claude (Opus 4.8)
- **assisted with**: locating the config/init/test mechanism for the feature, drafting the `crs-setup.conf.example` comment rewording, PR description drafting
- **review performed**: ran the full go-ftw regression suite and confirmed `920250` passes on the new default with the `VALIDATE_UTF8_ENCODING` override removed; established a baseline by stashing the change and confirming the two unrelated failures (`920360-1`, `920380-1`) pre-exist; verified the operator only validates UTF-8 and confirmed the `@validateUtf8Encoding` target variables against the RFC 3986 / WHATWG URL conventions; checked there are no other references to the setting in docs/INSTALL/README