### PR TITLE
fix(942390): backport bypassable length bound fix to lts/v4.25.x

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,11 @@
   or the CRS Google Group at
 * https://groups.google.com/a/owasp.org/g/modsecurity-core-rule-set-project
 
+### v4.25.2 - YYYY-MM-DD
+
+#### Security Fixes
+- Backport fix removing a bypassable length bound in the SQL `(X)OR` injection detection (rule 942390) (Felipe Zipitría, cherry-pick of #4713)
+
 ### v4.25.1 - 2026-07-01
 
 #### Breaking Changes

--- a/regex-assembly/942390.ra
+++ b/regex-assembly/942390.ra
@@ -3,15 +3,23 @@
 
 ##!+ i
 
+##! not_equal ([^=]{1,10} -> [^=]+) and the dot-run before a unary operator
+##! (.{1,20} -> .+) are intentionally unbounded: both are followed by a
+##! required terminator (a closing quote, or a unary operator), so a length
+##! cap there let an attacker bypass detection just by padding the literal
+##! past the cap. The bare \d{1,10} lines are left bounded: they have no
+##! required trailing anchor, so they already match on any 1-10-digit prefix
+##! regardless of what follows, and the cap was never a bypass vector there.
+
 \bor\b\s?\d{1,10}\s?[=<>]+
-\bor\b\s?[\'\"][^=]{1,10}[\'\"]\s?[=<>]+
-'\s+or\s+.{1,20}[+\-!<>=]
-'\s+xor\s+.{1,20}[+\-!<>=]
+\bor\b\s?[\'\"][^=]+[\'\"]\s?[=<>]+
+'\s+or\s+.+[+\-!<>=]
+'\s+xor\s+.+[+\-!<>=]
 \bor\b\s+\d{1,10}
-\bor\b\s+'[^=]{1,10}'
+\bor\b\s+'[^=]+'
 \bxor\b\s+\d{1,10}
-\bxor\b\s+'[^=]{1,10}'
+\bxor\b\s+'[^=]+'
 \bor\b\s+\d{1,10}\s*?[=<>]
 \bxor\b\s+\d{1,10}\s*?[=<>]
-\bor\b\s+'[^=]{1,10}'\s*?[=<>]
-\bxor\b\s+'[^=]{1,10}'\s*?[=<>]
+\bor\b\s+'[^=]+'\s*?[=<>]
+\bxor\b\s+'[^=]+'\s*?[=<>]

--- a/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+++ b/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
@@ -1153,7 +1153,7 @@ SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/*|XML://@* "@
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 942390
 #
-SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/*|XML://@* "@rx (?i)\b(?:or\b(?:[\s\x0b]?(?:[0-9]{1,10}|[\"'][^=]{1,10}[\"'])[\s\x0b]?[<->]+|[\s\x0b]+(?:[0-9]{1,10}|'[^=]{1,10}')(?:[\s\x0b]*?[<->])?)|xor\b[\s\x0b]+(?:[0-9]{1,10}|'[^=]{1,10}')(?:[\s\x0b]*?[<->])?)|'[\s\x0b]+x?or[\s\x0b]+.{1,20}[!\+\-<->]" \
+SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/*|XML://@* "@rx (?i)\b(?:or\b(?:[\s\x0b]?(?:[0-9]{1,10}|[\"'][^=]+[\"'])[\s\x0b]?[<->]+|[\s\x0b]+(?:[0-9]{1,10}|'[^=]+')(?:[\s\x0b]*?[<->])?)|xor\b[\s\x0b]+(?:[0-9]{1,10}|'[^=]+')(?:[\s\x0b]*?[<->])?)|'[\s\x0b]+x?or[\s\x0b]+.+[!\+\-<->]" \
     "id:942390,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942390.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942390.yaml
@@ -36,3 +36,37 @@ tests:
         output:
           log:
             expect_ids: [942390]
+  - test_id: 3
+    desc: "Positive test: quoted literal longer than 10 chars must still be caught (or 'aaaaaaaaaaaaaaaaaaaa' <)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: "*/*"
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "foo=%27%20or%20%27aaaaaaaaaaaaaaaaaaaa%27%20%3C"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [942390]
+  - test_id: 4
+    desc: "Positive test: unquoted literal longer than 20 chars before a unary operator must still be caught"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: "*/*"
+          method: POST
+          port: 80
+          uri: "/post"
+          data: "foo=%27%20or%20aaaaaaaaaaaaaaaaaaaaaaaaa%3C"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [942390]


### PR DESCRIPTION
## what

cherry-picks #4713 onto `lts/v4.25.x` (as `release/v4.25.2`): removes the bypassable `{1,10}`/`{1,20}` length bounds on the quoted-literal and unary-operator branches of rule 942390.

This branch predates #4011 (the `regex-assembly` `##!> define`/`##!> assemble` refactor for this rule), so the cherry-pick didn't apply cleanly — the same fix (remove the length cap on the two branches that require a terminator character immediately after the bounded run) was re-applied directly to this branch's flat, pre-refactor `regex-assembly/942390.ra` format instead of bringing in the unrelated format-migration PR. The `digits` bound is left untouched here too, for the same reason as the original PR: it has no required trailing anchor, so it was never a bypass vector.

The two new regression tests from #4713 also didn't append cleanly (this branch's `942390.yaml` only had 2 pre-existing tests vs. main's 29), so they were renumbered with `crs-toolchain util renumber-tests 942390` to continue the sequence without gaps.

Also adds the `CHANGES.md` entry for this release per step 4 of the [LTS point release procedure](https://github.com/coreruleset/coreruleset/wiki/LTS-Release-Procedure#lts-point-release-procedure-recurring) — date left as `YYYY-MM-DD` until the release is actually cut.

## why

`main` had a real detection bypass: a quoted SQLi literal (`' or '<literal>' <`) or an unquoted one before a unary operator evades 942390 entirely once the literal is longer than the arbitrary length cap, since the required closing quote/operator character can never be reached within the capped repetition count. Confirmed this branch has the identical bug in its own (differently-formatted) regex before backporting the fix.

## refs

- #4713
- #3902

## verification

- reproduced the bypass on this branch before the fix (reverted the fix in the working tree, confirmed the 2 new tests fail), reinstated it and confirmed all 4 tests in `942390.yaml` pass
- ran the full `REQUEST-942-APPLICATION-ATTACK-SQLI` regression suite (992 tests) — all passing
- ran the CI-pinned crs-linter (1.0.0) against both this branch's tip and the unmodified `lts/v4.25.x` baseline — identical error count (709, all pre-existing and unrelated to this change) and zero new `::error` lines

## ai disclosure

- **tools used**: Claude (Sonnet 5)
- **assisted with**: cherry-picking #4713 onto this branch, resolving the regex-assembly/compiled-regex conflicts caused by the pre-#4011 format divergence, re-deriving the equivalent fix against the older flat `.ra` format, renumbering the merged test file, drafting this PR description
- **review performed**: manually traced which of the old format's alternation branches were actually exploitable (vs. masked by an unrelated anchor-less alternative, same as in #4713) before editing; reverted-and-reconfirmed the new tests fail without the fix and pass with it; ran the full rule-family regression suite; ran the linter against both the baseline and the fixed branch and diffed the error sets line-by-line to confirm no new errors

