### PR TITLE
fix(942190): Fix the message to reflect that the rule applies to all SQL DBs

### DIFF
--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -209,7 +209,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)[\
     block,\
     capture,\
     t:none,t:urlDecodeUni,t:removeCommentsChar,\
-    msg:'Detects MSSQL code execution and information gathering attempts',\
+    msg:'Detects SQL code execution and information gathering attempts',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\
     tag:'language-multi',\


### PR DESCRIPTION
This rules applies to multiple RMDBSs, not just MSSQL. This matches the `platform-multi` tag.

## Proposed changes

This rules applies to multiple RMDBSs, not just MSSQL. This matches the `platform-multi` tag.

<!-- Github Tip: adding the text 'Fixes #<issue>' or 'Closes #<issue>' will automatically close the mentioned issue. -->

## PR Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/CONTRIBUTING.md) doc
- [ ] I have added positive tests proving my fix/feature works as intended.
- [ ] I have added negative tests that prove my fix/feature considers common cases that might end in false positives
- [ ] In case you changed a regular expression, you are not adding a ReDOS for pcre. You can check this using [regexploit](https://github.com/doyensec/regexploit)
- [ ] My test use the `comment` field to write the expected behavior
- [ ] I have added documentation for the rule or change (when appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... If there are no additional comments, you may remove this section. -->

## AI Disclosure

<!-- Required per our AI-Assisted Contribution Policy (AI-CONTRIBUTIONS.md) -->

<!-- Select exactly one by deleting the option that does not apply. -->
**AI usage for this contribution:** Used

**If "Used", complete the details below:**

| Detail | Response |
|--------|----------|
| Tool(s) used | Claude Code Opus 4.8 |
| What was AI-assisted | Claude analyzed the rule to check if it was specific to MSSQL or not. |
| Review performed | Manual review of Claude's findings. |

## For the reviewer

<!-- Don't remove this part. Reviewers will use it as guidance for the review process. -->

- [ ] Positive and negative tests were added
- [ ] Tests cover the intended fix/feature properly
- [ ] No usage of dangerous constructs like `ctl:requestBodyAccess=Off` were used in the rule
- [ ] In case a regular expression was changed, [there is no ReDOS](https://github.com/coreruleset/coreruleset/wiki/Testing-for-Regular-Expresion-DoS)
- [ ] Documentation is clear for the rule/change
- [ ] If a contribution shows signs of unreviewed AI generation (e.g., plausible-but-broken regex, generic boilerplate comments, hallucinated SecLang directives), reviewers should ask about AI usage regardless of what was checked.
