### PR TITLE
fix: allow optional json. prefix in rule 932171 ARGS_NAMES pattern

### DIFF
--- a/regex-assembly/932171.ra
+++ b/regex-assembly/932171.ra
@@ -1,0 +1,11 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Rule 932171: Remote Command Execution: Shellshock (CVE-2014-6271)
+##!
+##! Allow an optional 'json.' prefix so that libModSecurity3/Coraza's JSON
+##! body processor (which prepends 'json.' to ARGS_NAMES) is still matched.
+
+##!^ ^(?:json\.)?
+
+\(\s*\)\s+\{

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -755,7 +755,7 @@ SecRule REQUEST_HEADERS|REQUEST_LINE "@rx ^\(\s*\)\s+\{" \
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
-SecRule ARGS_NAMES|ARGS|FILES_NAMES "@rx ^\(\s*\)\s+\{" \
+SecRule ARGS_NAMES|ARGS|FILES_NAMES "@rx ^(?:json\.)?\([\s\x0b]*\)[\s\x0b]+\{" \
     "id:932171,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932171.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932171.yaml
@@ -38,3 +38,21 @@ tests:
         output:
           log:
             expect_ids: [932171]
+  - test_id: 3
+    desc: "Test for '() {' in JSON body key (ARGS_NAMES with 'json.' prefix)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Host: localhost
+            Content-Type: application/json
+            User-Agent: "OWASP CRS test agent"
+          method: POST
+          port: 80
+          uri: "/post"
+          data: '{ "() { :; }":"foo" }'
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [932171]

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932171.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932171.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "Franziska Bühler, azurit"
+  author: "Franziska Bühler, azurit, Felipe Zipitria"
   description: "Remote Command Execution: Shellshock (CVE-2014-6271)"
 rule_id: 932171
 tests:


### PR DESCRIPTION
## what

Rule 932171 (Shellshock, CVE-2014-6271) targets `ARGS_NAMES|ARGS|FILES_NAMES` with the start-anchored pattern `^\(\s*\)\s+\{`. The regex now allows an optional `json.` prefix: `^(?:json\.)?\(\s*\)\s+\{`.

## why

libModSecurity3/Coraza prefix `ARGS_NAMES` with `json.` for parameters extracted from a JSON request body, so `ARGS_NAMES` for a JSON key like `() { :; }` becomes `json.() { :; }`. The `^` anchor in 932171 never matched that prefixed name, meaning the rule missed Shellshock payloads submitted as JSON body keys on those engines. Sibling RCE rules in the same file (932250, 932260, 932236, etc.) already handle this exact case via an optional `(?:json\.)?` prefix; 932171 was the one rule in the family that hadn't been updated. `crs-linter` flags this class of issue.

## refs

- consistent with existing fixes for 934170, 943110, 943120, 942220, 942550, 932250, etc.

## ai disclosure

- **tools used**: Claude (Sonnet 5)
- **assisted with**: identifying that the crs-linter warning on rule 932171 was a genuine gap (not a false positive) by cross-referencing sibling RCE rules that already handle the `json.` ARGS_NAMES prefix; authoring `regex-assembly/932171.ra`; regenerating the rule regex via `crs-toolchain`; writing the new go-ftw regression test case; drafting this PR description
- **review performed**: ran `crs-linter` against the full rule set and confirmed the 932171 finding is gone with zero new errors; ran the full `REQUEST-932-APPLICATION-ATTACK-RCE` go-ftw suite (935 tests) against both `modsec2-apache` and `modsec3-nginx`, confirming all pass; manually reverted the fix and re-ran the new test against `modsec3-nginx` to confirm it fails without the change (proving the bug is real and the test catches it), then restored the fix and re-confirmed all tests pass