### PR TITLE
docs: remove inapplicable libmodsecurity v3.0.16 breaking-change note

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,9 +9,6 @@
 
 ## What's Changed
 
-### Breaking Change
-* this release requires libmodsecurity3 v3.0.16 because of https://github.com/owasp-modsecurity/ModSecurity/pull/3589.
-
 ### 🔒 Security
 * fix: inspect XML attribute values across attack-detection rules — https://github.com/coreruleset/coreruleset/security/advisories/GHSA-6jp8-c2w2-x7wr
 * fix: remove catastrophic backtracking in unix-shell-evasion prefix — https://github.com/coreruleset/coreruleset/security/advisories/GHSA-f5qm-3h4p-8qhg


### PR DESCRIPTION
## what

removes the "Breaking Change" note under v4.28.0 in `CHANGES.md` stating this release requires libmodsecurity3 v3.0.16 because of owasp-modsecurity/ModSecurity#3589.

## why

that requirement doesn't apply to `main`. It was carried over from the LTS release notes (`lts/v4.25.x` / `v3.3/master`), where the XML attribute inspection feature is implemented behind a runtime opt-in/opt-out gate using `ctl:ruleRemoveTargetByTag=<tag>;XML://@*` — the exact syntax that ModSecurity#3589 fixes a lexer rejection for.

`main` ships the `XML://@*` addition unconditionally instead: there is no `tx.crs_xml_attr_inspect` variable, no gate rule, and no `ctl:ruleRemoveTarget*` action anywhere in the ruleset that contains an `@` character in its target. Verified with:

```
grep -rn "ctl:ruleRemoveTarget" rules/ | grep "@"   # no matches
grep -rn "crs_xml_attr_inspect" rules/ crs-setup.conf.example   # no matches
```

Since nothing in `main`'s current ruleset exercises the fixed code path, the version requirement doesn't reflect what actually shipped and would incorrectly tell operators they need to upgrade ModSecurity for no reason.

## refs

- https://github.com/owasp-modsecurity/ModSecurity/pull/3589
- https://github.com/coreruleset/coreruleset/pull/4688 (where this note originated, for the LTS branch that does need it)

## ai disclosure

- **tools used**: Claude (Sonnet 5)
- **assisted with**: comparing `main`'s XML attribute inspection implementation against the LTS branches, verifying no `ctl:ruleRemoveTarget*` action with an `@`-containing target exists anywhere in `main`'s rules, drafting this PR description
- **review performed**: grepped the full `rules/` directory and `crs-setup.conf.example` for any reference to `crs_xml_attr_inspect`, `ctl:ruleRemoveTarget*` with `@`, or the PR/issue numbers involved, confirming none exist on `main`