### PR TITLE
chore: release v3.3.10

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,17 @@
   or the CRS Google Group at
 * <https://groups.google.com/a/owasp.org/forum/#!forum/modsecurity-core-rule-set-project>
 
+## Version 3.3.10 - 2026-07-01
+
+### ⚠️ Breaking Change
+
+* Fully opting out of XML attribute inspection (`tx.crs_xml_attr_inspect`) requires ModSecurity v2 >= v2.9.14, once <https://github.com/owasp-modsecurity/ModSecurity/issues/3591> is fixed upstream. Until then, `ctl:ruleRemoveTargetByTag` cannot remove the `XML://@*` target on ModSecurity v2, so rule 901181 cannot disable attribute inspection on that engine.
+
+### ⭐ Important changes
+
+* fix: R7U-260618 v3 by @fzipi in https://github.com/coreruleset/coreruleset/commit/4665b6d7a79a81aa8a802ef3c901d69491c009a4 (GHSA: <https://github.com/coreruleset/coreruleset/security/advisories/GHSA-f5qm-3h4p-8qhg>)
+* fix: N7Y-260316 v3 by @fzipi in https://github.com/coreruleset/coreruleset/commit/635cecf8f81908f02a687db4b5b13a55c3e3b9ed (GHSA: <https://github.com/coreruleset/coreruleset/security/advisories/GHSA-6jp8-c2w2-x7wr>)
+
 ## Version 3.3.9 - 2026-03-28
 
 ### ⭐ Important changes

--- a/crs-setup.conf.example
+++ b/crs-setup.conf.example
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -671,7 +671,7 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # CRS detection at every paranoia level.
 #
 # This LTS branch ships the fix gated behind an opt-in transaction variable.
-# When `tx.crs_xml_attr_inspect` is not set, rule id:901180 strips
+# When `tx.crs_xml_attr_inspect` is not set, rule id:901181 strips
 # `XML://@*` from the affected rules for each transaction, preserving
 # legacy LTS behavior by default.
 #
@@ -679,12 +679,12 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # value inspection.
 #
 #SecAction \
-# "id:900510,\
-#  phase:1,\
-#  nolog,\
-#  pass,\
-#  t:none,\
-#  setvar:'tx.crs_xml_attr_inspect=1'"
+#  "id:900510,\
+#   phase:1,\
+#   nolog,\
+#   pass,\
+#   t:none,\
+#   setvar:'tx.crs_xml_attr_inspect=1'"
 
 
 #
@@ -899,4 +899,4 @@ SecAction \
     pass,\
     t:none,\
     nolog,\
-    setvar:tx.crs_setup_version=339"
+    setvar:tx.crs_setup_version=3310"

--- a/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example
+++ b/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #

--- a/rules/REQUEST-901-INITIALIZATION.conf
+++ b/rules/REQUEST-901-INITIALIZATION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -26,7 +26,7 @@
 #
 # Ref: https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual#wiki-SecComponentSignature
 #
-SecComponentSignature "OWASP_CRS/3.3.9"
+SecComponentSignature "OWASP_CRS/3.3.10"
 
 #
 # -=[ Default setup values ]=-
@@ -59,7 +59,7 @@ SecRule &TX:crs_setup_version "@eq 0" \
     log,\
     auditlog,\
     msg:'ModSecurity Core Rule Set is deployed without configuration! Please copy the crs-setup.conf.example template to crs-setup.conf, and include the crs-setup.conf file in your webserver configuration before including the CRS rules. See the INSTALL file in the CRS directory for detailed instructions',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL'"
 
 
@@ -77,7 +77,7 @@ SecRule &TX:inbound_anomaly_score_threshold "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.inbound_anomaly_score_threshold=5'"
 
 # Default Outbound Anomaly Threshold Level (rule 900110 in setup.conf)
@@ -86,7 +86,7 @@ SecRule &TX:outbound_anomaly_score_threshold "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.outbound_anomaly_score_threshold=4'"
 
 # Default Paranoia Level (rule 900000 in setup.conf)
@@ -95,7 +95,7 @@ SecRule &TX:paranoia_level "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.paranoia_level=1'"
 
 # Default Executing Paranoia Level (rule 900000 in setup.conf)
@@ -104,7 +104,7 @@ SecRule &TX:executing_paranoia_level "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.executing_paranoia_level=%{TX.PARANOIA_LEVEL}'"
 
 # Default Sampling Percentage (rule 900400 in setup.conf)
@@ -113,7 +113,7 @@ SecRule &TX:sampling_percentage "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.sampling_percentage=100'"
 
 # Default Anomaly Scores (rule 900100 in setup.conf)
@@ -122,7 +122,7 @@ SecRule &TX:critical_anomaly_score "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.critical_anomaly_score=5'"
 
 SecRule &TX:error_anomaly_score "@eq 0" \
@@ -130,7 +130,7 @@ SecRule &TX:error_anomaly_score "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.error_anomaly_score=4'"
 
 SecRule &TX:warning_anomaly_score "@eq 0" \
@@ -138,7 +138,7 @@ SecRule &TX:warning_anomaly_score "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.warning_anomaly_score=3'"
 
 SecRule &TX:notice_anomaly_score "@eq 0" \
@@ -146,7 +146,7 @@ SecRule &TX:notice_anomaly_score "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.notice_anomaly_score=2'"
 
 # Default do_reput_block
@@ -155,7 +155,7 @@ SecRule &TX:do_reput_block "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.do_reput_block=0'"
 
 # Default block duration
@@ -164,7 +164,7 @@ SecRule &TX:reput_block_duration "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.reput_block_duration=300'"
 
 # Default HTTP policy: allowed_methods (rule 900200)
@@ -173,7 +173,7 @@ SecRule &TX:allowed_methods "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.allowed_methods=GET HEAD POST OPTIONS'"
 
 # Default HTTP policy: allowed_request_content_type (rule 900220)
@@ -182,7 +182,7 @@ SecRule &TX:allowed_request_content_type "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |text/xml| |application/xml| |application/soap+xml| |application/json|'"
 
 # Default HTTP policy: allowed_request_content_type_charset (rule 900270)
@@ -191,7 +191,7 @@ SecRule &TX:allowed_request_content_type_charset "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.allowed_request_content_type_charset=utf-8|iso-8859-1|iso-8859-15|windows-1252'"
 
 # Default HTTP policy: allowed_http_versions (rule 900230)
@@ -200,7 +200,7 @@ SecRule &TX:allowed_http_versions "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.allowed_http_versions=HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0'"
 
 # Default HTTP policy: restricted_extensions (rule 900240)
@@ -209,7 +209,7 @@ SecRule &TX:restricted_extensions "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .rdb/ .resources/ .resx/ .sql/ .swp/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'"
 
 # Default HTTP policy: restricted_headers (rule 900250)
@@ -218,7 +218,7 @@ SecRule &TX:restricted_headers "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.restricted_headers=/accept-charset/ /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/'"
 
 # Default HTTP policy: static_extensions (rule 900260)
@@ -227,7 +227,7 @@ SecRule &TX:static_extensions "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.static_extensions=/.jpg/ /.jpeg/ /.png/ /.gif/ /.js/ /.css/ /.ico/ /.svg/ /.webp/'"
 
 # Default enforcing of body processor URLENCODED
@@ -236,7 +236,7 @@ SecRule &TX:enforce_bodyproc_urlencoded "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.enforce_bodyproc_urlencoded=0'"
 
 # Default check for UTF8 encoding validation
@@ -245,7 +245,7 @@ SecRule &TX:crs_validate_utf8_encoding "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.crs_validate_utf8_encoding=0'"
 
 # Default monitor_anomaly_score value
@@ -254,8 +254,46 @@ SecRule &TX:monitor_anomaly_score "@eq 0" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.monitor_anomaly_score=0'"
+
+#
+# -=[ XML attribute value inspection (GHSA-6jp8-c2w2-x7wr) ]=-
+#
+# Every attack-detection rule that inspects XML element text (`XML:/*`)
+# has been extended to also inspect XML attribute values (`XML://@*`).
+# This runtime gate strips `XML://@*` from the affected rules for the
+# current transaction when `tx.crs_xml_attr_inspect` is not set (LTS
+# default), preserving legacy behavior. Operators opt in by uncommenting
+# id:900510 in crs-setup.conf (see crs-setup.conf.example).
+#
+# Known issue on ModSecurity v2: ctl:ruleRemoveTargetByTag does not
+# remove an XPath attribute target (XML://@*), so rule 901181 below
+# cannot actually disable attribute inspection on this engine until
+# that is fixed upstream. It works correctly on libmodsecurity v3.
+# See https://github.com/owasp-modsecurity/ModSecurity/issues/3591
+#
+SecRule &TX:crs_xml_attr_inspect "@eq 0" \
+    "id:901180,\
+    phase:1,\
+    pass,\
+    nolog,\
+    ver:'OWASP_CRS/3.3.10',\
+    setvar:'tx.crs_xml_attr_inspect=0'"
+
+SecRule TX:crs_xml_attr_inspect "@eq 0" \
+    "id:901181,\
+    phase:2,\
+    pass,\
+    nolog,\
+    ctl:ruleRemoveTargetByTag=attack-protocol;XML://@*,\
+    ctl:ruleRemoveTargetByTag=attack-lfi;XML://@*,\
+    ctl:ruleRemoveTargetByTag=attack-rce;XML://@*,\
+    ctl:ruleRemoveTargetByTag=attack-injection-php;XML://@*,\
+    ctl:ruleRemoveTargetByTag=attack-xss;XML://@*,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;XML://@*,\
+    ctl:ruleRemoveTargetByTag=attack-fixation;XML://@*,\
+    ver:'OWASP_CRS/3.3.10'"
 
 #
 # -=[ Initialize internal variables ]=-
@@ -272,7 +310,7 @@ SecAction \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.anomaly_score=0',\
     setvar:'tx.anomaly_score_pl1=0',\
     setvar:'tx.anomaly_score_pl2=0',\
@@ -309,7 +347,7 @@ SecRule REQUEST_HEADERS:User-Agent "@rx ^.*$" \
     pass,\
     t:none,t:sha1,t:hexEncode,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.ua_hash=%{MATCHED_VAR}'"
 
 SecAction \
@@ -318,7 +356,7 @@ SecAction \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     initcol:global=global,\
     initcol:ip=%{remote_addr}_%{tx.ua_hash},\
     setvar:'tx.real_ip=%{remote_addr}'"
@@ -338,7 +376,7 @@ SecRule REQBODY_PROCESSOR "!@rx (?:URLENCODED|MULTIPART|XML|JSON)" \
     noauditlog,\
     msg:'Enabling body inspection',\
     ctl:forceRequestBodyVariable=On,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Force body processor URLENCODED
 SecRule TX:enforce_bodyproc_urlencoded "@eq 1" \
@@ -349,7 +387,7 @@ SecRule TX:enforce_bodyproc_urlencoded "@eq 1" \
     nolog,\
     noauditlog,\
     msg:'Enabling forced body inspection for ASCII content',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule REQBODY_PROCESSOR "!@rx (?:URLENCODED|MULTIPART|XML|JSON)" \
         "ctl:requestBodyProcessor=URLENCODED"
