### PR TITLE
fix: add t:urlDecodeUni to rules 921151 and 932190 (#3919)

### DIFF
--- a/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+++ b/rules/REQUEST-921-PROTOCOL-ATTACK.conf
@@ -381,7 +381,7 @@ SecRule ARGS_GET "@rx [\n\r]" \
     phase:1,\
     block,\
     capture,\
-    t:none,\
+    t:none,t:urlDecodeUni,\
     msg:'HTTP Header Injection Attack via payload (CR/LF detected)',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -2084,7 +2084,7 @@ SecRule ARGS "@rx (?i)/(?:[\*\?]+[/-9A-Z_a-z]|[/-9A-Z_a-z]+[\*\?])" \
     phase:2,\
     block,\
     capture,\
-    t:none,t:normalizePath,t:cmdLine,\
+    t:none,t:urlDecodeUni,t:normalizePath,t:cmdLine,\
     msg:'Remote Command Execution: Wildcard bypass technique attempt',\
     logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}',\
     tag:'application-multi',\

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921151.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921151.yaml
@@ -65,3 +65,36 @@ tests:
         output:
           log:
             no_expect_ids: [921151]
+  - test_id: 5
+    desc: "IIS unicode CRLF injection (%u000d)"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          method: "GET"
+          port: 80
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: "localhost"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          uri: "/get?941151-5=test%u000dnext=more"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [921151]
+  - test_id: 6
+    desc: "Legitimate unicode text in %u format"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          method: "GET"
+          port: 80
+          headers:
+            User-Agent: "OWASP CRS test agent"
+            Host: "localhost"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          uri: "/get?941151-6=test%u041f%u0440%u0438%u0432%u0435%u0442"
+          version: "HTTP/1.1"
+        output:
+          log:
+            no_expect_ids: [921151]
+

--- a/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921151.yaml
+++ b/tests/regression/tests/REQUEST-921-PROTOCOL-ATTACK/921151.yaml
@@ -97,4 +97,3 @@ tests:
         output:
           log:
             no_expect_ids: [921151]
-

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932190.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932190.yaml
@@ -174,4 +174,3 @@ tests:
         output:
           log:
             no_expect_ids: [932190]
-

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932190.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932190.yaml
@@ -142,3 +142,36 @@ tests:
         output:
           log:
             expect_ids: [932190]
+  - test_id: 9
+    desc: "IIS unicode wildcard RCE bypass (%u002f%u003f%u003f%u003f%u002f%u003fs)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/get?vuln=%u002f%u003f%u003f%u003f%u002f%u003fs"
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [932190]
+  - test_id: 10
+    desc: "Legitimate unicode text in %u format"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/get?vuln=test%u0442%u0435%u0441%u0442"
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids: [932190]
+


### PR DESCRIPTION
Fixes #3919

Note on scope: Issue #3919 originally listed 5 rules (921151, 932190, 
942441, 942442, 942460). Rules 942441 and 942442 were removed in PR #4346 
("feat(942440): reduce false positive"), which refactored 942440 to 
natively handle the cases (gclid/fbclid/JWT tokens) those two exclusion 
rules existed to work around. This PR addresses the remaining three rules 
from the original issue: 921151, 932190, 942460.

Related: #3741 (background/context referenced in original issue)
Related: #3793 (Cyrillic false-positive precedent — informed added test 
coverage for 942460's non-Latin Unicode handling)
Related: #4346 (removed 942441/942442, explaining reduced scope of this PR)

## AI Disclosure

**Tools used:** Claude

**What was AI-assisted:**
- Research and analysis of the urlDecodeUni/double-decode tradeoff for rules 921151, 932190, 942460
- Drafting of regex/test approach options
- Drafting of some PR review responses

**What I personally verified:**
- Confirmed rule IDs/line numbers match the diff.

**Not yet verified — in progress:**
- crs-linter and full regression suite run
- Manual test of the new pattern against %u-encoded and benign payloads

I'll update this section once complete before requesting re-review.