### PR TITLE
fix(942200): revert to 4.23.0 - too many false positive on UA and Referer

### DIFF
--- a/regex-assembly/942200.ra
+++ b/regex-assembly/942200.ra
@@ -1,47 +1,23 @@
 ##! Please refer to the documentation at
 ##! https://coreruleset.org/docs/development/regex_assembly/.
 
-##! Detect the following patterns:
-##! - SELECT * FROM users WHERE username = 'admin', '1'='1'
-##! - INSERT INTO logs (ip, comment) VALUES ('192.168.0.1', 'test')
-##! - SELECT * FROM data WHERE hash = 'abc', 0x1a
-##! - SELECT * FROM orders WHERE product = 'item', (5)
-##! - ,varname"
-
-##! Do not detect things like French addresses:
-##! 999, rue d'Arlon
-
 ##!+ i
 
 ##! Helpers
-##!> define punctuation-plus ,.*?
+##!> define punctuation-hexnumbers ,.*?[)\da-f\"'`]
 
-##!> define hex-numbers [)\da-f]
-
-##!> define ticks \"'`
-
-##!> define ticks-class [{{ticks}}]
-
-##!> define not-ticks-class [^{{ticks}}]
+##!> define ticks [\"'`]
 
 ##!> define spaces \s*?\(\s*?space\s*?\(
 
 ##! Main assembly
 ##!> assemble
