### PR TITLE
feat(crs-setup): add default actions for phases 3-5

### DIFF
--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -97,6 +97,9 @@
 #
 SecDefaultAction "phase:1,log,auditlog,pass"
 SecDefaultAction "phase:2,log,auditlog,pass"
+SecDefaultAction "phase:3,log,auditlog,pass"
+SecDefaultAction "phase:4,log,auditlog,pass"
+SecDefaultAction "phase:5,log,auditlog,pass"
 
 # Example: Anomaly Scoring mode, log only to ModSecurity audit log
 # - By default, offending requests are blocked with an error 403 response.
@@ -107,6 +110,9 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 #
 # SecDefaultAction "phase:1,nolog,auditlog,pass"
 # SecDefaultAction "phase:2,nolog,auditlog,pass"
+# SecDefaultAction "phase:3,nolog,auditlog,pass"
+# SecDefaultAction "phase:4,nolog,auditlog,pass"
+# SecDefaultAction "phase:5,nolog,auditlog,pass"
 
 # Example: Self-contained mode, return error 403 on blocking
 # - In this configuration the default disruptive action becomes 'deny'. After a


### PR DESCRIPTION
## Proposed changes

This updates `crs-setup.conf.example` to define `SecDefaultAction` for phases 3, 4 and 5 in anomaly scoring mode.

Added:

* `SecDefaultAction "phase:3,log,auditlog,pass"`
* `SecDefaultAction "phase:4,log,auditlog,pass"`
* `SecDefaultAction "phase:5,log,auditlog,pass"`

Also updated the commented "log only to ModSecurity audit log" example to include phases 3–5 for consistency.

Related to #4668

## Further comments

This change aims to make CRS reporting and logging behavior more consistent across engines such as Coraza, where phase 3–5 logging may otherwise depend on engine defaults.
