### PR TITLE
feat: add Coraza/Caddy service to test docker-compose

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -49,7 +49,7 @@ x-coraza-env: &coraza-env
   CORAZA_AUDIT_LOG_TYPE: Serial
   # Default only logs 4xx/5xx responses; in DetectionOnly mode the response
   # is always 200, so without this the audit log would stay empty.
-  CORAZA_AUDIT_LOG_RELEVANT_STATUS: ".*"
+  CORAZA_AUDIT_LOG_RELEVANT_STATUS: ".+"
   CORAZA_RESP_BODY_ACCESS: "On"
   CORAZA_RESP_BODY_MIMETYPE: "text/plain text/html text/xml application/json"
   CORAZA_RULE_ENGINE: DetectionOnly

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -128,9 +128,6 @@ services:
       - ../rules:/opt/coraza/owasp-crs/rules:ro
       - ../plugins:/opt/coraza/owasp-crs/plugins:ro
       - ../crs-setup.conf.example:/opt/coraza/config/crs-setup.conf.example:ro
-    # activate-rules.sh runs `sed -i` on crs-setup.conf to apply the env vars
-    # above, which can't rename-over a bind-mounted file - copy it into place
-    # as a regular file first, same as the modsec targets' entrypoint override.
     entrypoint: ["/bin/sh", "-c", "cp /opt/coraza/config/crs-setup.conf.example /opt/coraza/config/crs-setup.conf && exec /entrypoint.sh caddy run --config /etc/caddy/Caddyfile --adapter caddyfile"]
     ports:
       - "80:8080"

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -32,6 +32,30 @@ x-nginx-env: &nginx-env
   MODSEC_AUDIT_LOG: "/var/log/nginx/modsec_audit.log"
   SERVERNAME: modsec3-nginx
 
+# Coraza uses its own CORAZA_-prefixed env vars instead of MODSEC_-prefixed
+# ones; see https://github.com/coreruleset/coraza-crs-docker#env-variables.
+# ARG_LENGTH/TOTAL_ARG_LENGTH/COMBINED_FILE_SIZES/MAX_FILE_SIZE/
+# CRS_ENABLE_TEST_MARKER/BACKEND/PORT are consumed by crs-setup.conf.example
+# itself, so they're shared with the ModSecurity targets above unchanged.
+x-coraza-env: &coraza-env
+  ARG_LENGTH: 400
+  TOTAL_ARG_LENGTH: 6400
+  BACKEND: "backend:80"
+  BLOCKING_PARANOIA: 4
+  COMBINED_FILE_SIZES: "65535"
+  CRS_ENABLE_TEST_MARKER: 1
+  MAX_FILE_SIZE: "64100"
+  CORAZA_AUDIT_LOG_FORMAT: JSON
+  CORAZA_AUDIT_LOG_TYPE: Serial
+  # Default only logs 4xx/5xx responses; in DetectionOnly mode the response
+  # is always 200, so without this the audit log would stay empty.
+  CORAZA_AUDIT_LOG_RELEVANT_STATUS: ".*"
+  CORAZA_RESP_BODY_ACCESS: "On"
+  CORAZA_RESP_BODY_MIMETYPE: "text/plain text/html text/xml application/json"
+  CORAZA_RULE_ENGINE: DetectionOnly
+  CORAZA_TMP_DIR: "/tmp/coraza"
+  PORT: "8080"
+
 services:
   modsec2-apache: &apache
     container_name: modsec2-apache
@@ -92,6 +116,35 @@ services:
       <<: *nginx-env
       MODSEC_DEBUG_LOG: "/var/log/nginx/modsec_debug.log"
       MODSEC_DEBUG_LOGLEVEL: 9
+
+  coraza-caddy: &coraza
+    container_name: coraza-caddy
+    image: ghcr.io/coreruleset/coraza-crs:caddy-alpine@sha256:d607eb5ebe110dceb88367ab4d0366536ba84b881d26d6772005ba3db1cbe163
+    environment:
+      <<: *coraza-env
+      CORAZA_AUDIT_LOG: "/var/log/coraza/audit.log"
+    volumes:
+      - ./logs/coraza-caddy:/var/log/coraza:rw
+      - ../rules:/opt/coraza/owasp-crs/rules:ro
+      - ../plugins:/opt/coraza/owasp-crs/plugins:ro
+      - ../crs-setup.conf.example:/opt/coraza/config/crs-setup.conf.example:ro
+    # activate-rules.sh runs `sed -i` on crs-setup.conf to apply the env vars
+    # above, which can't rename-over a bind-mounted file - copy it into place
+    # as a regular file first, same as the modsec targets' entrypoint override.
+    entrypoint: ["/bin/sh", "-c", "cp /opt/coraza/config/crs-setup.conf.example /opt/coraza/config/crs-setup.conf && exec /entrypoint.sh caddy run --config /etc/caddy/Caddyfile --adapter caddyfile"]
+    ports:
+      - "80:8080"
+    depends_on:
+      - backend
+
+  coraza-caddy-debug:
+    <<: *coraza
+    container_name: coraza-caddy-debug
+    environment:
+      <<: *coraza-env
+      CORAZA_AUDIT_LOG: "/var/log/coraza/audit.log"
+      CORAZA_DEBUG_LOG: "/var/log/coraza/debug.log"
+      CORAZA_DEBUG_LOGLEVEL: 9
 
   backend:
     image: ghcr.io/coreruleset/albedo:0.3.0@sha256:843ed01d28f48b594dcc0278ea9403175a0bf40ec065432040b796f589e89507


### PR DESCRIPTION
## what

adds `coraza-caddy` and `coraza-caddy-debug` services to `tests/docker-compose.yml`, alongside the existing ModSecurity Apache/nginx targets, using the `CORAZA_`-prefixed env vars documented in [coraza-crs-docker](https://github.com/coreruleset/coraza-crs-docker#env-variables).

## why

the test compose file only covered ModSecurity engines (Apache, nginx). adding a Coraza/Caddy target lets the test suite also run against Coraza.

## refs

- https://github.com/coreruleset/coraza-crs-docker

## ai disclosure

- **tools used**: Claude (Sonnet 5)
- **assisted with**: drafting the `coraza-caddy`/`coraza-caddy-debug` service definitions and shared `x-coraza-env` anchor in `tests/docker-compose.yml`, PR description drafting
- **review performed**: manually reviewed the compose diff for correctness against the coraza-crs-docker env variable reference and the existing ModSecurity service definitions in the same file