### PR TITLE
feat: Add wp2shell exploitation detection

### DIFF
--- a/rules/restricted-files.data
+++ b/rules/restricted-files.data
@@ -763,3 +763,5 @@ login.sql
 # IBM Cloud Cli config
 .bluemix/
 .ibmcloud/
+# path used in wp2shell poc
+/wp-json/batch/v1


### PR DESCRIPTION
# What?
Add wp2shell exploitation detection, an RCE in wordpresss

# Why?
Because a very critical alarming vuln, that can lead to instant RCE in unpatched sites, there was no waf detection for that

# References
- https://slcyber.io/research-center/wp2shell-pre-authentication-rce-in-wordpress-core/ 
 
# Further Questions?
i not added /batch/v1 because of false positives, what do you think @EsadCetiner about that?
