### PR TITLE
fix(942190): require operator or quote after '!' to cut natural-language FPs

### DIFF
--- a/regex-assembly/942190.ra
+++ b/regex-assembly/942190.ra
@@ -8,7 +8,7 @@
 ##!> assemble
   {{quotes}}
   ##!=>
-  \s*!\s*[\"'`\w]
+  \s*!\s*(?:[<=>]|{{quotes}})
   ##!> assemble
     ;?\s*
     ##!=>

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -203,7 +203,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/*|XML://@* "@
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 942190
 #
-SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/*|XML://@* "@rx (?i)[\"'`](?:[\s\x0b]*![\s\x0b]*[\"'0-9A-Z_-z]|;?[\s\x0b]*(?:having|select|union\b[\s\x0b]*(?:all|(?:distin|sele)ct))\b[\s\x0b]*[^\s\x0b])|\b(?:(?:(?:c(?:onnection_id|urrent_user)|database|schema|user)[\s\x0b]*?|select.*?[0-9A-Z_a-z]?user)\(|exec(?:ute)?[\s\x0b]+master\.|from[^0-9A-Z_a-z]+information_schema[^0-9A-Z_a-z]|into[\s\x0b\+]+(?:dump|out)file[\s\x0b]*?[\"'`]|union(?:[\s\x0b]select[\s\x0b]@|[\s\x0b\(0-9A-Z_a-z]*?select))|[\s\x0b]*?exec(?:ute)?.*?[^0-9A-Z_a-z]xp_cmdshell|[^0-9A-Z_a-z]iif[\s\x0b]*?\(" \
+SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/*|XML://@* "@rx (?i)[\"'`](?:[\s\x0b]*![\s\x0b]*[\"'<->`]|;?[\s\x0b]*(?:having|select|union\b[\s\x0b]*(?:all|(?:distin|sele)ct))\b[\s\x0b]*[^\s\x0b])|\b(?:(?:(?:c(?:onnection_id|urrent_user)|database|schema|user)[\s\x0b]*?|select.*?[0-9A-Z_a-z]?user)\(|exec(?:ute)?[\s\x0b]+master\.|from[^0-9A-Z_a-z]+information_schema[^0-9A-Z_a-z]|into[\s\x0b\+]+(?:dump|out)file[\s\x0b]*?[\"'`]|union(?:[\s\x0b]select[\s\x0b]@|[\s\x0b\(0-9A-Z_a-z]*?select))|[\s\x0b]*?exec(?:ute)?.*?[^0-9A-Z_a-z]xp_cmdshell|[^0-9A-Z_a-z]iif[\s\x0b]*?\(" \
     "id:942190,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942190.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942190.yaml
@@ -346,7 +346,10 @@ tests:
           log:
             expect_ids: [942190]
   - test_id: 21
-    desc: "MSSQL Code Execution and Information gathering attempts"
+    desc: |
+      Quote followed by '!' and a bare letter is not a reliable SQLi signal
+      on its own (formerly a known FP, see #4289); only '!=', '!<', '!>' or
+      a closing quote after '!' are matched now.
     stages:
       - input:
           dest_addr: 127.0.0.1
@@ -361,7 +364,7 @@ tests:
           version: HTTP/1.1
         output:
           log:
-            expect_ids: [942190]
+            no_expect_ids: [942190]
   - test_id: 22
     desc: "MSSQL Code Execution and Information gathering attempts"
     stages:
@@ -567,7 +570,10 @@ tests:
           log:
             expect_ids: [942190]
   - test_id: 34
-    desc: "MSSQL Code Execution and Information gathering attempts"
+    desc: |
+      Quote followed by '!' and a bare digit is not a reliable SQLi signal
+      on its own (formerly a known FP, see #4289); only '!=', '!<', '!>' or
+      a closing quote after '!' are matched now.
     stages:
       - input:
           dest_addr: 127.0.0.1
@@ -582,7 +588,7 @@ tests:
           version: HTTP/1.1
         output:
           log:
-            expect_ids: [942190]
+            no_expect_ids: [942190]
   - test_id: 35
     desc: "MSSQL Code Execution and Information gathering attempts"
     stages:
@@ -801,6 +807,45 @@ tests:
           uri: '/post'
           data: '<?xml version="1.0"?><root><a probe=" exec xp_cmdshell"></a></root>'
           version: 'HTTP/1.1'
+        output:
+          log:
+            expect_ids: [942190]
+  - test_id: 48
+    desc: |
+      False positive: quoted German text ending in '!' followed by a new
+      capitalized sentence must not match.
+      decoded payload: "Quote"! Next sentence
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "searchValue=%22Quote%22%21%20Next%20sentence"
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids: [942190]
+  - test_id: 49
+    desc: |
+      Quote followed directly by the '!=' operator must still match.
+      decoded payload: 'x'!='y
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "q=%27x%27%21%3D%27y"
+          version: HTTP/1.1
         output:
           log:
             expect_ids: [942190]


### PR DESCRIPTION
## what

- narrow the `'!'` branch of rule 942190 so it only matches a quote followed by `!` followed by an actual comparison operator (`=`, `<`, `>` — MSSQL's `!=`/`!<`/`!>`) or a closing quote (the `\"!\"` break-out idiom), instead of any letter, digit, or quote
- flip tests 21 (`"! Y`) and 34 (`` `!1 ``) from `expect_ids` to `no_expect_ids` — these were bare-letter/bare-digit combinatorial coverage from the 2017 disassembly of this rule, not distinct real-world payloads
- add test 48 covering the exact reported false positive
- add test 49 confirming `!=` after a quote is still detected

## why

the character class after `!` (`[\"'0-9A-Z_-z]`) never actually required an operator — it accepted any letter, digit, or quote. that meant ordinary punctuation (a quote, an exclamation mark, then a capitalized new sentence) matched, which is common in German and other languages, e.g. `"Quote"! Next sentence`.

### verification

- `go-ftw run` 942190: 49/49 tests pass
- reverted the fix locally and re-ran: confirmed test 21/34/48 fail without it, confirming they exercise the change
- `go-ftw run` full `REQUEST-942-APPLICATION-ATTACK-SQLI` suite: no other regressions
- `crs-linter` 1.0.0: exit 0
- `go-ftw quantitative -L deu -s 100K -r 942190` and `-L eng -s 100K -r 942190`: same false-positive count before/after (6, from the unrelated quote+having/select/union collision tracked in #4342) — confirms this change doesn't interact with that separate issue

## refs

- fixes #4289

## ai disclosure

- **tools used**: Claude (Sonnet 5)
- **assisted with**: reproducing the reported false positive against current main, diagnosing the exact character-class defect in `regex-assembly/942190.ra`, designing and implementing the narrowed pattern, regenerating the rule via `crs-toolchain`, updating/adding regression tests, running quantitative corpus checks, drafting this PR description
- **review performed**: reproduced the FP with curl against a local docker/ModSecurity test stack before and after the change; ran the full `942190` and `REQUEST-942-APPLICATION-ATTACK-SQLI` go-ftw suites; reverted the fix locally to confirm the new/changed tests actually fail without it; ran `crs-linter`; ran `go-ftw quantitative` against English and German 100K corpora and compared false-positive counts before/after to confirm no unrelated regression