### PR TITLE
ci: Update checkout version pinning to v7

### DIFF
--- a/.github/workflows/duty-scheduler.yaml
+++ b/.github/workflows/duty-scheduler.yaml
@@ -16,7 +16,7 @@ jobs:
       contents: write
     steps:
       - name: "Checkout gh-pages branch (sparse, only the files related to duty report)"
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        uses: actions/checkout@1044a6dea927916f2c38ba5aeffbc0a847b1221a # v7.0.0
         with:
           ref: 'gh-pages'
           sparse-checkout: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        uses: actions/checkout@1044a6dea927916f2c38ba5aeffbc0a847b1221a # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/quantitative.yaml
+++ b/.github/workflows/quantitative.yaml
@@ -34,12 +34,12 @@ jobs:
       contents: read
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        uses: actions/checkout@1044a6dea927916f2c38ba5aeffbc0a847b1221a # v7.0.0
         with:
           persist-credentials: false
 
       - name: "Checkout main repo"
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        uses: actions/checkout@1044a6dea927916f2c38ba5aeffbc0a847b1221a # v7.0.0
         with:
           repository: coreruleset/coreruleset
           ref: 'main'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         modsec_version: [modsec2-apache, modsec3-nginx]
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        uses: actions/checkout@1044a6dea927916f2c38ba5aeffbc0a847b1221a # v7.0.0
         with:
           persist-credentials: false
 


### PR DESCRIPTION
# What?
Update the actions/checkout version pinning 
# Why?
Read https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/, that was supply chain security improvemnet by github