### PR TITLE
fix(953100): more FPs related to RESPONSE_BODY ("(inclusive)" and "must be a valid")

### DIFF
--- a/rules/php-errors.data
+++ b/rules/php-errors.data
@@ -1286,7 +1286,6 @@ zlib window size (logarithm) (
 # ($end)
 # (after
 (breaking at opline
-(inclusive)
 (path:
 (tried to allocate
 - dynamic modules are not supported
@@ -2031,7 +2030,6 @@ must be a class name compatible with
 must be a class name derived from
 must be a file name or a stream resource,
 must be a string, an array(class, method), or a callable object,
-must be a valid
 must be a valid callback or null,
 must be a valid callback,
 must be a valid callback, function "


### PR DESCRIPTION
## Proposed changes

These phrases are too common and are causing FPs:
```
(inclusive)
must be a valid
```
## PR Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/CONTRIBUTING.md) doc
- [ ] I have added positive tests proving my fix/feature works as intended.
- [ ] I have added negative tests that prove my fix/feature considers common cases that might end in false positives
- [ ] In case you changed a regular expression, you are not adding a ReDOS for pcre. You can check this using [regexploit](https://github.com/doyensec/regexploit)
- [ ] My test use the `comment` field to write the expected behavior
- [ ] I have added documentation for the rule or change (when appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... If there are no additional comments, you may remove this section. -->

## AI Disclosure

<!-- Required per our AI-Assisted Contribution Policy (AI-CONTRIBUTIONS.md) -->

<!-- Select exactly one by deleting the option that does not apply. -->
**AI usage for this contribution:** None

**If "Used", complete the details below:**

| Detail | Response |
|--------|----------|
| Tool(s) used | <!-- e.g., GitHub Copilot, Claude 4, ChatGPT-4o --> |
| What was AI-assisted | <!-- e.g., initial regex draft, test scaffolding, docs wording --> |
| Review performed | <!-- e.g., validated against payload corpus, ran test suite, manual review --> |

## For the reviewer

<!-- Don't remove this part. Reviewers will use it as guidance for the review process. -->

- [ ] Positive and negative tests were added
- [ ] Tests cover the intended fix/feature properly
- [ ] No usage of dangerous constructs like `ctl:requestBodyAccess=Off` were used in the rule
- [ ] In case a regular expression was changed, [there is no ReDOS](https://github.com/coreruleset/coreruleset/wiki/Testing-for-Regular-Expresion-DoS)
- [ ] Documentation is clear for the rule/change
- [ ] If a contribution shows signs of unreviewed AI generation (e.g., plausible-but-broken regex, generic boilerplate comments, hallucinated SecLang directives), reviewers should ask about AI usage regardless of what was checked.
