### PR TITLE
docs: add missing libmodsecurity v3.0.16 requirement to v3.3.10 CHANGES

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 ### ⚠️ Breaking Change
 
+* Requires libmodsecurity v3.0.16 or later when running on nginx/libmodsecurity v3. The XML attribute injection fix (`ctl:ruleRemoveTargetByTag=...;XML://@*` in rule 901181) depends on [owasp-modsecurity/ModSecurity#3589](https://github.com/owasp-modsecurity/ModSecurity/pull/3589), which fixes the lexer's rejection of `@` in `ctl:ruleRemoveTarget*` actions. On libmodsecurity v3 versions older than v3.0.16, this `ctl` action fails to parse, breaking config load.
 * Fully opting out of XML attribute inspection (`tx.crs_xml_attr_inspect`) requires ModSecurity v2 >= v2.9.14, once <https://github.com/owasp-modsecurity/ModSecurity/issues/3591> is fixed upstream. Until then, `ctl:ruleRemoveTargetByTag` cannot remove the `XML://@*` target on ModSecurity v2, so rule 901181 cannot disable attribute inspection on that engine.
 
 ### ⭐ Important changes


### PR DESCRIPTION
## what

adds a "requires libmodsecurity v3.0.16 or later" breaking-change bullet to the v3.3.10 entry in `CHANGES.md`, alongside the existing ModSecurity v2 opt-out note.

## why

`v3.3.10` (#4689, already merged) added rule `901181`, which uses `ctl:ruleRemoveTargetByTag=<tag>;XML://@*` — the same syntax as v4.25.1's equivalent rule. The `@` character in that target fails to parse on libmodsecurity v3 versions older than v3.0.16 ([owasp-modsecurity/ModSecurity#3589](https://github.com/owasp-modsecurity/ModSecurity/pull/3589)), a parse-time failure distinct from the already-documented ModSecurity v2 runtime limitation.

`v3.3` supports running on nginx/libmodsecurity v3 (see `tests/docker-compose.yml`'s `modsec3-nginx` service), so this requirement applies here just as it does on v4.25.1 — but the v3.3.10 `CHANGES.md` entry only documented the ModSecurity v2 side. Missed because the two breaking changes address different engines (v2 vs v3) and different failure modes (silent no-op vs. parse failure); v4.25.1's `CHANGES.md` has both, v3.3.10's was missing this one.

## refs

- https://github.com/owasp-modsecurity/ModSecurity/pull/3589
- https://github.com/coreruleset/coreruleset/pull/4688 (v4.25.1, has both notes)
- https://github.com/coreruleset/coreruleset/pull/4689 (v3.3.10 release this follows up on)

## ai disclosure

- **tools used**: Claude (Sonnet 5)
- **assisted with**: identifying the missing note by comparing v3.3.10's merged `CHANGES.md` against v4.25.1's, confirming rule 901181 uses the affected `ctl` syntax, drafting this PR description
- **review performed**: grepped `rules/REQUEST-901-INITIALIZATION.conf` on `v3.3/master` post-merge to confirm the `ctl:ruleRemoveTargetByTag=...;XML://@*` action is present, and checked `tests/docker-compose.yml` to confirm nginx/libmodsecurity v3 is a supported target for this branch