### PR TITLE
fix: FPs related to RESPONSE_BODY

### DIFF
--- a/rules/php-errors.data
+++ b/rules/php-errors.data
@@ -1722,9 +1722,9 @@ Enum case type
 Enumerator value "
 Erroneous data format for unserializing '
 Error in packet at
-Error in packet at '
 Error while receiving public key. PID=
-Error while sending
+Error while sending QUERY packet. PID=
+Error while sending INIT_DB packet. PID=
 Error while sending public key request packet. PID=
 Error: OID not increasing:
 FFI Parser:


### PR DESCRIPTION
## Proposed changes

I'm experiencing FPs with phrase `Error while sending` which is too common anyway and needs to be removed. I replaced it with two other phrases which should cover originally matched error messages (or most of them).

Additionally, i removed phrase `Error in packet at '` as other phrase (one above it) covers also this one.

There are more to fix, for example:
```
Failed to compile
Failed to compile code for expression
```
```
Failed to open
Failed to open or create
Failed to open session:
```

But i think that first of the phrases are too common for both of these cases above so i don't recommned to keep it and remove rest of the phrases (but it should be removed anyway, and maybe replaced by other, more specific, phrases). What do you think?


## PR Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/CONTRIBUTING.md) doc
- [ ] I have added positive tests proving my fix/feature works as intended.
- [ ] I have added negative tests that prove my fix/feature considers common cases that might end in false positives
- [x] In case you changed a regular expression, you are not adding a ReDOS for pcre. You can check this using [regexploit](https://github.com/doyensec/regexploit)
- [ ] My test use the `comment` field to write the expected behavior
- [ ] I have added documentation for the rule or change (when appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... If there are no additional comments, you may remove this section. -->

## AI Disclosure

<!-- Required per our AI-Assisted Contribution Policy (AI-CONTRIBUTIONS.md) -->

<!-- Select exactly one by deleting the option that does not apply. -->
**AI usage for this contribution:** None

## For the reviewer

<!-- Don't remove this part. Reviewers will use it as guidance for the review process. -->

- [ ] Positive and negative tests were added
- [ ] Tests cover the intended fix/feature properly
- [ ] No usage of dangerous constructs like `ctl:requestBodyAccess=Off` were used in the rule
- [ ] In case a regular expression was changed, [there is no ReDOS](https://github.com/coreruleset/coreruleset/wiki/Testing-for-Regular-Expresion-DoS)
- [ ] Documentation is clear for the rule/change
- [ ] If a contribution shows signs of unreviewed AI generation (e.g., plausible-but-broken regex, generic boilerplate comments, hallucinated SecLang directives), reviewers should ask about AI usage regardless of what was checked.
