### PR TITLE
fix(941140): remove exponential backtracking in CSS url(javascript) detection

### DIFF
--- a/regex-assembly/941140.ra
+++ b/regex-assembly/941140.ra
@@ -1,0 +1,30 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Detects CSS-based XSS that reaches `url(javascript:...)` inside a style
+##! declaration, e.g. <p style="background:url(javascript:alert(1))">.
+##! An optional list of `name:value;` declarations may precede the payload.
+##!
+##! The declaration value is bounded with `[^;]` instead of a free `.+` to
+##! avoid exponential backtracking (ReDoS): a free `.+` next to the `[^:=]+`
+##! key inside the `*`-quantified declaration list lets the same characters
+##! be consumed in more than one way. `[^;]` stops the value at the
+##! declaration separator, so each declaration is matched exactly once.
+
+##!+ i
+
+##! A declaration key contains no `:` (name/value separator) or `=`.
+##!> define decl-key [^:=]+
+##! A declaration value runs up to the `;` separator.
+##!> define decl-value [^;]+
+
+##!> assemble
+  ##! attribute/property assignment, e.g. `style=`
+  [a-z]+=
+  ##!=>
+  ##! optional, lazily-matched list of `key:value;` declarations
+  (?:{{decl-key}}:{{decl-value}};)*?
+  ##!=>
+  ##! the payload: a final `key:url(javascript`
+  {{decl-key}}:url\(javascript
+##!<

--- a/regex-assembly/941140.ra
+++ b/regex-assembly/941140.ra
@@ -6,10 +6,14 @@
 ##! An optional list of `name:value;` declarations may precede the payload.
 ##!
 ##! The declaration value is bounded with `[^;]` instead of a free `.+` to
-##! avoid exponential backtracking (ReDoS): a free `.+` next to the `[^:=]+`
-##! key inside the `*`-quantified declaration list lets the same characters
-##! be consumed in more than one way. `[^;]` stops the value at the
-##! declaration separator, so each declaration is matched exactly once.
+##! avoid exponential backtracking (ReDoS): inside the `*`-quantified
+##! declaration list, a free `.+` and the `[^:=]+` key can consume the same
+##! characters in more than one way. `[^;]` stops the value at the `;`
+##! separator, so each declaration is matched exactly once.
+##!
+##! The rule applies `t:removeWhitespace`, so the input is whitespace-free by
+##! the time the regex runs; the character classes here intentionally do not
+##! account for whitespace.
 
 ##!+ i
 

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -211,7 +211,12 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|ARGS_NA
 # https://portswigger.net/web-security/cross-site-scripting/cheat-sheet#behaviors-for-older-modes-of-ie
 # examples: https://regex101.com/r/FFEpsh/1
 #
-SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@rx (?i)[a-z]+=(?:[^:=]+:.+;)*?[^:=]+:url\(javascript" \
+# Regular expression generated from regex-assembly/941140.ra.
+# To update the regular expression run the following shell script
+# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
+#   crs-toolchain regex update 941140
+#
+SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|REQUEST_HEADERS:User-Agent|REQUEST_HEADERS:Referer|ARGS_NAMES|ARGS|REQUEST_FILENAME|XML:/* "@rx (?i)[a-z]+=(?:[^:=]+:[^;]+;)*?[^:=]+:url\(javascript" \
     "id:941140,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941140.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941140.yaml
@@ -199,7 +199,7 @@ tests:
           log:
             no_expect_ids: [941140]
   - test_id: 13
-    desc: "ReDoS regression: long declaration list, no payload"
+    desc: "regression sample for the bounded declaration value: a long key:value; list with no url(javascript payload must not match (no false positive). On PCRE2 (the engine under test) both the old and new patterns complete quickly, so this is a no-match canary for the unbounded-value shape, not a latency assertion"
     stages:
       - input:
           dest_addr: 127.0.0.1

--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941140.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941140.yaml
@@ -70,3 +70,163 @@ tests:
         output:
           log:
             expect_ids: [941140]
+  - test_id: 5
+    desc: "multi-declaration list before payload, e.g. style=color:red;background:url(javascript"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          method: GET
+          port: 80
+          uri: "/get/bar?test=style%3Dcolor%3Ared%3Bbackground%3Aurl%28javascript%3Aalert%281%29%29"
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: localhost
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [941140]
+  - test_id: 6
+    desc: "two declarations before payload"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          method: GET
+          port: 80
+          uri: "/get/bar?test=style%3Da%3Ab%3Bc%3Ad%3Bbackground%3Aurl%28javascript%3Aalert%281%29%29"
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: localhost
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [941140]
+  - test_id: 7
+    desc: "declaration value containing colons"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          method: GET
+          port: 80
+          uri: "/get/bar?test=a%3Dk%3Av%3Aw%3Bm%3Aurl%28javascript%3Aalert%281%29%29"
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: localhost
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [941140]
+  - test_id: 8
+    desc: "case-insensitive URL(JAVASCRIPT"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          method: GET
+          port: 80
+          uri: "/get/bar?test=STYLE%3DX%3AURL%28JAVASCRIPT"
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: localhost
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [941140]
+  - test_id: 9
+    desc: "whitespace removed by t:removeWhitespace"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          method: GET
+          port: 80
+          uri: "/get/bar?test=style%20%3D%20background%20%3A%20url%20%28%20javascript%20%3A%20alert%281%29%20%29"
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: localhost
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [941140]
+  - test_id: 10
+    desc: "many declarations then payload via User-Agent"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          method: GET
+          port: 80
+          uri: "/get/bar"
+          headers:
+            User-Agent: "x=k:v;k:v;k:v;k:v;k:v;k:v;k:v;k:v;z:url(javascript"
+            Host: localhost
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [941140]
+  - test_id: 11
+    desc: "benign declarations, no payload"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          method: GET
+          port: 80
+          uri: "/get/bar?test=style%3Dcolor%3Ared%3Bbackground%3Awhite"
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: localhost
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [941140]
+  - test_id: 12
+    desc: "url scheme is not javascript"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          method: GET
+          port: 80
+          uri: "/get/bar?test=style%3Dbackground%3Aurl%28http%3A%2F%2Fexample.com%2Fx%29"
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: localhost
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [941140]
+  - test_id: 13
+    desc: "ReDoS regression: long declaration list, no payload"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          method: GET
+          port: 80
+          uri: "/get/bar?test=style%3Da%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3Ba%3Ab%3B"
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: localhost
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [941140]
+  - test_id: 14
+    desc: "url(javascript without a name= assignment"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          method: GET
+          port: 80
+          uri: "/get/bar?test=url%28javascript%3Aalert%281%29%29"
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: localhost
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [941140]


### PR DESCRIPTION
## what

moves rule 941140 (CSS-based XSS via `url(javascript:...)`) from an inline pattern to `regex-assembly/941140.ra` and removes its exponential backtracking. the declaration-list loop previously used a free `.+`:

- before: `(?i)[a-z]+=(?:[^:=]+:.+;)*?[^:=]+:url\(javascript`
- after: `(?i)[a-z]+=(?:[^:=]+:[^;]+;)*?[^:=]+:url\(javascript`

the `.+` (DOTALL) sat next to the `[^:=]+` key inside the `*`-quantified declaration list, so the same characters could be consumed in more than one way. bounding the value with `[^;]` (it stops at the declaration separator) makes each declaration match exactly once.

the new `.ra` decomposes the pattern with named defines (`decl-key`, `decl-value`) and a three-part sequence so the bound is self-documenting. expands the tests from 4 to 14 (multi-declaration lists, colon-containing values, case-insensitivity, the `t:removeWhitespace` path, the User-Agent source, benign no-match cases, and a ReDoS-regression no-match with a long declaration list).

## why

with `.` matching newlines (DOTALL, as ModSecurity runs `@rx`), the free `.+` next to `[^:=]+` under the repeat is ambiguous, so an input without a trailing `url(javascript` backtracks exponentially. measured on Python `re` (DOTALL): the old pattern timed out by n≈30 (`a=` + `x:y;`×n); the new pattern is flat (1.4 ms at n=8000). PCRE2 and RE2 already tame the old form (PCRE2 via auto-possessification, RE2 has no backtracking), so this is a moderate-severity hardening on backtracking engines, the same tier as the 933160/933161 and 933180 fixes, not a runtime DoS on CRS's supported engines.

detection is unchanged: a differential test of the old vs new pattern over 400,000 random inputs plus targeted templates found zero divergences. PL1, so the rule is always active; the full REQUEST-941 suite passes (228/228).

## refs

- #4666 (933160/933161 comment-suffix de-ambiguation)
- #4669 (933180 same hardening)
- #4667 (CONTRIBUTING.md guidance on avoiding catastrophic backtracking)

## ai disclosure

- **tools used**: Claude (Opus 4.8)
- **assisted with**: bounding the declaration value, authoring the regex-assembly `.ra` (defines + sequence), drafting the ten additional go-ftw tests, PR description drafting
- **review performed**: confirmed flat behavior under DOTALL on Python `re` (n up to 8000) and verified PCRE2 does not exceed its backtracking limit with `pcre2test` (match_limit=1,000,000); ran a 400,000-input differential test of old vs new pattern (zero divergences) to confirm no detection change; ran the full REQUEST-941 go-ftw suite on modsec2-apache (228/228) and confirmed all 14 941140 tests pass; verified the regex-assembly round-trip with `crs-toolchain regex compare`; ran crs-linter 1.0.0 (clean)
