### PR TITLE
fix(942390): remove bypassable length bound on quoted/unary literals

### DIFF
--- a/regex-assembly/942390.ra
+++ b/regex-assembly/942390.ra
@@ -19,7 +19,7 @@
 ##! xor 'b' <
 ##! xor 'b' >
 ##! xor 'b' =
-##! '   or    chars_less_than_20+
+##! '   or    chars+
 
 ##!> define x_or \bx?or\b
 ##!> define quotes ['"]
@@ -27,9 +27,16 @@
 ##!> define optional_spaces \s*
 ##!> define comparison_operators [><=]
 ##!> define unary_operators [+\-!<>=]
+##! digits is intentionally left bounded: the branch that uses it bare (no
+##! required trailing anchor) already matches on any 1-10-digit prefix
+##! regardless of what follows, so the bound can never cause a false negative
+##! there. not_equal and different_than_unary_operators are unbounded because
+##! their branches DO require a specific character (a closing quote, or a
+##! unary operator) immediately after the run - a length cap on those let an
+##! attacker bypass detection just by padding the literal past the cap.
 ##!> define digits \d{1,10}
-##!> define not_equal [^=]{1,10}
-##!> define different_than_unary_operators [^+\-!<=>]{1,20}
+##!> define not_equal [^=]+
+##!> define different_than_unary_operators [^+\-!<=>]+
 
 ##! The pattern below that matches 'or/xor' followed by digits without requiring a comparison operator is very prone to false positives.
 {{x_or}}{{spaces}}{{digits}}

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1153,7 +1153,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/*|XML://@* "@
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 942390
 #
-SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/*|XML://@* "@rx (?i)\bx?or\b(?:[\s\x0b]+[0-9]{1,10}(?:[\s\x0b]*[<->])?|[\s\x0b]*[\"'][^=]{1,10}[\"'])|[\"'][\s\x0b]+\bx?or\b[\s\x0b]+[^!\+\-<->]{1,20}[!\+\-<->]" \
+SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/*|XML://@* "@rx (?i)\bx?or\b(?:[\s\x0b]+[0-9]{1,10}(?:[\s\x0b]*[<->])?|[\s\x0b]*[\"'][^=]+[\"'])|[\"'][\s\x0b]+\bx?or\b[\s\x0b]+[^!\+\-<->]+[!\+\-<->]" \
     "id:942390,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942390.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942390.yaml
@@ -453,3 +453,37 @@ tests:
         output:
           log:
             expect_ids: [942390]
+  - test_id: 30
+    desc: "Positive test: quoted literal longer than 10 chars must still be caught (or 'aaaaaaaaaaaaaaaaaaaa' <)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: "*/*"
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "foo=%27%20or%20%27aaaaaaaaaaaaaaaaaaaa%27%20%3C"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [942390]
+  - test_id: 31
+    desc: "Positive test: unquoted literal longer than 20 chars before a unary operator must still be caught"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: "*/*"
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "foo=%27%20or%20aaaaaaaaaaaaaaaaaaaaaaaaa%3C"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [942390]


### PR DESCRIPTION
## what

removes the `{1,10}`/`{1,20}` length caps on the `not_equal` and `different_than_unary_operators` branches in `regex-assembly/942390.ra`, replacing them with unbounded `+` quantifiers. the `digits` branch keeps its `{1,10}` cap.

## why

both fixed branches require a specific terminator character (a closing quote, or a unary operator) immediately after the capped run. a literal longer than the cap can never reach that terminator within the allowed repetitions, so padding the payload past the cap bypassed detection entirely.

confirmed empirically against `modsec2-apache` on `main`:
- `' or 'aaaaaaaaaa' <` (10-char literal) → 942390 fires
- `' or 'aaaaaaaaaaaaaaaaaaaa' <` (same shape, 20-char literal) → no match

the `digits` branch is left unchanged: it has no required trailing anchor, so it already matches on any 1-10-digit prefix regardless of what follows, and the cap was never a bypass vector there — confirmed with an 11-digit payload (`or 12345678901 <2`), which still matched on current `main`.

both changed branches use the standard negated-character-class-plus-disjoint-terminator idiom already used elsewhere in CRS (the excluded characters in the class never overlap with the required terminator), so removing the cap does not introduce backtracking ambiguity. verified with a 50KB adversarial payload under PL4 — response time was flat (~4.2-4.4s) whether or not the unbounded branch was exercised, consistent with linear rather than exponential behavior.

## refs

- #3902

## ai disclosure

- **tools used**: Claude (Sonnet 5)
- **assisted with**: diagnosing the length-bound bypass in `regex-assembly/942390.ra`, drafting the regex-assembly fix, writing the two new regression tests, PR description drafting
- **review performed**: reproduced the bypass against `modsec2-apache` on `main` before the fix; reverted the fix in the working tree and confirmed the two new regression tests fail without it, then reinstated the fix and confirmed all 31 tests pass; ran the full `REQUEST-942-APPLICATION-ATTACK-SQLI` suite (1030 tests, all passing); ran `go-ftw quantitative -L eng -y 2023 -s 100K -r 942390` with zero false positives; ran the CI-pinned `crs-linter` (1.0.0) with zero errors; manually tested a 50KB adversarial payload to confirm flat response time (no catastrophic backtracking)