@@ -388,7 +426,7 @@ SecRule TX:sampling_percentage "@eq 100" \
     phase:1,\
     pass,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     skipAfter:END-SAMPLING"
 
 SecRule UNIQUE_ID "@rx ^." \
@@ -397,7 +435,7 @@ SecRule UNIQUE_ID "@rx ^." \
     pass,\
     t:sha1,t:hexEncode,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'TX.sampling_rnd100=%{MATCHED_VAR}'"
 
 SecRule DURATION "@rx (..)$" \
@@ -406,7 +444,7 @@ SecRule DURATION "@rx (..)$" \
     pass,\
     capture,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'TX.sampling_rnd100=%{TX.sampling_rnd100}%{TX.1}'"
 
 SecRule TX:sampling_rnd100 "@rx ^[a-f]*([0-9])[a-f]*([0-9])" \
@@ -415,7 +453,7 @@ SecRule TX:sampling_rnd100 "@rx ^[a-f]*([0-9])[a-f]*([0-9])" \
     pass,\
     capture,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'TX.sampling_rnd100=%{TX.1}%{TX.2}'"
 
 SecRule TX:sampling_rnd100 "@rx ^0([0-9])" \
@@ -424,7 +462,7 @@ SecRule TX:sampling_rnd100 "@rx ^0([0-9])" \
     pass,\
     capture,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'TX.sampling_rnd100=%{TX.1}'"
 
 
@@ -449,7 +487,7 @@ SecRule TX:sampling_rnd100 "!@lt %{tx.sampling_percentage}" \
     noauditlog,\
     msg:'Sampling: Disable the rule engine based on sampling_percentage %{TX.sampling_percentage} and random number %{TX.sampling_rnd100}',\
     ctl:ruleEngine=Off,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 SecMarker "END-SAMPLING"
 
@@ -467,4 +505,4 @@ SecRule TX:executing_paranoia_level "@lt %{tx.paranoia_level}" \
     t:none,\
     log,\
     msg:'Executing paranoia level configured is lower than the paranoia level itself. This is illegal. Blocking request. Aborting',\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"

--- a/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -69,7 +69,7 @@ SecRule &TX:crs_exclusions_drupal|TX:crs_exclusions_drupal "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     skipAfter:END-DRUPAL-RULE-EXCLUSIONS"
 
 SecRule &TX:crs_exclusions_drupal|TX:crs_exclusions_drupal "@eq 0" \
@@ -78,7 +78,7 @@ SecRule &TX:crs_exclusions_drupal|TX:crs_exclusions_drupal "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     skipAfter:END-DRUPAL-RULE-EXCLUSIONS"
 
 
@@ -116,7 +116,7 @@ SecAction "id:9001100,\
     nolog,\
     ctl:ruleRemoveTargetById=942450;REQUEST_COOKIES_NAMES,\
     ctl:ruleRemoveTargetById=942450;REQUEST_COOKIES,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 
 #
@@ -131,7 +131,7 @@ SecRule REQUEST_FILENAME "@endsWith /core/install.php" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:account[pass][pass1],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:account[pass][pass2],\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 SecRule REQUEST_FILENAME "@endsWith /user/login" \
     "id:9001112,\
@@ -140,7 +140,7 @@ SecRule REQUEST_FILENAME "@endsWith /user/login" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/people/create" \
     "id:9001114,\
@@ -149,7 +149,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/people/create" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass[pass1],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass[pass2],\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 SecRule REQUEST_FILENAME "@rx /user/[0-9]+/edit$" \
     "id:9001116,\
@@ -159,7 +159,7 @@ SecRule REQUEST_FILENAME "@rx /user/[0-9]+/edit$" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:current_pass,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass[pass1],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass[pass2],\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 
 #
@@ -179,7 +179,7 @@ SecRule REQUEST_FILENAME "@contains /admin/config/" \
     pass,\
     nolog,\
     ctl:ruleRemoveById=942430,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/people/accounts" \
     "id:9001124,\
@@ -196,7 +196,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/people/accounts" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:user_mail_status_activated_body,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:user_mail_status_blocked_body,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:user_mail_status_canceled_body,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/development/configuration/single/import" \
     "id:9001126,\
@@ -205,7 +205,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/development/configuration/sing
     nolog,\
     ctl:ruleRemoveById=920271,\
     ctl:ruleRemoveById=942440,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/development/maintenance" \
     "id:9001128,\
@@ -213,7 +213,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/development/maintenance" \
     pass,\
     nolog,\
     ctl:ruleRemoveById=942440,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 
 #
@@ -230,7 +230,7 @@ SecRule REQUEST_FILENAME "@endsWith /contextual/render" \
     pass,\
     nolog,\
     ctl:ruleRemoveTargetById=942130;ARGS:ids[],\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 
 #
@@ -249,7 +249,7 @@ SecAction "id:9001160,\
     ctl:ruleRemoveTargetById=942440;ARGS:form_build_id,\
     ctl:ruleRemoveTargetById=942450;ARGS:form_token,\
     ctl:ruleRemoveTargetById=942450;ARGS:form_build_id,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 
 #
@@ -266,7 +266,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/content/formats/manage/full_ht
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:editor[settings][toolbar][button_groups],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:filters[filter_html][settings][allowed_html],\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 
 #
@@ -286,7 +286,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/content/formats/manage/full_ht
 #    t:none,\
 #    nolog,\
 #    noauditlog,\
-#    ver:'OWASP_CRS/3.3.9',\
+#    ver:'OWASP_CRS/3.3.10',\
 #    chain"
 #    SecRule REQUEST_FILENAME "@rx /admin/content/assets/add/[a-z]+$" \
 #        "chain"
@@ -302,7 +302,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/content/formats/manage/full_ht
 #    t:none,\
 #    nolog,\
 #    noauditlog,\
-#    ver:'OWASP_CRS/3.3.9',\
+#    ver:'OWASP_CRS/3.3.10',\
 #    chain"
 #    SecRule REQUEST_FILENAME "@rx /admin/content/assets/manage/[0-9]+$" \
 #        "chain"
@@ -322,7 +322,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/content/formats/manage/full_ht
 #    t:none,\
 #    nolog,\
 #    noauditlog,\
-#    ver:'OWASP_CRS/3.3.9',\
+#    ver:'OWASP_CRS/3.3.10',\
 #    chain"
 #    SecRule REQUEST_FILENAME "@rx /file/ajax/field_asset_[a-z0-9_]+/[ua]nd/0/form-[a-z0-9A-Z_-]+$" \
 #        "chain"
@@ -350,7 +350,7 @@ SecRule REQUEST_FILENAME "@endsWith /node/add/article" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body[0][value],\
     ctl:ruleRemoveTargetById=942410;ARGS:uid[0][target_id],\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 SecRule REQUEST_FILENAME "@endsWith /node/add/page" \
     "id:9001202,\
@@ -359,7 +359,7 @@ SecRule REQUEST_FILENAME "@endsWith /node/add/page" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body[0][value],\
     ctl:ruleRemoveTargetById=942410;ARGS:uid[0][target_id],\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 SecRule REQUEST_FILENAME "@rx /node/[0-9]+/edit$" \
     "id:9001204,\
@@ -369,7 +369,7 @@ SecRule REQUEST_FILENAME "@rx /node/[0-9]+/edit$" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body[0][value],\
     ctl:ruleRemoveTargetById=942410;ARGS:uid[0][target_id],\
     ctl:ruleRemoveTargetById=932110;ARGS:destination,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 SecRule REQUEST_FILENAME "@endsWith /block/add" \
     "id:9001206,\
@@ -377,7 +377,7 @@ SecRule REQUEST_FILENAME "@endsWith /block/add" \
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body[0][value],\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/structure/block/block-content/manage/basic" \
     "id:9001208,\
@@ -385,7 +385,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/structure/block/block-content/manage/
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:description,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 SecRule REQUEST_FILENAME "@rx /editor/filter_xss/(?:full|basic)_html$" \
     "id:9001210,\
@@ -393,7 +393,7 @@ SecRule REQUEST_FILENAME "@rx /editor/filter_xss/(?:full|basic)_html$" \
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:value,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 SecRule REQUEST_FILENAME "@rx /user/[0-9]+/contact$" \
     "id:9001212,\
@@ -401,7 +401,7 @@ SecRule REQUEST_FILENAME "@rx /user/[0-9]+/contact$" \
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message[0][value],\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/development/maintenance" \
     "id:9001214,\
@@ -409,7 +409,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/development/maintenance" \
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:maintenance_mode_message,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 SecRule REQUEST_FILENAME "@endsWith /admin/config/services/rss-publishing" \
     "id:9001216,\
@@ -417,7 +417,7 @@ SecRule REQUEST_FILENAME "@endsWith /admin/config/services/rss-publishing" \
     pass,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:feed_description,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 
 SecMarker "END-DRUPAL-RULE-EXCLUSIONS"

--- a/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -23,7 +23,7 @@ SecRule &TX:crs_exclusions_wordpress|TX:crs_exclusions_wordpress "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     skipAfter:END-WORDPRESS"
 
 SecRule &TX:crs_exclusions_wordpress|TX:crs_exclusions_wordpress "@eq 0" \
@@ -32,7 +32,7 @@ SecRule &TX:crs_exclusions_wordpress|TX:crs_exclusions_wordpress "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     skipAfter:END-WORDPRESS"
 
 
@@ -53,7 +53,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pwd,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Reset password
 SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
@@ -62,7 +62,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule ARGS:action "@streq resetpass" \
         "t:none,\
@@ -86,7 +86,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-comments-post.php" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=931130;ARGS:url,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 
 #
@@ -103,7 +103,7 @@ SecRule REQUEST_FILENAME "@rx /wp-json/wp/v[0-9]+/(?:posts|pages)" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:content,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.content,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Gutenberg via rest_route for sites without pretty permalinks
 SecRule REQUEST_FILENAME "@endsWith /index.php" \
@@ -112,7 +112,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule &ARGS:rest_route "@eq 1" \
         "t:none,\
@@ -132,7 +132,7 @@ SecRule REQUEST_FILENAME "@rx /wp-json/wp/v[0-9]+/media" \
     nolog,\
     ctl:ruleRemoveById=200002,\
     ctl:ruleRemoveById=200003,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Gutenberg upload image/media via rest_route for sites without pretty permalinks
 SecRule REQUEST_FILENAME "@endsWith /index.php" \
@@ -141,7 +141,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule &ARGS:rest_route "@eq 1" \
         "t:none,\
@@ -170,7 +170,7 @@ SecRule ARGS:wp_customize "@streq on" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule &ARGS:action "@eq 0" \
         "t:none,\
@@ -191,7 +191,7 @@ SecRule ARGS:wp_customize "@streq on" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule ARGS:action "@rx ^(?:|customize_save|update-widget)$" \
         "t:none,\
@@ -232,7 +232,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-cron.php" \
     nolog,\
     ctl:ruleRemoveById=920180,\
     ctl:ruleRemoveById=920300,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 
 #
@@ -247,7 +247,7 @@ SecRule REQUEST_COOKIES:_wp_session "@rx ^[0-9a-f]+\|\|\d+\|\|\d+$" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule &REQUEST_COOKIES:_wp_session "@eq 1" \
         "t:none,\
@@ -266,7 +266,7 @@ SecRule REQUEST_FILENAME "!@contains /wp-admin/" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     skipAfter:END-WORDPRESS-ADMIN"
 
 SecRule REQUEST_FILENAME "!@contains /wp-admin/" \
