### PR TITLE
fix(rce): decode URL-encoded payloads in header RCE rules (#3504)

### DIFF
--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -1104,7 +1104,7 @@ SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer "@rx \$(?:\((?:[^\)]+
     phase:1,\
     block,\
     capture,\
-    t:none,t:cmdLine,\
+    t:none,t:urlDecodeUni,t:cmdLine,\
     msg:'Remote Command Execution: Unix Shell Expression Found',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
@@ -1747,7 +1747,7 @@ SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer "@rx (?i)(?:^|b[\"'\)
     phase:1,\
     block,\
     capture,\
-    t:none,\
+    t:none,t:urlDecodeUni,\
     msg:'Remote Command Execution: Unix Command Injection found in user-agent or referer header',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
@@ -1782,7 +1782,7 @@ SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer "@pmFromFile unix-she
     phase:1,\
     block,\
     capture,\
-    t:none,t:cmdLine,t:normalizePath,\
+    t:none,t:urlDecodeUni,t:cmdLine,t:normalizePath,\
     msg:'Remote Command Execution: Unix Shell Code Found in REQUEST_HEADERS',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
@@ -1950,7 +1950,7 @@ SecRule REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer "@rx (?i)\b(?:(?:7z[a
     phase:1,\
     block,\
     capture,\
-    t:none,t:cmdLine,t:normalizePath,\
+    t:none,t:urlDecodeUni,t:cmdLine,t:normalizePath,\
     msg:'Remote Command Execution: Unix Shell Code Found in REQUEST_HEADERS',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932131.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932131.yaml
@@ -35,3 +35,37 @@ tests:
         output:
           log:
             no_expect_ids: [932131]
+  - test_id: 3
+    desc: "URL-encoded Unix shell expression in Referer is detected after urlDecodeUni (#3504)"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          method: "GET"
+          port: 80
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Referer: "http://example.com/%24%28cat%20%2Fetc%2Fpasswd%29"
+            Host: "localhost"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          uri: "/get"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [932131]
+  - test_id: 4
+    desc: "Benign URL-encoded Referer must not false-positive after urlDecodeUni (#3504)"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          method: "GET"
+          port: 80
+          headers:
+            User-Agent: "Mozilla/5.0"
+            Referer: "https://example.com/my%20documents/report%202024.pdf"
+            Host: "localhost"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          uri: "/get"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [932131]

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932161.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932161.yaml
@@ -189,3 +189,37 @@ tests:
         output:
           log:
             expect_ids: [932161]
+  - test_id: 13
+    desc: "URL-encoded Unix RCE in Referer is detected after urlDecodeUni (#3504)"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          method: "GET"
+          port: 80
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Referer: "http://example.com/%3Bcat%20%2Fetc%2Fpasswd"
+            Host: "localhost"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          uri: "/get"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [932161]
+  - test_id: 14
+    desc: "Benign URL-encoded Referer must not false-positive after urlDecodeUni (#3504)"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          method: "GET"
+          port: 80
+          headers:
+            User-Agent: "Mozilla/5.0"
+            Referer: "https://example.com/my%20documents/report%202024.pdf"
+            Host: "localhost"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          uri: "/get"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [932161]

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932237.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932237.yaml
@@ -544,3 +544,37 @@ tests:
         output:
           log:
             no_expect_ids: [932237]
+  - test_id: 34
+    desc: "URL-encoded Unix RCE in Referer is detected after urlDecodeUni (#3504)"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          method: "GET"
+          port: 80
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Referer: "http://example.com/%3Bcat%20%2Fetc%2Fpasswd"
+            Host: "localhost"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          uri: "/get"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [932237]
+  - test_id: 35
+    desc: "Benign URL-encoded Referer must not false-positive after urlDecodeUni (#3504)"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          method: "GET"
+          port: 80
+          headers:
+            User-Agent: "Mozilla/5.0"
+            Referer: "https://example.com/my%20documents/report%202024.pdf"
+            Host: "localhost"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          uri: "/get"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [932237]

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932239.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932239.yaml
@@ -973,3 +973,37 @@ tests:
         output:
           log:
             no_expect_ids: [932239]
+  - test_id: 58
+    desc: "URL-encoded Unix RCE in Referer is detected after urlDecodeUni (#3504)"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          method: "GET"
+          port: 80
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Referer: "http://example.com/%3Bcat%20%2Fetc%2Fpasswd"
+            Host: "localhost"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          uri: "/get"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [932239]
+  - test_id: 59
+    desc: "Benign URL-encoded Referer must not false-positive after urlDecodeUni (#3504)"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          method: "GET"
+          port: 80
+          headers:
+            User-Agent: "Mozilla/5.0"
+            Referer: "https://example.com/my%20documents/report%202024.pdf"
+            Host: "localhost"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          uri: "/get"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [932239]


### PR DESCRIPTION
## Proposed changes

Fixes #3504.

The header-only RCE rules **932131, 932161, 932237, 932239** inspect the `User-Agent` and `Referer` headers but do not apply `t:urlDecodeUni`, so URL-encoded (and `%uXXXX`-encoded) payloads in those headers bypass detection. This adds `t:urlDecodeUni` (before `t:cmdLine`, matching the existing header-only rules 932205–932207 and the 932 convention) to all four, plus positive and negative regression tests per rule.

Repro on `main` (no decoding today):
- `Referer: http://example.com/%3Bcat%20%2Fetc%2Fpasswd` (`;cat /etc/passwd`) — not caught by 932161/932237/932239
- `Referer: http://example.com/%24%28cat%20%2Fetc%2Fpasswd%29` (`$(cat /etc/passwd)`) — not caught by 932131

### Scope justification

Per @theseion and @azurit on #3504, this affects more than 932239 — all four header-only RCE rules are updated. The mixed-target rules **932238/932340/932350** also read these headers but additionally inspect `ARGS`/`COOKIES`/`XML`, which ModSecurity already URL-decodes; adding `t:urlDecodeUni` there would double-decode `ARGS`, so they are intentionally left unchanged. Note **932340 is PL1**, so the encoded-header bypass still applies at the default paranoia level via that rule — closing it cleanly looks like it needs a separate header-only PL1 sibling (à la 932205–207); I've raised that as an open question on #3504. This change is transform-only, so no `regex-assembly` edits are required.

### Tests

Each rule's test file gets a positive test (encoded RCE payload in `Referer` is now detected) and a negative test (a benign URL-encoded `Referer` does not false-positive). Verified on **modsec2-apache** and **modsec3-nginx**: the full go-ftw regression suite passes, plain payloads still match (no regression), the encoded bypass is now detected at PL2+, and benign URL-encoded URLs do not false-positive. No regex changed, so there is no new ReDoS surface.

## AI Disclosure

**AI usage for this contribution: Used**

| Detail | Response |
|--------|----------|
| Tool(s) used | Claude (Anthropic) |
| What was AI-assisted | Regression-test scaffolding (the encoded/benign `Referer` YAML cases) and wording of this PR description. |
| Review performed | Root-cause analysis, the fix (transform selection + ordering), and all validation are mine: reproduced the bypass, confirmed the fix detects it and that plain payloads still match, ran the full go-ftw suite on modsec2-apache and modsec3-nginx (all pass), checked that benign URL-encoded URLs do not false-positive, and ran crs-linter / crs-toolchain clean. No regular expression was changed (transform-only), so there is no new ReDoS surface. |