### PR TITLE
fix(932171): backport regex-assembly formalization to lts/v4.25.x

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,11 @@
   or the CRS Google Group at
 * https://groups.google.com/a/owasp.org/g/modsecurity-core-rule-set-project
 
+### v4.25.2 - YYYY-MM-DD
+
+#### Other Changes
+- Formalize rule 932171 (Shellshock, CVE-2014-6271) into a `regex-assembly` file and apply the standard `[\s\x0b]` whitespace-class normalization; the `json.` ARGS_NAMES prefix detection itself was already present on this branch via an untracked fix, so this is a maintainability/consistency change, not a functional fix (partial cherry-pick of #4703)
+
 ### v4.25.1 - 2026-07-01
 
 #### Breaking Changes

--- a/regex-assembly/932171.ra
+++ b/regex-assembly/932171.ra
@@ -1,0 +1,11 @@
+##! Please refer to the documentation at
+##! https://coreruleset.org/docs/development/regex_assembly/.
+
+##! Rule 932171: Remote Command Execution: Shellshock (CVE-2014-6271)
+##!
+##! Allow an optional 'json.' prefix so that libModSecurity3/Coraza's JSON
+##! body processor (which prepends 'json.' to ARGS_NAMES) is still matched.
+
+##!^ ^(?:json\.)?
+
+\(\s*\)\s+\{

--- a/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+++ b/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
@@ -755,7 +755,7 @@ SecRule REQUEST_HEADERS|REQUEST_LINE "@rx ^\(\s*\)\s+\{" \
     setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
-SecRule ARGS_NAMES|ARGS|FILES_NAMES "@rx ^(?:json\.)?\(\s*\)\s+\{" \
+SecRule ARGS_NAMES|ARGS|FILES_NAMES "@rx ^(?:json\.)?\([\s\x0b]*\)[\s\x0b]+\{" \
     "id:932171,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932171.yaml
+++ b/tests/regression/tests/REQUEST-932-APPLICATION-ATTACK-RCE/932171.yaml
@@ -38,3 +38,21 @@ tests:
         output:
           log:
             expect_ids: [932171]
+  - test_id: 3
+    desc: "Test for '() {' in JSON body key (ARGS_NAMES with 'json.' prefix)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Host: localhost
+            Content-Type: application/json
+            User-Agent: "OWASP CRS test agent"
+          method: POST
+          port: 80
+          uri: "/post"
+          data: '{ "() { :; }":"foo" }'
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [932171]


### PR DESCRIPTION
## what

Partial backport related to #4703 ("fix: allow optional json. prefix in rule 932171 ARGS_NAMES pattern"): formalizes rule 932171 into a `regex-assembly/932171.ra` file (previously hand-written inline) and applies the project's standard `[\s\x0b]` whitespace-class normalization.

## why

This is **not** a functional fix on this branch — the actual `json.` ARGS_NAMES prefix detection that #4703 restores on `main` was already present here. Backporting PR #4672 (4RI-250413) onto this branch earlier took the LTS side wholesale for this file and silently dropped that fix for hand-written inline rules (932171, 942361) — see commit `d9eda15e1` ("fix: restore dropped json. prefix fixes..."), which independently restored it as part of preparing v4.25.1, before #4703 re-fixed the same gap on `main` (where it had separately regressed via an unrelated fork-merge conflict resolution).

Traced this precisely before backporting anything: confirmed the exact regex on this branch already matches `^(?:json\.)?\(\s*\)\s+\{`, and confirmed via `git log -L` that `main`'s copy of this rule flip-flopped (added by #4672, reverted by an unrelated ReDoS-fix fork-merge, restored by #4703) while this branch never lost it. So the only real delta worth backporting is the `.ra` formalization and the `\s` → `[\s\x0b]` normalization.

Also checked rule 942361 (the other rule named in `d9eda15e1`) — identical and correct on both branches already, no action needed there.

## refs

- #4703
- d9eda15e1 (LTS-only fix this branch already has)

## verification

- ran the full `REQUEST-932-APPLICATION-ATTACK-RCE` regression suite (918 tests) — all passing
- ran the CI-pinned crs-linter (1.0.0) against both this branch and the unmodified `lts/v4.25.x` baseline — identical error count (709) and zero new `::error` lines
- confirmed the diff against `lts/v4.25.x` touches exactly one line in `rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf` (caught and reverted an earlier mistake where `git checkout --theirs` on the whole file would have wrongly overwritten 55 unrelated rules' `ver:` tags and pulled in a rule that doesn't exist on this branch)

## ai disclosure

- **tools used**: Claude (Sonnet 5)
- **assisted with**: tracing the cross-branch history of rule 932171's json. prefix fix across both `main` and `lts/v4.25.x` to determine this backport's actual scope, formalizing the `.ra` file, resolving the conflict surgically, drafting this PR description
- **review performed**: used `git log -L` (line-history tracking) to precisely trace every change to this rule's regex on `main`, confirming which commits added/removed the json. prefix and why; verified the target regex via `crs-toolchain regex compare` (read-only) rather than `regex update`, after catching that a naive `git checkout --theirs` on the whole file would have introduced 55 unrelated changes; ran the full rule-family regression suite and diffed linter error counts against baseline