@@ -275,7 +275,7 @@ SecRule REQUEST_FILENAME "!@contains /wp-admin/" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     skipAfter:END-WORDPRESS-ADMIN"
 
 
@@ -290,7 +290,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/setup-config.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule ARGS:step "@streq 2" \
         "t:none,\
@@ -306,7 +306,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/install.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule ARGS:step "@streq 2" \
         "t:none,\
@@ -329,7 +329,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/profile.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule ARGS:action "@streq update" \
         "t:none,\
@@ -357,7 +357,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/user-edit.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule ARGS:action "@streq update" \
         "t:none,\
@@ -386,7 +386,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/user-new.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule ARGS:action "@streq createuser" \
         "t:none,\
@@ -427,7 +427,7 @@ SecAction \
     ctl:ruleRemoveTargetById=942200;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=942260;ARGS:wp_http_referer,\
     ctl:ruleRemoveTargetById=942431;ARGS:wp_http_referer,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 #
 # [ Content editing ]
@@ -444,7 +444,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/post.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule ARGS:action "@rx ^(?:edit|editpost)$" \
         "t:none,\
@@ -464,7 +464,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule ARGS:action "@streq heartbeat" \
         "t:none,\
@@ -486,7 +486,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/nav-menus.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule ARGS:action "@streq update" \
         "t:none,\
@@ -511,7 +511,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule ARGS:action "@rx ^(?:save-widget|update-widget)$" \
         "t:none,\
@@ -566,7 +566,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule ARGS:action "@streq widgets-order" \
         "t:none,\
@@ -595,7 +595,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule ARGS:action "@streq sample-permalink" \
         "t:none,\
@@ -611,7 +611,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule ARGS:action "@streq add-menu-item" \
         "t:none,\
@@ -627,7 +627,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule ARGS:action "@streq send-attachment-to-editor" \
         "t:none,\
@@ -648,7 +648,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/options.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule ARGS:option_page "@streq general" \
         "t:none,\
@@ -679,7 +679,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/options-permalink.php" \
     ctl:ruleRemoveTargetById=920272;ARGS:permalink_structure,\
     ctl:ruleRemoveTargetById=942431;ARGS:permalink_structure,\
     ctl:ruleRemoveTargetById=920272;REQUEST_BODY,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Comments blacklist and moderation list
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/options.php" \
@@ -688,7 +688,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/options.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule ARGS:option_page "@streq discussion" \
         "t:none,\
@@ -712,7 +712,7 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/edit.php" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:s,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 
 #
@@ -751,7 +751,7 @@ SecRule REQUEST_FILENAME "@rx /wp-admin/load-(?:scripts|styles)\.php$" \
     ctl:ruleRemoveTargetById=942430;ARGS:load[],\
     ctl:ruleRemoveTargetById=942431;ARGS:load[],\
     ctl:ruleRemoveTargetById=942432;ARGS:load[],\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 
 SecMarker "END-WORDPRESS-ADMIN"

--- a/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -44,7 +44,7 @@ SecRule &TX:crs_exclusions_nextcloud|TX:crs_exclusions_nextcloud "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     skipAfter:END-NEXTCLOUD"
 
 SecRule &TX:crs_exclusions_nextcloud|TX:crs_exclusions_nextcloud "@eq 0" \
@@ -53,7 +53,7 @@ SecRule &TX:crs_exclusions_nextcloud|TX:crs_exclusions_nextcloud "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     skipAfter:END-NEXTCLOUD"
 
 
@@ -75,7 +75,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/webdav" \
     ctl:ruleRemoveById=953100-953130,\
     ctl:ruleRemoveById=920420,\
     ctl:ruleRemoveById=920440,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Skip PUT parsing for invalid encoding / protocol violations in binary files.
 
@@ -85,7 +85,7 @@ SecRule REQUEST_METHOD "@streq PUT" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule REQUEST_FILENAME "@contains /remote.php/webdav" \
         "t:none,\
@@ -103,7 +103,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/vcard|'"
 
 # Allow the data type 'application/octet-stream'
@@ -114,7 +114,7 @@ SecRule REQUEST_METHOD "@rx ^(?:PUT|MOVE)$" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule REQUEST_FILENAME "@rx /remote\.php/dav/(?:files|uploads)/" \
         "setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |application/octet-stream|'"
@@ -127,7 +127,7 @@ SecRule REQUEST_METHOD "@streq PUT" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule REQUEST_FILENAME "@rx (?:/public\.php/webdav/|/remote\.php/dav/uploads/)" \
         "ctl:ruleRemoveById=920340,\
@@ -148,7 +148,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     ctl:ruleRemoveById=951000-951999,\
     ctl:ruleRemoveById=953100-953130,\
     ctl:ruleRemoveById=920440,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Allow REPORT requests without Content-Type header (at least the iOS app does this)
 
@@ -177,7 +177,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/core/search" \
     ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:query,\
     ctl:ruleRemoveTargetById=941000-942999;ARGS:query,\
     ctl:ruleRemoveTargetById=932000-932999;ARGS:query,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 
 # [ DAV ]
@@ -199,7 +199,7 @@ SecRule REQUEST_FILENAME "@rx /(?:remote|index|public)\.php/" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT PATCH CHECKOUT COPY DELETE LOCK MERGE MKACTIVITY MKCOL MOVE PROPFIND PROPPATCH UNLOCK REPORT TRACE jsonp'"
 
 
@@ -213,7 +213,7 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/files_sharing/" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT DELETE'"
 
 
@@ -226,7 +226,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/core/preview.png" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=932150;ARGS:file,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Filepreview for trashbin
 
@@ -238,7 +238,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/files_trashbin/ajax/preview.
     nolog,\
     ctl:ruleRemoveTargetById=932150;ARGS:file,\
     ctl:ruleRemoveTargetById=942190;ARGS:file,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 SecRule REQUEST_FILENAME "@rx /index\.php/(?:apps/gallery/thumbnails|logout$)" \
     "id:9003160,\
@@ -247,7 +247,7 @@ SecRule REQUEST_FILENAME "@rx /index\.php/(?:apps/gallery/thumbnails|logout$)" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=941120;ARGS:requesttoken,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 
 # [ Ownnote ]
@@ -259,7 +259,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/ownnote/" \
     t:none,\
     nolog,\
     ctl:ruleRemoveById=941150,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 
 # [ Text Editor ]
@@ -277,7 +277,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/files_texteditor/" \
     ctl:ruleRemoveTargetById=932150;ARGS:filename,\
     ctl:ruleRemoveTargetById=920370-920390;ARGS:filecontents,\
     ctl:ruleRemoveTargetById=920370-920390;ARGS_COMBINED_SIZE,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 
 # [ Address Book ]
@@ -290,7 +290,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/addressbooks/" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/vcard|'"
 
 # Allow modifying contacts via the web interface
@@ -316,7 +316,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/calendars/" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/calendar|'"
 
 # Allow modifying calendar events via the web interface
@@ -344,7 +344,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/notes/" \
     t:none,\
     nolog,\
     ctl:ruleRemoveByTag=attack-injection-php,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 
 # [ Bookmarks ]
@@ -358,7 +358,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/bookmarks/" \
     t:none,\
     nolog,\
     ctl:ruleRemoveById=931130,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 
 #
@@ -377,7 +377,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/login" \
     nolog,\
     ctl:ruleRemoveTargetById=941100;ARGS:requesttoken,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Reset password.
 
@@ -387,7 +387,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/login" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule ARGS:action "@streq resetpass" \
         "t:none,\
@@ -408,7 +408,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/settings/users" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:newuserpassword,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 
 SecMarker "END-NEXTCLOUD-ADMIN"

--- a/rules/REQUEST-903.9004-DOKUWIKI-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9004-DOKUWIKI-EXCLUSION-RULES.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -27,7 +27,7 @@ SecRule &TX:crs_exclusions_dokuwiki|TX:crs_exclusions_dokuwiki "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     skipAfter:END-DOKUWIKI"
 
 SecRule &TX:crs_exclusions_dokuwiki|TX:crs_exclusions_dokuwiki "@eq 0" \
@@ -36,7 +36,7 @@ SecRule &TX:crs_exclusions_dokuwiki|TX:crs_exclusions_dokuwiki "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     skipAfter:END-DOKUWIKI"
 
 
@@ -81,7 +81,7 @@ SecRule REQUEST_FILENAME "@rx (?:/doku.php|/lib/exe/ajax.php)$" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule REQUEST_METHOD "@streq POST" \
         "t:none,\
@@ -106,7 +106,7 @@ SecRule REQUEST_FILENAME "@endsWith /lib/exe/ajax.php" \
     t:none,\
     nolog,\
     noauditlog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule REQUEST_METHOD "@streq POST" \
         "t:none,\
@@ -125,7 +125,7 @@ SecRule REQUEST_FILENAME "@endsWith /doku.php" \
     t:none,\
     nolog,\
     noauditlog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule ARGS:do "@streq index" \
         "t:none,\
@@ -149,7 +149,7 @@ SecRule REQUEST_FILENAME "@endsWith /doku.php" \
     t:none,\
     nolog,\
     noauditlog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule ARGS:do "@streq login" \
         "t:none,\
@@ -170,7 +170,7 @@ SecRule ARGS:do "!@streq admin" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     skipAfter:END-DOKUWIKI-ADMIN"
 
 SecRule ARGS:do "!@streq admin" \
@@ -179,7 +179,7 @@ SecRule ARGS:do "!@streq admin" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     skipAfter:END-DOKUWIKI-ADMIN"
 
 
@@ -194,7 +194,7 @@ SecRule REQUEST_FILENAME "@endsWith /doku.php" \
     t:none,\
     nolog,\
     noauditlog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule ARGS:do "@streq login" \
         "t:none,\
@@ -220,7 +220,7 @@ SecRule REQUEST_FILENAME "@endsWith /doku.php" \
     t:none,\
     nolog,\
     noauditlog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule ARGS:page "@streq config" \
         "t:none,\
@@ -252,7 +252,7 @@ SecRule REQUEST_FILENAME "@endsWith /doku.php" \
     t:none,\
     nolog,\
     noauditlog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule ARGS:page "@streq config" \
         "t:none,\

--- a/rules/REQUEST-903.9005-CPANEL-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9005-CPANEL-EXCLUSION-RULES.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -19,7 +19,7 @@ SecRule &TX:crs_exclusions_cpanel|TX:crs_exclusions_cpanel "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     skipAfter:END-CPANEL"
 
 SecRule &TX:crs_exclusions_cpanel|TX:crs_exclusions_cpanel "@eq 0" \
@@ -28,7 +28,7 @@ SecRule &TX:crs_exclusions_cpanel|TX:crs_exclusions_cpanel "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     skipAfter:END-CPANEL"
 
 
@@ -53,7 +53,7 @@ SecRule REQUEST_LINE "@rx ^GET /whm-server-status(?:/|/\?auto)? HTTP/[12]\.[01]$
     tag:'language-multi',\
     tag:'platform-apache',\
     tag:'attack-generic',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
         "t:none,\

