### PR TITLE
feat(921260): detect malformed Origin: * request header

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -363,6 +363,42 @@ SecRule REQUEST_COOKIES:/\x22?\x24Version/ "@streq 1" \
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 
+# Malformed Origin Request Header
+#
+# The 'Origin' header is forbidden/protected: browsers compute and set it
+# themselves and never send a literal wildcard. A request Origin of '*' can
+# only come from a non-browser client (a script, cURL, or automated tooling
+# probing the server's origin-reflection logic), so this is not a signal
+# that requires tuning around legitimate browser traffic.
+#
+# Note: this does not detect or block a working CORS bypass. The actual
+# "null origin" CORS vulnerability is a server-side response misconfiguration
+# (Access-Control-Allow-Origin: null + Access-Control-Allow-Credentials: true)
+# triggered from a victim's own browser (e.g. via a sandboxed iframe), which
+# is indistinguishable at the request level from many legitimate causes
+# (sandboxed iframes, data:/file: origins, Referrer-Policy: no-referrer
+# navigations, etc.) and is out of scope for a WAF to detect reliably.
+#
+SecRule REQUEST_HEADERS:Origin "@streq *" \
+    "id:921260,\
+    phase:1,\
+    block,\
+    t:none,t:trim,\
+    msg:'Malformed Origin Request Header',\
+    logdata:'Matched Data: Header %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
+    tag:'application-multi',\
+    tag:'language-multi',\
+    tag:'platform-multi',\
+    tag:'attack-protocol',\
+    tag:'paranoia-level/1',\
+    tag:'OWASP_CRS',\
+    tag:'OWASP_CRS/PROTOCOL-ATTACK',\
+    tag:'capec/1000/210/272/220',\
+    ver:'OWASP_CRS/4.29.0-dev',\
+    severity:'CRITICAL',\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:921013,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.29.0-dev',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "id:921014,phase:2,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.29.0-dev',skipAfter:END-REQUEST-921-PROTOCOL-ATTACK"
 #

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921260.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921260.yaml
@@ -1,0 +1,73 @@
+---
+meta:
+  author: "Felipe Zipitria"
+  description: "Malformed Origin Request Header"
+rule_id: 921260
+tests:
+  - test_id: 1
+    desc: "Origin: * is never sent by a real browser, forbidden at PL1 by default"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          headers:
+            Host: "localhost"
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Origin: "*"
+          port: 80
+          uri: "/"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [921260]
+  - test_id: 2
+    desc: "Origin: * with surrounding whitespace must still match"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          headers:
+            Host: "localhost"
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Origin: "  *  "
+          port: 80
+          uri: "/"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [921260]
+  - test_id: 3
+    desc: "Legitimate Origin header must not match"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          headers:
+            Host: "localhost"
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Origin: "https://example.com"
+          port: 80
+          uri: "/"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [921260]
+  - test_id: 4
+    desc: |
+      Origin: null must not match (out of scope, see coreruleset/coreruleset#4564:
+      the null-origin CORS issue is a server-side response misconfiguration,
+      not something a WAF can reliably distinguish from legitimate traffic)
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          headers:
+            Host: "localhost"
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Origin: "null"
+          port: 80
+          uri: "/"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [921260]


### PR DESCRIPTION
## what

- add rule 921260: detects a request `Origin` header value of literal `*`, at PL1
- `Origin: null` is intentionally not covered by this PR (see why below)

## why

`Origin` is a forbidden/protected header — browsers compute and set it themselves, and no browser ever sends a literal wildcard. So a request `Origin: *` can only come from a non-browser client (a script, cURL, or automated tooling probing a server's CORS origin-reflection logic). That makes it an essentially FP-free signal, appropriate for PL1.

The rule's `msg` and a comment above it are deliberately explicit that this does **not** detect or block a working CORS bypass — it fingerprints non-browser traffic. The actual "null origin" CORS vulnerability referenced in the originating issue is a server-side response misconfiguration (`Access-Control-Allow-Origin: null` + `Access-Control-Allow-Credentials: true`), triggered from a victim's own browser via mechanisms (sandboxed iframes, `data:`/`file:` origins, `Referrer-Policy: no-referrer` navigations, etc.) that are indistinguishable at the request level from ordinary legitimate traffic. A WAF can't tell "attacker's PoC" from "a real user on a known app" — Nextcloud is a confirmed example of legitimate `Origin: null` traffic. Blocking on that basis wouldn't fix the underlying issue either, since the bug lives in the app's own CORS response logic. Full reasoning posted on the issue: https://github.com/coreruleset/coreruleset/issues/4564#issuecomment-4953891279

## refs

- fixes #4564 (partially — the `Origin: *` half only, by agreement in the issue thread)

## ai disclosure

- **tools used**: Claude (Sonnet 5)
- **assisted with**: researching the CORS references cited in the issue to assess real-world severity/prevalence of both signals, drafting the issue comment explaining why `Origin: null` was dropped, implementing rule 921260, placing it correctly within the file's paranoia-level ordering, writing regression tests, drafting this PR description
- **review performed**: verified the rule's correct placement relative to the file's PL-gating `skipAfter` structure (a rule placed after the PL2 skip guard would never fire at PL1 — `crs-linter` caught this and I moved the rule), ran the full `REQUEST-921-PROTOCOL-ATTACK` go-ftw suite (121/121 pass) including new tests for `Origin: *`, whitespace-padded `*`, a legitimate origin, and `Origin: null` (confirming it does NOT trigger this rule), ran `crs-linter` (exit 0)