-  ##!> assemble
-    {{punctuation-plus}}{{hex-numbers}}
-    ##!=>
-    $
-    {{ticks-class}}$
-    {{ticks-class}}{{not-ticks-class}}+{{ticks-class}}
-    \z
-    \n\z
-    \r\n\z
-    ##!=>
-  ##!<
-  ##!> assemble
-    {{punctuation-plus}}{{ticks-class}}{{not-ticks-class}}+{{ticks-class}}
-  ##!<
+  {{punctuation-hexnumbers}}{{ticks}}
+  ##!=>
+  {{ticks}}.*?{{ticks}}
+  (?:\r?\n)?\z
+  [^\"'`]+
+  ##!=>
 ##!<
 
 \Wselect.+\W*?from

--- a/regex-assembly/942200.ra
+++ b/regex-assembly/942200.ra
@@ -14,9 +14,9 @@
 ##!+ i
 
 ##! Helpers
-##!> define comma-plus ,[^)]*?
+##!> define punctuation-plus ,.*?
 
-##!> define hex-numbers [\da-f]+
+##!> define hex-numbers [)\da-f]
 
 ##!> define ticks \"'`
 
@@ -29,9 +29,7 @@
 ##! Main assembly
 ##!> assemble
   ##!> assemble
-    {{comma-plus}}{{hex-numbers}}
-    {{comma-plus}}\({{hex-numbers}}\)
-    \([^,]+(?:,\s*{{hex-numbers}})+\)
+    {{punctuation-plus}}{{hex-numbers}}
     ##!=>
     $
     {{ticks-class}}$
@@ -42,7 +40,7 @@
     ##!=>
   ##!<
   ##!> assemble
-    {{comma-plus}}{{ticks-class}}{{not-ticks-class}}+{{ticks-class}}
+    {{punctuation-plus}}{{ticks-class}}{{not-ticks-class}}+{{ticks-class}}
   ##!<
 ##!<
 

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -841,7 +841,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 942200 942200-chain1
 #
-SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?:,[^\)]*?(?:[0-9a-f]+|\([0-9a-f]+\))|\([^,]+(?:,[\s\x0b]*[0-9a-f]+)+\))(?:$|[\"'`](?:$|[^\"'`]+[\"'`])|(?:\r?\n)?\z)|,[^\)]*?[\"'`][^\"'`]+[\"'`]|[^0-9A-Z_a-z]select.+[^0-9A-Z_a-z]*?from|(?:alter|(?:(?:cre|trunc|upd)at|renam)e|d(?:e(?:lete|sc)|rop)|(?:inser|selec)t|load)[\s\x0b]*?\([\s\x0b]*?space[\s\x0b]*?\(" \
+SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@rx (?i),.*?(?:[\)0-9a-f](?:$|[\"'`](?:$|[^\"'`]+[\"'`])|(?:\r?\n)?\z)|[\"'`][^\"'`]+[\"'`])|[^0-9A-Z_a-z]select.+[^0-9A-Z_a-z]*?from|(?:alter|(?:(?:cre|trunc|upd)at|renam)e|d(?:e(?:lete|sc)|rop)|(?:inser|selec)t|load)[\s\x0b]*?\([\s\x0b]*?space[\s\x0b]*?\(" \
     "id:942200,\
     phase:2,\
     block,\

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -841,7 +841,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)(?
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 942200 942200-chain1
 #
-SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@rx (?i),.*?(?:[\)0-9a-f](?:$|[\"'`](?:$|[^\"'`]+[\"'`])|(?:\r?\n)?\z)|[\"'`][^\"'`]+[\"'`])|[^0-9A-Z_a-z]select.+[^0-9A-Z_a-z]*?from|(?:alter|(?:(?:cre|trunc|upd)at|renam)e|d(?:e(?:lete|sc)|rop)|(?:inser|selec)t|load)[\s\x0b]*?\([\s\x0b]*?space[\s\x0b]*?\(" \
+SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|XML:/* "@rx (?i),.*?[\"'\)0-9`-f][\"'`](?:[\"'`].*?[\"'`]|(?:\r?\n)?\z|[^\"'`]+)|[^0-9A-Z_a-z]select.+[^0-9A-Z_a-z]*?from|(?:alter|(?:(?:cre|trunc|upd)at|renam)e|d(?:e(?:lete|sc)|rop)|(?:inser|selec)t|load)[\s\x0b]*?\([\s\x0b]*?space[\s\x0b]*?\(" \
     "id:942200,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942200.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942200.yaml
@@ -373,3 +373,35 @@ tests:
         output:
           log:
             no_expect_ids: [942200]
+  - test_id: 23
+    desc: "Do not match comma in user agent strings: Facebook on Mac"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/22H352 Safari/604.1 [FBAN/FBIOS;FBAV/564.0.0.57.71;FBBV/985438427;FBDV/iPhone11,2;FBMD/iPhone;FBSN/iOS;FBSV/18.7.8;FBSS/3;FBID/phone;FBLC/fr_FR;FBOP/5;FBRV/990999493;IABMV/1];FBNV/1"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: GET
+          port: 80
+          uri: "/"
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids: [942200]
+  - test_id: 24
+    desc: "Do not match comma in user agent strings: Microsoft Office Outlook on Mac"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "Microsoft Office Outlook/16.100.824 (Mac OS/15.6.1; Desktop; fr-FR; NonAppStore; Apple/Mac16,7)"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: GET
+          port: 80
+          uri: "/"
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids: [942200]

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942200.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942200.yaml
@@ -337,3 +337,39 @@ tests:
         output:
           log:
             expect_ids: [942200]
+  - test_id: 21
+    desc: |
+      Referer header: presence of a comma within a parameter used to list multiple items, a common pattern in search engines and faceted navigation systems found in CMS platforms such as PrestaShop and WooCommerce.
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Referer: https://www.test.fr/327-peintures-interieur?categories=peintures-de-decorations,peintures-de-finitions&page=2
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: GET
+          port: 80
+          uri: "/"
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids: [942200]
+  - test_id: 22
+    desc: |
+      Referer header: presence of a comma within a parameter used to list multiple items, a common pattern in search engines and faceted navigation systems found in CMS platforms such as PrestaShop and WooCommerce.
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Referer: https://www.test.fr/?filter_product_brand=5432,5646,5380
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: GET
+          port: 80
+          uri: "/"
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids: [942200]

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942200.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942200.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "Christian S.J. Peron, Franziska Bühler, azurit, Esad Cetiner"
+  author: "Christian S.J. Peron, Franziska Bühler, azurit, Esad Cetiner, touchweb_vincent"
 rule_id: 942200
 tests:
   - test_id: 1


### PR DESCRIPTION
## Proposed changes

Hello,

The new regex is currently matching virtually any sequence containing `,\d+`, which is not acceptable given the volume of legitimate traffic patterns that follow this format.

This creates a significant false-positive risk across both User-Agent and Referer headers. Common examples include application versioning, browser metadata, tracking parameters, faceted navigation, and search-related URLs. As a result, the current implementation dramatically broadens the detection scope and risks triggering on a substantial amount of legitimate traffic.

In practice, this level of false positives is likely to lead operators to disable the rule entirely, which would effectively defeat its original purpose.

For this reason, I do not believe the rule can reasonably remain in its current state. I recommend reverting to the previous regex while a more targeted implementation is discussed.

Additional unit tests have been added to demonstrate the issue.

What do you think ?

Vincent



<!-- Github Tip: adding the text 'Fixes #<issue>' or 'Closes #<issue>' will automatically close the mentioned issue. -->

## PR Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/CONTRIBUTING.md) doc
- [x] I have added positive tests proving my fix/feature works as intended.
- [x] I have added negative tests that prove my fix/feature considers common cases that might end in false positives
- [ ] In case you changed a regular expression, you are not adding a ReDOS for pcre. You can check this using [regexploit](https://github.com/doyensec/regexploit)
- [ ] My test use the `comment` field to write the expected behavior
- [ ] I have added documentation for the rule or change (when appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... If there are no additional comments, you may remove this section. -->

## AI Disclosure

<!-- Required per our AI-Assisted Contribution Policy (AI-CONTRIBUTIONS.md) -->

<!-- Select exactly one by deleting the option that does not apply. -->
**AI usage for this contribution:** None / Used

**If "Used", complete the details below:**

| Detail | Response |
|--------|----------|
| Tool(s) used | <!-- e.g., GitHub Copilot, Claude 4, ChatGPT-4o --> |
| What was AI-assisted | <!-- e.g., initial regex draft, test scaffolding, docs wording --> |
| Review performed | <!-- e.g., validated against payload corpus, ran test suite, manual review --> |

## For the reviewer

<!-- Don't remove this part. Reviewers will use it as guidance for the review process. -->

- [ ] Positive and negative tests were added
- [ ] Tests cover the intended fix/feature properly
- [ ] No usage of dangerous constructs like `ctl:requestBodyAccess=Off` were used in the rule
- [ ] In case a regular expression was changed, [there is no ReDOS](https://github.com/coreruleset/coreruleset/wiki/Testing-for-Regular-Expresion-DoS)
- [ ] Documentation is clear for the rule/change
- [ ] If a contribution shows signs of unreviewed AI generation (e.g., plausible-but-broken regex, generic boilerplate comments, hallucinated SecLang directives), reviewers should ask about AI usage regardless of what was checked.