--- a/rules/REQUEST-903.9006-XENFORO-EXCLUSION-RULES.conf
+++ b/rules/REQUEST-903.9006-XENFORO-EXCLUSION-RULES.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -18,7 +18,7 @@ SecRule &TX:crs_exclusions_xenforo|TX:crs_exclusions_xenforo "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     skipAfter:END-XENFORO"
 
 SecRule &TX:crs_exclusions_xenforo|TX:crs_exclusions_xenforo "@eq 0" \
@@ -27,7 +27,7 @@ SecRule &TX:crs_exclusions_xenforo|TX:crs_exclusions_xenforo "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     skipAfter:END-XENFORO"
 
 
@@ -49,7 +49,7 @@ SecRule REQUEST_FILENAME "@endsWith /proxy.php" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:link,\
     ctl:ruleRemoveTargetById=931130;ARGS:referrer,\
     ctl:ruleRemoveTargetById=942230;ARGS:referrer,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Store drafts for private message, forum post, thread reply
 # POST /xf/conversations/draft
@@ -73,7 +73,7 @@ SecRule REQUEST_FILENAME "@rx /(?:conversations|(?:conversations|forums|threads)
     ctl:ruleRemoveTargetById=942260;ARGS:attachment_hash_combined,\
     ctl:ruleRemoveTargetById=942340;ARGS:attachment_hash_combined,\
     ctl:ruleRemoveTargetById=942370;ARGS:attachment_hash_combined,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Send PM, edit post, create thread, reply to thread
 # POST /xf/conversations/add
@@ -100,7 +100,7 @@ SecRule REQUEST_FILENAME "@rx /(?:conversations/add(?:-preview)?|conversations/m
     ctl:ruleRemoveTargetById=942260;ARGS:attachment_hash_combined,\
     ctl:ruleRemoveTargetById=942340;ARGS:attachment_hash_combined,\
     ctl:ruleRemoveTargetById=942370;ARGS:attachment_hash_combined,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Quote
 # POST /xf/posts/12345/quote
@@ -111,7 +111,7 @@ SecRule REQUEST_FILENAME "@rx /posts/\d+/quote$" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:quoteHtml,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Multi quote
 # POST /xf/conversations/convo-title.12345/multi-quote
@@ -134,7 +134,7 @@ SecRule REQUEST_FILENAME "@rx /(?:conversations|threads)/.*\.\d+/multi-quote$" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:insert[7][value],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:insert[8][value],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:insert[9][value],\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Delete thread
 # POST /xf/threads/thread-title.12345/delete
@@ -145,7 +145,7 @@ SecRule REQUEST_FILENAME "@rx /threads/.*\.\d+/delete$" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=942130;ARGS:starter_alert_reason,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Feature thread
 # POST /xf/threads/thread-title.12345/feature-edit
@@ -167,7 +167,7 @@ SecRule REQUEST_FILENAME "@endsWith /inline-mod/" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:author_alert_reason,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Warn member
 # POST /xf/members/name.12345/warn
@@ -180,7 +180,7 @@ SecRule REQUEST_FILENAME "@rx /(?:members/.*\.\d+|posts/\d+)/warn$" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:conversation_message,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:notes,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Editor
 SecRule REQUEST_URI "@endsWith /index.php?editor/to-html" \
@@ -194,7 +194,7 @@ SecRule REQUEST_URI "@endsWith /index.php?editor/to-html" \
     ctl:ruleRemoveTargetById=942260;ARGS:attachment_hash_combined,\
     ctl:ruleRemoveTargetById=942340;ARGS:attachment_hash_combined,\
     ctl:ruleRemoveTargetById=942370;ARGS:attachment_hash_combined,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Editor
 SecRule REQUEST_URI "@endsWith /index.php?editor/to-bb-code" \
@@ -204,7 +204,7 @@ SecRule REQUEST_URI "@endsWith /index.php?editor/to-bb-code" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:html,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Post attachment
 # POST /xf/account/avatar
@@ -220,7 +220,7 @@ SecRule REQUEST_FILENAME "@rx /(?:account/avatar|attachments/upload)$" \
     ctl:ruleRemoveTargetById=942440;ARGS:flowIdentifier,\
     ctl:ruleRemoveTargetById=942440;ARGS:flowFilename,\
     ctl:ruleRemoveTargetById=942440;ARGS:flowRelativePath,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Media
 # POST /xf/index.php?editor/media
@@ -232,7 +232,7 @@ SecRule REQUEST_URI "@endsWith /index.php?editor/media" \
     nolog,\
     ctl:ruleRemoveTargetById=931130;ARGS:url,\
     ctl:ruleRemoveTargetById=942130;ARGS:url,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Emoji
 # GET /xf/index.php?misc/find-emoji&q=(%0A%0A
@@ -243,7 +243,7 @@ SecRule REQUEST_URI "@rx /index\.php\?misc/find-emoji&q=" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetById=921151;ARGS:q,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Login
 # POST /xf/login/login
@@ -254,7 +254,7 @@ SecRule REQUEST_FILENAME "@endsWith /login/login" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Register account
 # POST /xf/register/register
@@ -269,7 +269,7 @@ SecRule REQUEST_FILENAME "@endsWith /register/register" \
     nolog,\
     ctl:ruleRemoveTargetById=942130;ARGS,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:reg_key,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Confirm account
 # GET /xf/account-confirmation/name.12345/email?c=foo
@@ -291,7 +291,7 @@ SecRule REQUEST_FILENAME "@endsWith /account/account-details" \
     nolog,\
     ctl:ruleRemoveTargetById=931130;ARGS:custom_fields[picture],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:about_html,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Lost password
 # POST /xf/lost-password/user-name.12345/confirm?c=foo
@@ -302,7 +302,7 @@ SecRule REQUEST_FILENAME "@rx /lost-password/.*\.\d+/confirm$" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:c,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Set forum signature
 # POST /xf/account/signature
@@ -313,7 +313,7 @@ SecRule REQUEST_FILENAME "@endsWith /account/signature" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:signature_html,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Search
 # POST /xf/search/search
@@ -328,7 +328,7 @@ SecRule REQUEST_FILENAME "@endsWith /search/search" \
     ctl:ruleRemoveTargetById=942260;ARGS:constraints,\
     ctl:ruleRemoveTargetById=942340;ARGS:constraints,\
     ctl:ruleRemoveTargetById=942370;ARGS:constraints,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Search within thread
 # GET /xf/threads/foo.12345/page12?highlight=foo
@@ -339,7 +339,7 @@ SecRule REQUEST_FILENAME "@rx /threads/.*\.\d+/(?:page\d+)?$" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:highlight,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Search within search result
 # GET /xf/search/12345/?q=foo
@@ -350,7 +350,7 @@ SecRule REQUEST_FILENAME "@rx /search/\d+/$" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:q,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Contact form
 # POST /xf/misc/contact
@@ -362,7 +362,7 @@ SecRule REQUEST_FILENAME "@endsWith /misc/contact" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:subject,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Report post
 # POST /xf/posts/12345/report
@@ -373,7 +373,7 @@ SecRule REQUEST_FILENAME "@rx /posts/\d+/report$" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Alternate thread view route
 # /xf/index.php?threads/title-having-some-sql.12345/
@@ -388,7 +388,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule REQUEST_METHOD "@streq GET" \
         "t:none,\
@@ -412,7 +412,7 @@ SecRule REQUEST_URI "@endsWith /index.php?dbtech-security/fingerprint" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:components[14][value],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:components[15][value],\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:components[16][value],\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Get location info
 SecRule REQUEST_FILENAME "@endsWith /misc/location-info" \
@@ -422,7 +422,7 @@ SecRule REQUEST_FILENAME "@endsWith /misc/location-info" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:location,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 #
 # -=[ XenForo Global Exclusions ]=-
@@ -455,7 +455,7 @@ SecAction \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;REQUEST_COOKIES:xf_ls,\
     ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:xf_session,\
     ctl:ruleRemoveTargetById=942100;REQUEST_COOKIES:xf_user,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 #
 # -=[ XenForo Administration Back-End ]=-
@@ -469,7 +469,7 @@ SecRule REQUEST_FILENAME "!@endsWith /admin.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     skipAfter:END-XENFORO-ADMIN"
 
 SecRule REQUEST_FILENAME "!@endsWith /admin.php" \
@@ -478,7 +478,7 @@ SecRule REQUEST_FILENAME "!@endsWith /admin.php" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     skipAfter:END-XENFORO-ADMIN"
 
 # Admin edit user
@@ -491,7 +491,7 @@ SecRule REQUEST_URI "@rx /admin\.php\?users/.*\.\d+/edit$" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:profile[about],\
     ctl:ruleRemoveTargetById=931130;ARGS:profile[website],\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Admin save user
 # POST /xf/admin.php?users/the-user-name.12345/save
@@ -510,7 +510,7 @@ SecRule REQUEST_URI "@rx /admin\.php\?users/.*\.\d+/save$" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:custom_fields[sexuality],\
     ctl:ruleRemoveTargetById=931130;ARGS:custom_fields[picture],\
     ctl:ruleRemoveTargetById=931130;ARGS:profile[website],\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 
 # Admin edit forum notice
@@ -524,7 +524,7 @@ SecRule REQUEST_URI "@rx /admin\.php\?notices/(?:.*\.)?\d+/save$" \
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:title,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Admin batch thread update
 # POST /xf/admin.php?threads/batch-update/action
@@ -539,7 +539,7 @@ SecRule REQUEST_URI "@rx /admin\.php\?(?:threads|users)/batch-update/action$" \
     ctl:ruleRemoveTargetById=942330;ARGS:criteria,\
     ctl:ruleRemoveTargetById=942340;ARGS:criteria,\
     ctl:ruleRemoveTargetById=942370;ARGS:criteria,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Edit forum theme
 # POST /xf/admin.php?styles/title.1234/style-properties/group&group=basic
@@ -556,7 +556,7 @@ SecRule REQUEST_URI "@rx /admin\.php\?styles/" \
     ctl:ruleRemoveTargetById=942340;ARGS:json,\
     ctl:ruleRemoveTargetById=942370;ARGS:json,\
     ctl:ruleRemoveTargetById=942440;ARGS:json,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Set forum options
 # POST /xf/admin.php?options/update
@@ -567,7 +567,7 @@ SecRule REQUEST_URI "@rx /admin\.php\?options/update" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:options[boardInactiveMessage],\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Edit pages/templates
 # POST /xf/admin.php?pages/0/save
@@ -580,7 +580,7 @@ SecRule REQUEST_URI "@rx /admin\.php\?(?:pages|templates)/.*/save" \
     t:none,\
     nolog,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:template,\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 SecMarker "END-XENFORO-ADMIN"
 

--- a/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
+++ b/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -24,7 +24,7 @@ SecRule REQUEST_LINE "@streq GET /" \
     tag:'language-multi',\
     tag:'platform-apache',\
     tag:'attack-generic',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
         "t:none,\
@@ -44,7 +44,7 @@ SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
     tag:'language-multi',\
     tag:'platform-apache',\
     tag:'attack-generic',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule REQUEST_HEADERS:User-Agent "@endsWith (internal dummy connection)" \
         "t:none,\

