### PR TITLE
fix: remove exponential backtracking in 933160/933161 comment suffix

### DIFF
--- a/regex-assembly/933160.ra
+++ b/regex-assembly/933160.ra
@@ -7,8 +7,12 @@
 ##! optional quotes
 ##!^ ['\"]*
 
-##! match comments: `/*...*/`, `//...`, `#...`
-##!$ (?:/\*.*?\*/|//[^\r\n]*|#[^\r\n]*
+##! match comments: `/*...*/` (unrolled to avoid exponential backtracking),
+##! and line comments `//...` / `#...`. Line comments must terminate at a line
+##! break: a line comment before `(` is only reachable across a newline,
+##! otherwise the `(` would be inside the comment. The branches are kept
+##! unambiguous to avoid exponential backtracking (ReDoS).
+##!$ (?:/\*[^*]*\*+(?:[^/*][^*]*\*+)*/|(?:#|//)[^\r\n]*[\r\n]
 ##! match white space and quotes
 ##!$ |\s|\")*
 

--- a/regex-assembly/933160.ra
+++ b/regex-assembly/933160.ra
@@ -7,11 +7,24 @@
 ##! optional quotes
 ##!^ ['\"]*
 
-##! match comments: `/*...*/` (unrolled to avoid exponential backtracking),
-##! and line comments `//...` / `#...`. Line comments must terminate at a line
-##! break: a line comment before `(` is only reachable across a newline,
-##! otherwise the `(` would be inside the comment. The branches are kept
-##! unambiguous to avoid exponential backtracking (ReDoS).
+##! Comments and whitespace allowed between the command and its argument
+##! list. The branches are kept mutually unambiguous (no two branches can
+##! match the same character) to avoid exponential backtracking (ReDoS).
+##!
+##! Block comment, written using the "unrolling-the-loop" technique
+##! (Jeffrey Friedl, "Mastering Regular Expressions", O'Reilly) instead of
+##! the ambiguous `/\*.*\*/`:
+##!   /\*                 literal `/*` opener
+##!   [^*]*               run of non-`*` characters
+##!   \*+                 one or more `*`
+##!   (?:[^/*][^*]*\*+)*   repeat: a character that is neither `/` nor `*`
+##!                       (so not the closer), then more non-`*`, then `*`s
+##!   /                   literal `/` closer
+##!
+##! Line comments (`#` and `//`) must terminate at a line break (`[\r\n]`):
+##! everything from `#`/`//` up to the newline is the comment body, so only
+##! across a newline can the following tokens (quotes, the argument
+##! parentheses) be matched.
 ##!$ (?:/\*[^*]*\*+(?:[^/*][^*]*\*+)*/|(?:#|//)[^\r\n]*[\r\n]
 ##! match white space and quotes
 ##!$ |\s|\")*

--- a/regex-assembly/933161.ra
+++ b/regex-assembly/933161.ra
@@ -8,7 +8,8 @@
 ##! Suffix: optional whitespace and PHP comments between the function name and
 ##! the opening parenthesis. The branches are kept unambiguous to avoid
 ##! exponential backtracking (ReDoS):
-##!   - block comments use the unrolled (Friedl) form, not /\*.*\*/
+##!   - block comments use the "unrolling-the-loop" form (Jeffrey Friedl,
+##!     "Mastering Regular Expressions", O'Reilly), not /\*.*\*/
 ##!   - line comments (# and //) must terminate at a line break, because a
 ##!     line comment before '(' is only reachable across a newline (otherwise
 ##!     the '(' would be inside the comment and there is no function call)

--- a/regex-assembly/933161.ra
+++ b/regex-assembly/933161.ra
@@ -5,7 +5,14 @@
 
 ##!+ i
 ##!^ \b
