### PR TITLE
ci: config renovatebot to include all supported updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,9 +5,6 @@
     "schedule:weekly"
   ],
   "ignorePaths": [],
-  "enabledManagers": [
-    "docker-compose"
-  ],
   "packageRules": [
     {
       "matchUpdateTypes": [


### PR DESCRIPTION
## what

- remove only enabling docker-compose manager

## why

- allow updating github actions and other modules