--- a/rules/REQUEST-910-IP-REPUTATION.conf
+++ b/rules/REQUEST-910-IP-REPUTATION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -41,7 +41,7 @@ SecRule TX:DO_REPUT_BLOCK "@eq 1" \
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain,\
     skipAfter:BEGIN-REQUEST-BLOCKING-EVAL"
@@ -71,7 +71,7 @@ SecRule TX:HIGH_RISK_COUNTRY_CODES "!@rx ^$" \
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule TX:REAL_IP "@geoLookup" \
@@ -125,7 +125,7 @@ SecRule IP:PREVIOUS_RBL_CHECK "@eq 1" \
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     skipAfter:END-RBL-LOOKUP"
 
 #
@@ -148,7 +148,7 @@ SecRule &TX:block_suspicious_ip "@eq 0" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain,\
     skipAfter:END-RBL-CHECK"
     SecRule &TX:block_harvester_ip "@eq 0" \
@@ -169,7 +169,7 @@ SecRule TX:REAL_IP "@rbl dnsbl.httpbl.org" \
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.httpbl_msg=%{tx.0}',\
     chain"
     SecRule TX:httpbl_msg "@rx RBL lookup of .*?.dnsbl.httpbl.org succeeded at TX:checkip. (.*?): .*" \
@@ -190,7 +190,7 @@ SecRule TX:block_search_ip "@eq 1" \
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain,\
     skipAfter:END-RBL-CHECK"
@@ -214,7 +214,7 @@ SecRule TX:block_spammer_ip "@eq 1" \
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain,\
     skipAfter:END-RBL-CHECK"
@@ -238,7 +238,7 @@ SecRule TX:block_suspicious_ip "@eq 1" \
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain,\
     skipAfter:END-RBL-CHECK"
@@ -262,7 +262,7 @@ SecRule TX:block_harvester_ip "@eq 1" \
     tag:'attack-reputation-ip',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain,\
     skipAfter:END-RBL-CHECK"
@@ -284,7 +284,7 @@ SecAction \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'ip.previous_rbl_check=1',\
     expirevar:'ip.previous_rbl_check=86400'"
 

--- a/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
+++ b/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -39,7 +39,7 @@ SecRule REQUEST_METHOD "!@within %{tx.allowed_methods}" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/274',\
     tag:'PCI/12.1',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 

--- a/rules/REQUEST-912-DOS-PROTECTION.conf
+++ b/rules/REQUEST-912-DOS-PROTECTION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -70,7 +70,7 @@ SecRule &TX:dos_burst_time_slice "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain,\
     skipAfter:END-DOS-PROTECTION-CHECKS"
     SecRule &TX:dos_counter_threshold "@eq 0" \
@@ -83,7 +83,7 @@ SecRule &TX:dos_burst_time_slice "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain,\
     skipAfter:END-DOS-PROTECTION-CHECKS"
     SecRule &TX:dos_counter_threshold "@eq 0" \
@@ -116,7 +116,7 @@ SecRule IP:DOS_BLOCK "@eq 1" \
     tag:'attack-dos',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/227/469',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule &IP:DOS_BLOCK_FLAG "@eq 0" \
         "setvar:'ip.dos_block_counter=+1',\
@@ -141,7 +141,7 @@ SecRule IP:DOS_BLOCK "@eq 1" \
     tag:'attack-dos',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/227/469',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'ip.dos_block_counter=+1'"
 
 
@@ -162,7 +162,7 @@ SecRule IP:DOS_BLOCK "@eq 1" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-dos',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     skipAfter:END-DOS-PROTECTION-CHECKS"
 
 
@@ -182,7 +182,7 @@ SecRule REQUEST_BASENAME "@rx .*?(\.[a-z0-9]{1,10})?$" \
     tag:'attack-dos',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/227/469',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.extension=/%{TX.1}/',\
     chain"
     SecRule TX:EXTENSION "!@within %{tx.static_extensions}" \
@@ -213,7 +213,7 @@ SecRule IP:DOS_COUNTER "@ge %{tx.dos_counter_threshold}" \
     tag:'attack-dos',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/227/469',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule &IP:DOS_BURST_COUNTER "@eq 0" \
         "setvar:'ip.dos_burst_counter=1',\
@@ -233,7 +233,7 @@ SecRule IP:DOS_COUNTER "@ge %{tx.dos_counter_threshold}" \
     tag:'attack-dos',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/227/469',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule &IP:DOS_BURST_COUNTER "@ge 1" \
         "setvar:'ip.dos_burst_counter=2',\
@@ -260,7 +260,7 @@ SecRule IP:DOS_BURST_COUNTER "@ge 2" \
     tag:'attack-dos',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/227/469',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'ip.dos_block=1',\
     expirevar:'ip.dos_block=%{tx.dos_block_timeout}'"
 
@@ -294,7 +294,7 @@ SecRule IP:DOS_BURST_COUNTER "@ge 1" \
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/227/469',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'ip.dos_block=1',\
     expirevar:'ip.dos_block=%{tx.dos_block_timeout}'"
 

--- a/rules/REQUEST-913-SCANNER-DETECTION.conf
+++ b/rules/REQUEST-913-SCANNER-DETECTION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -47,7 +47,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scanners-user-agents.data" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/224/541/310',\
     tag:'PCI/6.5.10',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'ip.reput_block_flag=1',\
@@ -70,7 +70,7 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@pmFromFile scanners-headers.data
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/224/541/310',\
     tag:'PCI/6.5.10',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'ip.reput_block_flag=1',\
@@ -95,7 +95,7 @@ SecRule REQUEST_FILENAME|ARGS "@pmFromFile scanners-urls.data" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/224/541/310',\
     tag:'PCI/6.5.10',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'ip.reput_block_flag=1',\
@@ -135,7 +135,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scripting-user-agents.data" \
     tag:'capec/1000/118/224/541/310',\
     tag:'PCI/6.5.10',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
     setvar:'ip.reput_block_flag=1',\
@@ -169,7 +169,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile crawlers-user-agents.data" \
     tag:'capec/1000/118/224/541/310',\
     tag:'PCI/6.5.10',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
     setvar:'ip.reput_block_flag=1',\

--- a/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+++ b/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -59,7 +59,7 @@ SecRule REQUEST_LINE "!@rx ^(?i:(?:[a-z]{3,10}\s+(?:\w{3,7}?://[\w\-\./]*(?::\d+
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
@@ -109,7 +109,7 @@ SecRule FILES_NAMES|FILES "@rx (?<!&(?:[aAoOuUyY]uml)|&(?:[aAeEiIoOuU]circ)|&(?:
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -138,7 +138,7 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^\d+$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -172,7 +172,7 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule REQUEST_HEADERS:Content-Length "!@rx ^0?$" \
@@ -197,7 +197,7 @@ SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule &REQUEST_HEADERS:Transfer-Encoding "!@eq 0" \
@@ -233,7 +233,7 @@ SecRule REQUEST_PROTOCOL "!@within HTTP/2 HTTP/2.0" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_METHOD "@streq POST" \
@@ -262,7 +262,7 @@ SecRule &REQUEST_HEADERS:Transfer-Encoding "!@eq 0" \
     tag:'attack-protocol',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'WARNING',\
     chain"
     SecRule &REQUEST_HEADERS:Content-Length "!@eq 0" \
@@ -300,7 +300,7 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx (\d+)-(\d+)" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'WARNING',\
     chain"
     SecRule TX:2 "@lt %{tx.1}" \
@@ -333,7 +333,7 @@ SecRule REQUEST_HEADERS:Connection "@rx \b(?:keep-alive|close),\s?(?:keep-alive|
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
@@ -366,7 +366,7 @@ SecRule REQUEST_URI "@rx \x25" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/267/72',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_URI "@validateUrlEncoding" \
@@ -386,7 +386,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)application/x-www-form-urlencoded
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/267/72',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_BODY "@rx \x25" \
@@ -418,7 +418,7 @@ SecRule TX:CRS_VALIDATE_UTF8_ENCODING "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/267',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_FILENAME|ARGS|ARGS_NAMES "@validateUtf8Encoding" \
@@ -457,7 +457,7 @@ SecRule REQUEST_URI|REQUEST_BODY "@rx \%u[fF]{2}[0-9a-fA-F]{2}" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/267/72',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
@@ -511,7 +511,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 1-255" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -543,7 +543,7 @@ SecRule &REQUEST_HEADERS:Host "@eq 0" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'PCI/6.5.10',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}',\
     skipAfter:END-HOST-CHECK"
@@ -562,7 +562,7 @@ SecRule REQUEST_HEADERS:Host "@rx ^$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
@@ -602,7 +602,7 @@ SecRule REQUEST_HEADERS:Accept "@rx ^$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'NOTICE',\
     chain"
     SecRule REQUEST_METHOD "!@rx ^OPTIONS$" \
@@ -627,7 +627,7 @@ SecRule REQUEST_HEADERS:Accept "@rx ^$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'NOTICE',\
     chain"
     SecRule REQUEST_METHOD "!@rx ^OPTIONS$" \
@@ -660,7 +660,7 @@ SecRule REQUEST_HEADERS:User-Agent "@rx ^$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'NOTICE',\
     setvar:'tx.anomaly_score_pl1=+%{tx.notice_anomaly_score}'"
 
@@ -697,7 +697,7 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'NOTICE',\
     chain"
     SecRule &REQUEST_HEADERS:Content-Type "@eq 0" \
@@ -730,7 +730,7 @@ SecRule REQUEST_HEADERS:Host "@rx ^[\d.:]+$" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'PCI/6.5.10',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl1=+%{tx.warning_anomaly_score}'"
 
@@ -762,7 +762,7 @@ SecRule &TX:MAX_NUM_ARGS "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule &ARGS "@gt %{tx.max_num_args}" \
@@ -787,7 +787,7 @@ SecRule &TX:ARG_NAME_LENGTH "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule ARGS_NAMES "@gt %{tx.arg_name_length}" \
@@ -814,7 +814,7 @@ SecRule &TX:ARG_LENGTH "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule ARGS "@gt %{tx.arg_length}" \
@@ -838,7 +838,7 @@ SecRule &TX:TOTAL_ARG_LENGTH "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule ARGS_COMBINED_SIZE "@gt %{tx.total_arg_length}" \
@@ -863,7 +863,7 @@ SecRule &TX:MAX_FILE_SIZE "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule REQUEST_HEADERS:Content-Type "@rx ^(?i)multipart/form-data" \
@@ -889,7 +889,7 @@ SecRule &TX:COMBINED_FILE_SIZES "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule FILES_COMBINED_SIZE "@gt %{tx.combined_file_sizes}" \
@@ -927,7 +927,7 @@ SecRule REQUEST_HEADERS:Content-Type "!@rx ^[\w/.+-]+(?:\s?;\s?(?:action|boundar
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153',\
     tag:'PCI/12.1',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -950,7 +950,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s]+" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153',\
     tag:'PCI/12.1',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.content_type=|%{tx.0}|',\
     chain"
