### PR TITLE
fix: Update restricted-files.data to include NPM subdirectories without causing FPs

### DIFF
--- a/rules/lfi-os-files.data
+++ b/rules/lfi-os-files.data
@@ -1062,7 +1062,8 @@ build.zig.zon
 # Red Hat Subscription Manager config
 .redhat/
 # NPM node modules
-node_modules/
+node_modules/.bin
+node_modules/.cache
 # Bun Dir
 .bun/
 # Bun global config

--- a/rules/restricted-files.data
+++ b/rules/restricted-files.data
@@ -627,8 +627,6 @@ build.zig.zon
 # NPM node modules
 node_modules/.bin/
 node_modules/.cache/
-node_modules/package.json
-node_modules/.package-lock.json
 # Bun Dir
 .bun/
 # Bun global config

--- a/rules/restricted-files.data
+++ b/rules/restricted-files.data
@@ -625,7 +625,10 @@ build.zig.zon
 # Red Hat Subscription Manager config
 .redhat/
 # NPM node modules
-# node_modules/
+node_modules/.bin/
+node_modules/.cache/
+node_modules/package.json
+node_modules/.package-lock.json
 # Bun Dir
 .bun/
 # Bun global config


### PR DESCRIPTION
# What?
Add node_modules/ common subdirs common like .bin and .cache and package.json and .package.lock.json
# Why?
Because node_modules/ alone can cause heavy fps alone, in the previous pr node_modules/ caused FPs because in loading static sites that is the problem, but after that, what do you think @EsadCetiner with that, while benefiting the detection with low FPs

# PRs associated with that
1- https://github.com/coreruleset/coreruleset/pull/4607
2- https://github.com/coreruleset/coreruleset/pull/4536