-##!$ (?:\s|/\*.*\*/|#.*|//.*)*\(.*\)
+##! Suffix: optional whitespace and PHP comments between the function name and
+##! the opening parenthesis. The branches are kept unambiguous to avoid
+##! exponential backtracking (ReDoS):
+##!   - block comments use the unrolled (Friedl) form, not /\*.*\*/
+##!   - line comments (# and //) must terminate at a line break, because a
+##!     line comment before '(' is only reachable across a newline (otherwise
+##!     the '(' would be inside the comment and there is no function call)
+##!$ (?:\s|/\*[^*]*\*+(?:[^/*][^*]*\*+)*/|(?:#|//)[^\n\r]*[\n\r])*\(.*\)
 
 abs
 asin

--- a/regex-assembly/933161.ra
+++ b/regex-assembly/933161.ra
@@ -5,14 +5,23 @@
 
 ##!+ i
 ##!^ \b
-##! Suffix: optional whitespace and PHP comments between the function name and
-##! the opening parenthesis. The branches are kept unambiguous to avoid
-##! exponential backtracking (ReDoS):
-##!   - block comments use the "unrolling-the-loop" form (Jeffrey Friedl,
-##!     "Mastering Regular Expressions", O'Reilly), not /\*.*\*/
-##!   - line comments (# and //) must terminate at a line break, because a
-##!     line comment before '(' is only reachable across a newline (otherwise
-##!     the '(' would be inside the comment and there is no function call)
+##! Optional whitespace and PHP comments between the function name and
+##! the opening parenthesis. The branches are kept mutually unambiguous (no two branches can
+##! match the same character) to avoid exponential backtracking (ReDoS).
+##!
+##! Block comment, written using the "unrolling-the-loop" technique
+##! (Jeffrey Friedl, "Mastering Regular Expressions", O'Reilly) instead of
+##! the ambiguous `/\*.*\*/`:
+##!   /\*                 literal `/*` opener
+##!   [^*]*               run of non-`*` characters
+##!   \*+                 one or more `*`
+##!   (?:[^/*][^*]*\*+)*   repeat: a character that is neither `/` nor `*`
+##!                       (so not the closer), then more non-`*`, then `*`s
+##!   /                   literal `/` closer
+##!
+##!   Line comments (# and //) must terminate at a line break, because a
+##!   line comment before '(' is only reachable across a newline (otherwise
+##!   the '(' would be inside the comment and there is no function call)
 ##!$ (?:\s|/\*[^*]*\*+(?:[^/*][^*]*\*+)*/|(?:#|//)[^\n\r]*[\n\r])*\(.*\)
 
 abs

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -384,7 +384,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|X
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 933160
 #
-SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\b\(?[\"']*(?:assert(?:_options)?|c(?:hr|reate_function)|e(?:val|x(?:ec|p))|f(?:ile(?:group)?|open|puts)|glob|i(?:mage(?:gif|(?:jpe|pn)g|wbmp|xbm)|s_a|ntval)|m(?:d5|kdir)|o(?:pendir|rd)|p(?:assthru|hpinfo|open|r(?:intf|ev))|r(?:eadfile|trim)|s(?:t(?:rip_tags|at)|ubstr|ystem)|tmpfile|u(?:n(?:(?:pac|lin)k|serialize)|sort))(?:/(?:\*.*?\*/|/[^\n\r]*)|#[^\n\r]*|[\s\x0b\"])*[\"']*\)?[\s\x0b]*\([^\)]*\)" \
+SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\b\(?[\"']*(?:assert(?:_options)?|c(?:hr|reate_function)|e(?:val|x(?:ec|p))|f(?:ile(?:group)?|open|puts)|glob|i(?:mage(?:gif|(?:jpe|pn)g|wbmp|xbm)|s_a|ntval)|m(?:d5|kdir)|o(?:pendir|rd)|p(?:assthru|hpinfo|open|r(?:intf|ev))|r(?:eadfile|trim)|s(?:t(?:rip_tags|at)|ubstr|ystem)|tmpfile|u(?:n(?:(?:pac|lin)k|serialize)|sort))(?:/\*[^\*]*\*+(?:[^\*/][^\*]*\*+)*/|(?:#|//)[^\n\r]*[\n\r]|[\s\x0b\"])*[\"']*\)?[\s\x0b]*\([^\)]*\)" \
     "id:933160,\
     phase:2,\
     block,\
@@ -814,7 +814,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx AUTH_T
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 933161
 #
-SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\b(?:a(?:bs|s(?:in|sert(?:_options)?))|basename|c(?:h(?:eckdate|r(?:oot)?)|o(?:(?:mpac|(?:nsta|u)n)t|py|sh?)|r(?:eate_function|ypt)|urrent)|d(?:ate|e(?:coct|fined?)|ir)|e(?:nd|val|x(?:ec|p(?:lode)?|tract))|f(?:ile(?:(?:[acm]tim|inod|siz|typ)e|group|owner|perms)?|l(?:o(?:ck|or)|ush))|glob|h(?:ash|eader)|i(?:date|m(?:age(?:gif|(?:jpe|pn)g|wbmp|xbm)|plode)|s_a)|key|l(?:ink|og)|m(?:a(?:il|x)|d5|in)|n(?:ame|ext)|o(?:pendir|rd)|p(?:a(?:ck|ss(?:thru)?)|i|o(?:pen|w)|rev)|r(?:an(?:d|ge)|e(?:(?:adfil|nam)e|set)|ound)|s(?:(?:erializ|huffl)e|in|leep|(?:or|ta)t|ubstr|y(?:mlink|s(?:log|tem)))|t(?:an|(?:im|mpfil)e|ouch|rim)|u(?:cfirst|n(?:lin|pac)k)|virtual)(?:[\s\x0b]|/\*.*\*/|(?:#|//).*)*\(.*\)" \
+SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "@rx (?i)\b(?:a(?:bs|s(?:in|sert(?:_options)?))|basename|c(?:h(?:eckdate|r(?:oot)?)|o(?:(?:mpac|(?:nsta|u)n)t|py|sh?)|r(?:eate_function|ypt)|urrent)|d(?:ate|e(?:coct|fined?)|ir)|e(?:nd|val|x(?:ec|p(?:lode)?|tract))|f(?:ile(?:(?:[acm]tim|inod|siz|typ)e|group|owner|perms)?|l(?:o(?:ck|or)|ush))|glob|h(?:ash|eader)|i(?:date|m(?:age(?:gif|(?:jpe|pn)g|wbmp|xbm)|plode)|s_a)|key|l(?:ink|og)|m(?:a(?:il|x)|d5|in)|n(?:ame|ext)|o(?:pendir|rd)|p(?:a(?:ck|ss(?:thru)?)|i|o(?:pen|w)|rev)|r(?:an(?:d|ge)|e(?:(?:adfil|nam)e|set)|ound)|s(?:(?:erializ|huffl)e|in|leep|(?:or|ta)t|ubstr|y(?:mlink|s(?:log|tem)))|t(?:an|(?:im|mpfil)e|ouch|rim)|u(?:cfirst|n(?:lin|pac)k)|virtual)(?:[\s\x0b]|/\*[^\*]*\*+(?:[^\*/][^\*]*\*+)*/|(?:#|//)[^\n\r]*[\n\r])*\(.*\)" \
     "id:933161,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933161.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933161.yaml
@@ -90,3 +90,168 @@ tests:
         output:
           log:
             no_expect_ids: [933161]
+  - test_id: 6
+    desc: "block comment between function name and parens: checkdate/*x*/()"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: "*/*"
+          method: GET
+          port: 80
+          uri: "/get?foo=checkdate%2f%2ax%2a%2f%28%29"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [933161]
+  - test_id: 7
+    desc: "// line comment terminated by a newline before parens: symlink//c\\n()"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: "*/*"
+          method: GET
+          port: 80
+          uri: "/get?foo=symlink%2f%2fc%0a%28%29"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [933161]
+  - test_id: 8
+    desc: "# line comment terminated by a newline before parens: serialize#c\\n()"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: "*/*"
+          method: GET
+          port: 80
+          uri: "/get?foo=serialize%23c%0a%28%29"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [933161]
+  - test_id: 9
+    desc: "multi-line block comment between function name and parens: touch/*a\\r\\nb*/()"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: "*/*"
+          method: GET
+          port: 80
+          uri: "/get?foo=touch%2f%2aa%0d%0ab%2a%2f%28%29"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [933161]
+  - test_id: 10
+    desc: "vertical tab as separator before parens: pi\\x0b()"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: "*/*"
+          method: GET
+          port: 80
+          uri: "/get?foo=pi%0b%28%29"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [933161]
+  - test_id: 11
+    desc: "mixed whitespace and block comment before parens: range \\t/*x*/()"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: "*/*"
+          method: GET
+          port: 80
+          uri: "/get?foo=range%20%09%2f%2ax%2a%2f%28%29"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [933161]
+  - test_id: 12
+    desc: "function call with arguments inside the parens: crypt(abc)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: "*/*"
+          method: GET
+          port: 80
+          uri: "/get?foo=crypt%28abc%29"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [933161]
+  - test_id: 13
+    desc: |
+      Negative - function name as a substring without a word boundary
+      (xcheckdate) must not match
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: "*/*"
+          method: GET
+          port: 80
+          uri: "/get?foo=xcheckdate%28%29"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [933161]
+  - test_id: 14
+    desc: |
+      Negative - a # line comment without a trailing newline puts the parens
+      inside the comment, so it is not a function call: symlink#x()
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: "*/*"
+          method: GET
+          port: 80
+          uri: "/get?foo=symlink%23x%28%29"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [933161]
+  - test_id: 15
+    desc: |
+      Negative - bare function name without parentheses must not match
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: "*/*"
+          method: GET
+          port: 80
+          uri: "/get?foo=checkdate"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [933161]


### PR DESCRIPTION
## what

- de-ambiguate the whitespace/comment suffix in the PHP function-call rules 933160 and 933161 to remove exponential backtracking on backtracking regex engines
- block comments now use the unrolled form instead of `/\*.*\*/`
- line comments (`#`, `//`) must terminate at a line break
- expand the 933161 test file from 4 to 14 active tests (comment/whitespace evasions plus negatives)

## why

- the suffix matched optional whitespace and PHP comments between a function name and the opening `(` with an ambiguous alternation: the whitespace branch and the comment bodies could both consume the same characters under a `*` quantifier. an input that never reaches `(` can then backtrack exponentially.
- RE2 (Coraza) is not affected, and PCRE2's required-literal optimization tames the live case, but the pattern is structurally fragile. de-ambiguating the alternation removes the issue without relying on engine-specific optimizations, and keeps everything RE2-compatible (no atomic groups).
- the line-comment change is also more correct: a `#` or `//` comment placed before `(` is only reachable across a newline; without a newline the `(` is inside the comment and there is no function call. one resulting behavior change: `func#x()` on a single line no longer matches (it is not an executable call).

verification: flat (sub-millisecond at n=4000) on both Python `re` and PCRE2 (`grep -P`) under DOTALL; all 933161 (14) and full REQUEST-933 (412) go-ftw tests pass on a freshly reloaded engine; `crs-linter` clean; `.ra` format check clean.

## refs

- relates to #3693 (test `933161-4` cleanup)

## ai disclosure

- **tools used**: Claude (Opus 4.8)
- **assisted with**: regex de-ambiguation design for the comment/whitespace suffix, `.ra` edits, regeneration via crs-toolchain, test scaffolding for 933161, PR description drafting
- **review performed**: confirmed the original suffix is exponential and the new one is flat (sub-ms at n=4000) on Python `re` and PCRE2 `grep -P`, both under DOTALL to match ModSecurity's engine behavior; verified functional parity of all legitimate evasions and negatives; ran the full REQUEST-933 go-ftw suite (412/412) on a freshly reloaded container after confirming a stale-container false pass; ran crs-linter v1.0.0 (exit 0, no errors) and `crs-toolchain regex format --check`