@@ -978,7 +978,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx charset\s*=\s*[\"']?([^;\"'\s]+)" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153',\
     tag:'PCI/12.1',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule TX:1 "!@rx ^%{tx.allowed_request_content_type_charset}$" \
@@ -1004,7 +1004,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx charset.*?charset" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153',\
     tag:'PCI/12.1',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -1026,7 +1026,7 @@ SecRule REQUEST_PROTOCOL "!@within %{tx.allowed_http_versions}" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'PCI/6.5.10',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -1049,7 +1049,7 @@ SecRule REQUEST_BASENAME "@rx \.([^.]+)$" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'PCI/6.5.10',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.extension=.%{tx.1}/',\
     chain"
@@ -1076,7 +1076,7 @@ SecRule REQUEST_FILENAME "@rx \.[^.~]+~(?:/.*|)$" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'PCI/6.5.10',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -1121,7 +1121,7 @@ SecRule REQUEST_HEADERS_NAMES "@rx ^.*$" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'PCI/12.1',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.header_name_%{tx.0}=/%{tx.0}/',\
     chain"
@@ -1156,7 +1156,7 @@ SecRule REQUEST_HEADERS:Accept "!@rx ^(?:(?:\*|[^\"(),\/:;<=>?![\x5c\]{}]+)\/(?:
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -1188,7 +1188,7 @@ SecRule &REQUEST_HEADERS:Content-Type "@gt 1" \
     tag:'attack-protocol',\
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -1232,7 +1232,7 @@ SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_BASENAME "!@endsWith .pdf" \
@@ -1256,7 +1256,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d+)?-(?:\d+)?\s*,?\s*){63}" \
@@ -1277,7 +1277,7 @@ SecRule ARGS "@rx %[0-9a-fA-F]{2}" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/267/120',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl2=+%{tx.warning_anomaly_score}'"
 
@@ -1308,7 +1308,7 @@ SecRule &REQUEST_HEADERS:Accept "@eq 0" \
     tag:'capec/1000/210/272',\
     tag:'PCI/6.5.10',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'NOTICE',\
     chain"
     SecRule REQUEST_METHOD "!@rx ^OPTIONS$" \
@@ -1334,7 +1334,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@validateByteRange 9,10,13,
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
@@ -1361,7 +1361,7 @@ SecRule &REQUEST_HEADERS:User-Agent "@eq 0" \
     tag:'capec/1000/210/272',\
     tag:'PCI/6.5.10',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'NOTICE',\
     setvar:'tx.anomaly_score_pl2=+%{tx.notice_anomaly_score}'"
 
@@ -1383,7 +1383,7 @@ SecRule FILES_NAMES|FILES "@rx ['\";=\x5c]" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
@@ -1408,7 +1408,7 @@ SecRule REQUEST_HEADERS:Content-Length "!@rx ^0$" \
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule &REQUEST_HEADERS:Content-Type "@eq 0" \
@@ -1442,7 +1442,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteR
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'paranoia-level/3',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
@@ -1470,7 +1470,7 @@ SecRule &REQUEST_HEADERS:x-up-devcap-post-charset "@ge 1" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'paranoia-level/3',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule REQUEST_HEADERS:User-Agent "@rx ^(?i)up" \
@@ -1523,7 +1523,7 @@ SecRule &REQUEST_HEADERS:Cache-Control "@gt 0" \
     tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule REQUEST_HEADERS:Cache-Control "!@rx ^(?:(?:max-age=[0-9]+|min-fresh=[0-9]+|no-cache|no-store|no-transform|only-if-cached|max-stale(?:=[0-9]+)?)(\s*\,\s*|$)){1,7}$" \
@@ -1554,7 +1554,7 @@ SecRule REQUEST_BASENAME "@endsWith .pdf" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'paranoia-level/4',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'WARNING',\
     chain"
     SecRule REQUEST_HEADERS:Range|REQUEST_HEADERS:Request-Range "@rx ^bytes=(?:(?:\d+)?-(?:\d+)?\s*,?\s*){6}" \
@@ -1581,7 +1581,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_BODY "@validateByteRange 38,44-46,48-58,61,65-90
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'paranoia-level/4',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
 
@@ -1602,7 +1602,7 @@ SecRule REQUEST_HEADERS|!REQUEST_HEADERS:User-Agent|!REQUEST_HEADERS:Referer|!RE
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'paranoia-level/4',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
 
@@ -1626,7 +1626,7 @@ SecRule REQUEST_HEADERS:Sec-Fetch-User "@validateByteRange 32,34,38,42-59,61,63,
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272',\
     tag:'paranoia-level/4',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl4=+%{tx.critical_anomaly_score}'"
 
@@ -1672,7 +1672,7 @@ SecRule REQUEST_URI|REQUEST_HEADERS|ARGS|ARGS_NAMES "@rx (?:^|[^\\\\])\\\\[cdegh
     tag:'OWASP_CRS',\
     tag:'capec/1000/153/267',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl4=+%{tx.critical_anomaly_score}'"

--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -47,7 +47,7 @@ SecRule ARGS_NAMES|ARGS|REQUEST_BODY|XML:/*|XML://@* "@rx (?:get|post|head|optio
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/33',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -80,7 +80,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/34',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -102,7 +102,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/34',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -137,7 +137,7 @@ SecRule REQUEST_HEADERS_NAMES|REQUEST_HEADERS "@rx [\n\r]" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/273',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -166,7 +166,7 @@ SecRule ARGS_NAMES "@rx [\n\r]" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/33',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -188,7 +188,7 @@ SecRule ARGS_GET_NAMES|ARGS_GET "@rx [\n\r]+(?:\s|location|refresh|(?:set-)?cook
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/33',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -214,7 +214,7 @@ SecRule REQUEST_FILENAME "@rx [\n\r]" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/34',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -247,7 +247,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/136',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -280,7 +280,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s,]+[;\s,].*?(?:(?:application(?:
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153',\
     tag:'PCI/12.1',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -314,7 +314,7 @@ SecRule ARGS_GET "@rx [\n\r]" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220/33',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.http_violation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -350,7 +350,7 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^[^;\s,]+[;\s,].*?\b(?:(audio|image|vi
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153',\
     tag:'PCI/12.1',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
@@ -386,7 +386,7 @@ SecRule &REQUEST_HEADERS:Range "@gt 0" \
     tag:'paranoia-level/3',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/272/220',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
 
@@ -420,7 +420,7 @@ SecRule ARGS_NAMES "@rx ." \
     tag:'attack-protocol',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/137/15/460',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'TX.paramcounter_%{MATCHED_VAR_NAME}=+1'"
 
 SecRule TX:/paramcounter_.*/ "@gt 1" \
@@ -436,7 +436,7 @@ SecRule TX:/paramcounter_.*/ "@gt 1" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/137/15/460',\
     tag:'paranoia-level/3',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VARS_NAMES "@rx TX:paramcounter_(.*)" \

--- a/rules/REQUEST-922-MULTIPART-ATTACK.conf
+++ b/rules/REQUEST-922-MULTIPART-ATTACK.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -38,7 +38,7 @@ SecRule &MULTIPART_PART_HEADERS:_charset_ "!@eq 0" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153',\
     tag:'paranoia-level/1',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule ARGS:_charset_ "!@within |%{tx.allowed_request_content_type_charset}|" \
@@ -62,7 +62,7 @@ SecRule &MULTIPART_PART_HEADERS "@gt 0" \
     t:none,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.multipart_headers_content_counter=0'"
 
 SecRule MULTIPART_PART_HEADERS "@rx ^content-type\s*:\s*(.*)$" \
@@ -73,7 +73,7 @@ SecRule MULTIPART_PART_HEADERS "@rx ^content-type\s*:\s*(.*)$" \
     t:none,t:lowercase,\
     nolog,\
     tag:'OWASP_CRS',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.multipart_headers_content_types_%{tx.multipart_headers_content_counter}=%{tx.1}',\
     setvar:'tx.multipart_headers_content_counter=+1'"
 
@@ -92,7 +92,7 @@ SecRule TX:/MULTIPART_HEADERS_CONTENT_TYPES_*/ "!@rx ^(?:(?:\*|[^!\"\(\),/:-\?\[
     tag:'OWASP_CRS',\
     tag:'capec/272/220',\
     tag:'paranoia-level/1',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -113,7 +113,7 @@ SecRule MULTIPART_PART_HEADERS "@rx content-transfer-encoding:(.*)" \
     tag:'OWASP_CRS',\
     tag:'capec/272/220',\
     tag:'paranoia-level/1',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -136,6 +136,6 @@ SecRule MULTIPART_PART_HEADERS "@rx [^\x21-\x7E][\x21-\x39\x3B-\x7E]*:" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/272/220',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"

--- a/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+++ b/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -42,7 +42,7 @@ SecRule REQUEST_URI_RAW|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/*|XML
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/126',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}'"
@@ -65,7 +65,7 @@ SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|XML:/*|XML://@
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/126',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
@@ -92,7 +92,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/126',\
     tag:'PCI/6.5.4',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -119,7 +119,7 @@ SecRule REQUEST_FILENAME "@pmFromFile restricted-files.data" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/255/153/126',\
     tag:'PCI/6.5.4',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"

--- a/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
+++ b/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -50,7 +50,7 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?):\/\/(?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/175/253',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -71,7 +71,7 @@ SecRule QUERY_STRING|REQUEST_BODY "@rx (?i)(?:\binclude\s*\([^)]*|mosConfig_abso
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/175/253',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -92,7 +92,7 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?).*?\?+$" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/175/253',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -120,7 +120,7 @@ SecRule ARGS "@rx ^(?i:file|ftps?|https?)://([^/]*).*$" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/175/253',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.rfi_parameter_%{MATCHED_VAR_NAME}=.%{tx.1}',\
     chain"

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -117,7 +117,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -153,7 +153,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -250,7 +250,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -289,7 +289,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -324,7 +324,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -361,7 +361,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -407,7 +407,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -458,7 +458,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -495,7 +495,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -527,7 +527,7 @@ SecRule REQUEST_HEADERS|REQUEST_LINE "@rx ^\(\s*\)\s+{" \
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -549,7 +549,7 @@ SecRule ARGS_NAMES|ARGS|FILES_NAMES "@rx ^\(\s*\)\s+{" \
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -584,7 +584,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -629,7 +629,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/88',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VAR "@rx /" "t:none,t:urlDecodeUni,chain"
@@ -679,7 +679,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -711,7 +711,7 @@ SecRule ARGS "@rx (?:/|\\\\)(?:[\?\*]+[a-z/\\\\]+|[a-z/\\\\]+[\?\*]+)" \
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"

--- a/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+++ b/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -60,7 +60,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -102,7 +102,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -126,7 +126,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VARS "@pm =" \
@@ -155,7 +155,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -192,7 +192,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -221,7 +221,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -289,7 +289,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -343,7 +343,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -399,7 +399,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -455,7 +455,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -497,7 +497,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -540,7 +540,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VARS "@pm (" \
@@ -595,7 +595,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/242',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -641,7 +641,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'capec/1000/152/242',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -684,7 +684,7 @@ SecRule FILES|REQUEST_HEADERS:X-Filename|REQUEST_HEADERS:X_Filename|REQUEST_HEAD
     tag:'capec/1000/152/242',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -714,7 +714,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/242',\
     tag:'paranoia-level/3',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.php_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"

--- a/rules/REQUEST-934-APPLICATION-ATTACK-NODEJS.conf
+++ b/rules/REQUEST-934-APPLICATION-ATTACK-NODEJS.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -63,7 +63,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\

--- a/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+++ b/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -50,7 +50,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -77,7 +77,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_F
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -103,7 +103,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -133,7 +133,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -159,7 +159,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -194,7 +194,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -219,7 +219,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -245,7 +245,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -272,7 +272,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -294,7 +294,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -316,7 +316,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -338,7 +338,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -360,7 +360,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -382,7 +382,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -404,7 +404,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -426,7 +426,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -448,7 +448,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -470,7 +470,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -492,7 +492,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -514,7 +514,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -541,7 +541,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -568,7 +568,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -610,7 +610,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242/63',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -638,7 +638,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS|XML:
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/242/63',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -669,7 +669,7 @@ SecRule REQUEST_HEADERS:Referer "@detectXSS" \
     tag:'capec/1000/152/242',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -695,7 +695,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'capec/1000/152/242',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -778,7 +778,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'capec/1000/152/242/63',\
     tag:'PCI/6.5.1',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -799,7 +799,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'capec/1000/152/242',\
     tag:'PCI/6.5.1',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -823,7 +823,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'capec/1000/152/242',\
     tag:'PCI/6.5.1',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -856,7 +856,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/242/63',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -59,7 +59,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_H
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
@@ -94,7 +94,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -120,7 +120,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -149,7 +149,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -178,7 +178,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -199,7 +199,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -220,7 +220,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -249,7 +249,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -270,7 +270,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -291,7 +291,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -320,7 +320,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -341,7 +341,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -370,7 +370,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -399,7 +399,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -439,7 +439,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -475,7 +475,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -513,7 +513,7 @@ SecRule ARGS_NAMES|ARGS|XML:/*|XML://@* "@rx (?:^\s*[\"'`;]+|[\"'`]+\s*$)" \
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'WARNING',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.warning_anomaly_score}'"
@@ -549,7 +549,7 @@ SecRule ARGS_NAMES|ARGS|XML:/*|XML://@* "@rx (?i:(?:(?:^|\W)in[+\s]*\([\s\d\"]+[
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -584,7 +584,7 @@ SecRule ARGS_NAMES|ARGS|XML:/*|XML://@* "@rx (?i:[\s'\"`()]*?\b([\d\w]+)\b[\s'\"
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     multiMatch,\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
@@ -623,7 +623,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -652,7 +652,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -684,7 +684,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -716,7 +716,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -745,7 +745,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -774,7 +774,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -803,7 +803,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -840,7 +840,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -871,7 +871,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -896,7 +896,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -930,7 +930,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -957,7 +957,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -984,7 +984,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1014,7 +1014,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1051,7 +1051,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1084,7 +1084,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1117,7 +1117,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1158,7 +1158,7 @@ SecRule ARGS_NAMES|ARGS|XML:/*|XML://@* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl2=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"
@@ -1202,7 +1202,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
@@ -1227,7 +1227,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1276,7 +1276,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1315,7 +1315,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -1339,7 +1339,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -1379,7 +1379,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl3=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"
@@ -1408,7 +1408,7 @@ SecRule ARGS_NAMES|ARGS|XML:/*|XML://@* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl3=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"
@@ -1438,7 +1438,7 @@ SecRule ARGS "@rx \W{4}" \
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'WARNING',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.warning_anomaly_score}'"
@@ -1472,7 +1472,7 @@ SecRule REQUEST_BASENAME "@detectSQLi" \
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -1522,7 +1522,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"
@@ -1555,7 +1555,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQU
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/4',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl4=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"
@@ -1584,7 +1584,7 @@ SecRule ARGS_NAMES|ARGS|XML:/*|XML://@* "@rx ((?:[~!@#\$%\^&\*\(\)\-\+=\{\}\[\]\
     tag:'capec/1000/152/248/66',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/4',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'WARNING',\
     setvar:'tx.anomaly_score_pl4=+%{tx.warning_anomaly_score}',\
     setvar:'tx.sql_injection_score=+%{tx.warning_anomaly_score}'"

--- a/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
+++ b/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -44,7 +44,7 @@ SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAME
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/21/593/61',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.session_fixation_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -65,7 +65,7 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/21/593/61',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule REQUEST_HEADERS:Referer "@rx ^(?:ht|f)tps?://(.*?)\/" \
@@ -92,7 +92,7 @@ SecRule ARGS_NAMES "@rx ^(?:jsessionid|aspsessionid|asp\.net_sessionid|phpsessio
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/225/21/593/61',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule &REQUEST_HEADERS:Referer "@eq 0" \

--- a/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+++ b/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -47,7 +47,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'capec/1000/152/137/6',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/1',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -81,7 +81,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/1',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* "@rx (?:unmarshaller|base64data|java\.)" \
@@ -107,7 +107,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/1',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule MATCHED_VARS "@rx (?:runtime|processbuilder)" \
@@ -141,7 +141,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/1',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -180,7 +180,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -202,7 +202,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -224,7 +224,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -249,7 +249,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/2',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -285,7 +285,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
     tag:'capec/1000/152/248',\
     tag:'PCI/6.5.2',\
     tag:'paranoia-level/3',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.anomaly_score_pl3=+%{tx.critical_anomaly_score}'"

--- a/rules/REQUEST-949-BLOCKING-EVALUATION.conf
+++ b/rules/REQUEST-949-BLOCKING-EVALUATION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -69,7 +69,7 @@ SecRule IP:REPUT_BLOCK_FLAG "@eq 1" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-reputation-ip',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule TX:DO_REPUT_BLOCK "@eq 1" \
@@ -89,7 +89,7 @@ SecRule TX:ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
     tag:'language-multi',\
     tag:'platform-multi',\
     tag:'attack-generic',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     setvar:'tx.inbound_anomaly_score=%{tx.anomaly_score}'"
 

--- a/rules/RESPONSE-950-DATA-LEAKAGES.conf
+++ b/rules/RESPONSE-950-DATA-LEAKAGES.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -45,7 +45,7 @@ SecRule RESPONSE_BODY "@rx (?:<(?:TITLE>Index of.*?<H|title>Index of.*?<h)1>Inde
     tag:'capec/1000/118/116/54/127',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
@@ -79,7 +79,7 @@ SecRule RESPONSE_BODY "@rx ^#\!\s?/" \
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
@@ -111,7 +111,7 @@ SecRule RESPONSE_STATUS "@rx ^5\d{2}$" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/152',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl2=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl2=+%{tx.error_anomaly_score}'"

--- a/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+++ b/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -38,7 +38,7 @@ SecRule RESPONSE_BODY "@pmFromFile sql-errors.data" \
     tag:'attack-disclosure',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.sql_error_match=1'"
 
 SecRule TX:sql_error_match "@eq 1" \
@@ -56,7 +56,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:JET Database Engine|Access Database Engine|\[Microsoft\]\[ODBC Microsoft Access Driver\])" \
@@ -81,7 +81,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:ORA-[0-9][0-9][0-9][0-9]|java\.sql\.SQLException|Oracle error|Oracle.*Driver|Warning.*oci_.*|Warning.*ora_.*)" \
@@ -106,7 +106,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:DB2 SQL error:|\[IBM\]\[CLI Driver\]\[DB2/6000\]|CLI Driver.*DB2|DB2 SQL error|db2_\w+\()" \
@@ -131,7 +131,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:\[DM_QUERY_E_SYNTAX\]|has occurred in the vicinity of:)" \
@@ -156,7 +156,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)Dynamic SQL Error" \
@@ -182,7 +182,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)Exception (?:condition )?\d+\. Transaction rollback\." \
@@ -207,7 +207,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)org\.hsqldb\.jdbc" \
@@ -232,7 +232,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:An illegal character has been found in the statement|com\.informix\.jdbc|Exception.*Informix)" \
@@ -258,7 +258,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:Warning.*ingres_|Ingres SQLSTATE|Ingres\W.*Driver)" \
@@ -284,7 +284,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:<b>Warning</b>: ibase_|Unexpected end of command in statement)" \
@@ -309,7 +309,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:SQL error.*POS[0-9]+.*|Warning.*maxdb.*)" \
@@ -334,7 +334,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)(?:System\.Data\.OleDb\.OleDbException|\[Microsoft\]\[ODBC SQL Server Driver\]|\[Macromedia\]\[SQLServer JDBC Driver\]|\[SqlException|System\.Data\.SqlClient\.SqlException|Unclosed quotation mark after the character string|'80040e14'|mssql_query\(\)|Microsoft OLE DB Provider for ODBC Drivers|Microsoft OLE DB Provider for SQL Server|Incorrect syntax near|Sintaxis incorrecta cerca de|Syntax error in string in query expression|Procedure or function .* expects parameter|Unclosed quotation mark before the character string|Syntax error .* in query expression|Data type mismatch in criteria expression\.|ADODB\.Field \(0x800A0BCD\)|the used select statements have different number of columns|OLE DB.*SQL Server|Warning.*mssql_.*|Driver.*SQL[ _-]*Server|SQL Server.*Driver|SQL Server.*[0-9a-fA-F]{8}|Exception.*\WSystem\.Data\.SqlClient\.)" \
@@ -359,7 +359,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)(?:supplied argument is not a valid MySQL|Column count doesn't match value count at row|mysql_fetch_array\(\)|on MySQL result index|You have an error in your SQL syntax;|You have an error in your SQL syntax near|MySQL server version for the right syntax to use|\[MySQL\]\[ODBC|Column count doesn't match|Table '[^']+' doesn't exist|SQL syntax.*MySQL|Warning.*mysql_.*|valid MySQL result|MySqlClient\.)" \
@@ -384,7 +384,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i:PostgreSQL query failed:|pg_query\(\) \[:|pg_exec\(\) \[:|PostgreSQL.*ERROR|Warning.*pg_.*|valid PostgreSQL result|Npgsql\.|PG::[a-zA-Z]*Error|Supplied argument is not a valid PostgreSQL .*? resource|Unable to connect to PostgreSQL server)" \
@@ -409,7 +409,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)(?:Warning.*sqlite_.*|Warning.*SQLite3::|SQLite/JDBCDriver|SQLite\.Exception|System\.Data\.SQLite\.SQLiteException)" \
@@ -434,7 +434,7 @@ SecRule TX:sql_error_match "@eq 1" \
     tag:'paranoia-level/1',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116/54',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'CRITICAL',\
     chain"
     SecRule RESPONSE_BODY "@rx (?i)(?:Sybase message:|Warning.*sybase.*|Sybase.*Server message.*)" \

--- a/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
+++ b/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -40,7 +40,7 @@ SecRule RESPONSE_BODY "@pmFromFile java-code-leakages.data" \
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
@@ -67,7 +67,7 @@ SecRule RESPONSE_BODY "@pmFromFile java-errors.data" \
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"

--- a/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+++ b/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -40,7 +40,7 @@ SecRule RESPONSE_BODY "@pmFromFile php-errors.data" \
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
@@ -67,7 +67,7 @@ SecRule RESPONSE_BODY "@rx (?:\b(?:f(?:tp_(?:nb_)?f?(?:ge|pu)t|get(?:s?s|c)|scan
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
@@ -97,7 +97,7 @@ SecRule RESPONSE_BODY "@rx <\?(?!xml)" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'ERROR',\
     chain"
     SecRule RESPONSE_BODY "!@rx (?:\x1f\x8b\x08|\b(?:(?:i(?:nterplay|hdr|d3)|m(?:ovi|thd)|r(?:ar!|iff)|(?:ex|jf)if|f(?:lv|ws)|varg|cws)\b|gif)|B(?:%pdf|\.ra)\b|^wOF[F2])" \

--- a/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
+++ b/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -38,7 +38,7 @@ SecRule RESPONSE_BODY "@rx [a-z]:\\\\inetpub\b" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
@@ -61,7 +61,7 @@ SecRule RESPONSE_BODY "@rx (?:Microsoft OLE DB Provider for SQL Server(?:<\/font
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
@@ -87,7 +87,7 @@ SecRule RESPONSE_BODY "@rx (?:\b(?:A(?:DODB\.Command\b.{0,100}?\b(?:Application 
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
     ctl:auditLogParts=+E,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'ERROR',\
     setvar:'tx.outbound_anomaly_score_pl1=+%{tx.error_anomaly_score}',\
     setvar:'tx.anomaly_score_pl1=+%{tx.error_anomaly_score}'"
@@ -110,7 +110,7 @@ SecRule RESPONSE_STATUS "!@rx ^404$" \
     tag:'OWASP_CRS',\
     tag:'capec/1000/118/116',\
     tag:'PCI/6.5.6',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'ERROR',\
     chain"
     SecRule RESPONSE_BODY "@rx \bServer Error in.{0,50}?\bApplication\b" \

--- a/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
+++ b/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -73,7 +73,7 @@ SecRule TX:OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
     t:none,\
     msg:'Outbound Anomaly Score Exceeded (Total Score: %{TX.OUTBOUND_ANOMALY_SCORE})',\
     tag:'anomaly-evaluation',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.anomaly_score=+%{tx.outbound_anomaly_score}'"
 
 

--- a/rules/RESPONSE-980-CORRELATION.conf
+++ b/rules/RESPONSE-980-CORRELATION.conf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #
@@ -30,7 +30,7 @@ SecRule &TX:'/LEAKAGE\\\/ERRORS/' "@ge 1" \
     log,\
     msg:'Correlated Successful Attack Identified: (Total Score: %{tx.anomaly_score}) Inbound Attack (Inbound Anomaly Score: %{TX.INBOUND_ANOMALY_SCORE}) + Outbound Data Leakage (Outbound Anomaly Score: %{TX.OUTBOUND_ANOMALY_SCORE})',\
     tag:'event-correlation',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'EMERGENCY',\
     chain,\
     skipAfter:END-CORRELATION"
@@ -47,7 +47,7 @@ SecRule &TX:'/AVAILABILITY\\\/APP_NOT_AVAIL/' "@ge 1" \
     log,\
     msg:'Correlated Attack Attempt Identified: (Total Score: %{tx.anomaly_score}) Inbound Attack (Inbound Anomaly Score: %{TX.INBOUND_ANOMALY_SCORE}) + Outbound Application Error (Outbound Anomaly Score: %{TX.OUTBOUND_ANOMALY_SCORE})',\
     tag:'event-correlation',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     severity:'ALERT',\
     chain,\
     skipAfter:END-CORRELATION"
@@ -61,7 +61,7 @@ SecAction \
     t:none,\
     nolog,\
     noauditlog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.executing_anomaly_score=%{tx.anomaly_score_pl1}',\
     setvar:'tx.executing_anomaly_score=+%{tx.anomaly_score_pl2}',\
     setvar:'tx.executing_anomaly_score=+%{tx.anomaly_score_pl3}',\
@@ -76,7 +76,7 @@ SecRule TX:INBOUND_ANOMALY_SCORE "@lt %{tx.inbound_anomaly_score_threshold}" \
     noauditlog,\
     msg:'Inbound Anomaly Score (Total Inbound Score: %{TX.INBOUND_ANOMALY_SCORE} - SQLI=%{tx.sql_injection_score},XSS=%{tx.xss_score},RFI=%{tx.rfi_score},LFI=%{tx.lfi_score},RCE=%{tx.rce_score},PHPI=%{tx.php_injection_score},HTTP=%{tx.http_violation_score},SESS=%{tx.session_fixation_score}): individual paranoia level scores: %{TX.ANOMALY_SCORE_PL1}, %{TX.ANOMALY_SCORE_PL2}, %{TX.ANOMALY_SCORE_PL3}, %{TX.ANOMALY_SCORE_PL4}',\
     tag:'event-correlation',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule TX:MONITOR_ANOMALY_SCORE "@gt 1"
 
@@ -89,7 +89,7 @@ SecRule TX:INBOUND_ANOMALY_SCORE "@ge %{tx.inbound_anomaly_score_threshold}" \
     noauditlog,\
     msg:'Inbound Anomaly Score Exceeded (Total Inbound Score: %{TX.INBOUND_ANOMALY_SCORE} - SQLI=%{tx.sql_injection_score},XSS=%{tx.xss_score},RFI=%{tx.rfi_score},LFI=%{tx.lfi_score},RCE=%{tx.rce_score},PHPI=%{tx.php_injection_score},HTTP=%{tx.http_violation_score},SESS=%{tx.session_fixation_score}): individual paranoia level scores: %{TX.ANOMALY_SCORE_PL1}, %{TX.ANOMALY_SCORE_PL2}, %{TX.ANOMALY_SCORE_PL3}, %{TX.ANOMALY_SCORE_PL4}',\
     tag:'event-correlation',\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 SecRule TX:OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
     "id:980140,\
@@ -100,7 +100,7 @@ SecRule TX:OUTBOUND_ANOMALY_SCORE "@ge %{tx.outbound_anomaly_score_threshold}" \
     noauditlog,\
     msg:'Outbound Anomaly Score Exceeded (score %{TX.OUTBOUND_ANOMALY_SCORE}): individual paranoia level scores: %{TX.OUTBOUND_ANOMALY_SCORE_PL1}, %{TX.OUTBOUND_ANOMALY_SCORE_PL2}, %{TX.OUTBOUND_ANOMALY_SCORE_PL3}, %{TX.OUTBOUND_ANOMALY_SCORE_PL4}',\
     tag:'event-correlation',\
-    ver:'OWASP_CRS/3.3.9'"
+    ver:'OWASP_CRS/3.3.10'"
 
 # Creating a total sum of all triggered outbound rules, including the ones only being monitored
 SecAction \
@@ -110,7 +110,7 @@ SecAction \
     t:none,\
     nolog,\
     noauditlog,\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     setvar:'tx.executing_anomaly_score=%{tx.outbound_anomaly_score_pl1}',\
     setvar:'tx.executing_anomaly_score=+%{tx.outbound_anomaly_score_pl2}',\
     setvar:'tx.executing_anomaly_score=+%{tx.outbound_anomaly_score_pl3}',\
@@ -125,7 +125,7 @@ SecRule TX:OUTBOUND_ANOMALY_SCORE "@lt %{tx.outbound_anomaly_score_threshold}" \
     noauditlog,\
     msg:'Outbound Anomaly Score (Total Outbound Score: %{TX.OUTBOUND_ANOMALY_SCORE}): individual paranoia level scores: %{TX.OUTBOUND_ANOMALY_SCORE_PL1}, %{TX.OUTBOUND_ANOMALY_SCORE_PL2}, %{TX.OUTBOUND_ANOMALY_SCORE_PL3}, %{TX.OUTBOUND_ANOMALY_SCORE_PL4}',\
     tag:'event-correlation',\
-    ver:'OWASP_CRS/3.3.9',\
+    ver:'OWASP_CRS/3.3.10',\
     chain"
     SecRule TX:MONITOR_ANOMALY_SCORE "@gt 1"
 

--- a/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf.example
+++ b/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf.example
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set ver.3.3.9
+# OWASP ModSecurity Core Rule Set ver.3.3.10
 # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
 # Copyright (c) 2021-2026 Core Rule Set project. All rights reserved.
 #


### PR DESCRIPTION
## what

release prep for v3.3.10:

- version/copyright bump to 3.3.10 across `crs-setup.conf.example`, `rules/*.conf`, `rules/*.conf.example` via `crs-toolchain chore update-copyright`
- CHANGES.md entry for v3.3.10, with GHSA links for both fixes and a breaking-change note
- adds the previously-missing `901180`/`901181` XML attribute inspection opt-in gate rules to `rules/REQUEST-901-INITIALIZATION.conf`
- fixes the stale `901180` rule-id reference in `crs-setup.conf.example` (now points to `901181`) and a pre-existing indentation issue in that same commented block

security fixes already on this branch (no code change in this PR, documented in CHANGES.md):
- R7U-260618 v3 (GHSA-f5qm-3h4p-8qhg): ReDoS in shared unix-shell-evasion regex
- N7Y-260316 v3 (GHSA-6jp8-c2w2-x7wr): XML attribute value bypass

## why

`v3.3/master` had two security fixes merged directly (ReDoS hardening, XML attribute inspection coverage) since v3.3.9 but was never cut as a release. While preparing the release, the XML attribute inspection fix's own commit message and `crs-setup.conf.example` both reference a runtime gate rule (`901180`) that strips `XML://@*` from the affected rules unless an operator opts in — but that rule was never actually added anywhere in `rules/*.conf`. This PR adds it (split into a default-setter `901180` and an enforcer `901181`, mirroring the existing `crs_skip_response_analysis` pattern already used in this file).

While validating the fix against a live container, I found `ctl:ruleRemoveTargetByTag=<tag>;XML://@*` does not actually strip the target on ModSecurity v2 (Apache) — the mechanism works correctly for ordinary variables (verified with an `ARGS` control case) and works correctly on libmodsecurity v3, but silently has no effect for this XPath target on ModSecurity v2. Filed upstream: https://github.com/owasp-modsecurity/ModSecurity/issues/3591. The rule is added anyway since the design is correct and already validated on libmodsecurity v3; a comment in the rule file and a breaking-change note in CHANGES.md document the current ModSecurity v2 limitation.

## refs

- https://github.com/owasp-modsecurity/ModSecurity/issues/3591
- https://github.com/coreruleset/coreruleset/security/advisories/GHSA-f5qm-3h4p-8qhg
- https://github.com/coreruleset/coreruleset/security/advisories/GHSA-6jp8-c2w2-x7wr

## ai disclosure

- **tools used**: Claude (Sonnet 5)
- **assisted with**: running `crs-toolchain chore update-copyright`, discovering the missing `901180` gate rule and designing its two-rule split, isolating and reproducing the ModSecurity v2 `ctl:ruleRemoveTargetByTag` bug (including the `ARGS` control case and the libmodsecurity v3 comparison used in the upstream issue), drafting the CHANGES.md entry and this PR description
- **review performed**: verified `rules/*.conf` syntax with `secrules-parser` (the same tool used in this branch's CI); started the `modsec2-apache` test container fresh and confirmed no config-load errors; manually sent an XML-attribute SQLi payload against the running container to confirm the positive (opt-in enabled, default test-harness state) detection path still fires correctly with no regression; the ModSecurity v2 negative-path (opt-out) limitation was independently reproduced and confirmed against both `owasp/modsecurity-crs:apache` and `owasp/modsecurity-crs:nginx` before filing the upstream issue