### PR TITLE
fix(ci): pass explicit --version to crs-linter on lts/v4.25.x

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -69,21 +69,44 @@ jobs:
       - name: "Check CRS formatting"
         env:
           HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref }}
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           pip install -U setuptools
           pip install crs-linter==${{ env.CRS_LINTER_VERSION }}
-          crs-linter \
-            --output=github \
-            -r crs-setup.conf.example \
-            -r 'rules/*.conf' \
-            -t util/APPROVED_TAGS \
-            -f util/FILENAME_EXCLUSIONS \
-            -T 'tests/regression/tests/' \
-            -E 'tests/TESTS_EXCLUSIONS' \
-            -d "$(pwd)" \
-            --head-ref "$HEAD_REF" \
-            --commit-message "$COMMIT_MESSAGE"
+          # crs-linter's own version auto-detection (commit message, then a
+          # `release/vX.Y.Z` branch-name pattern, then falling back to the
+          # latest reachable git tag bumped one minor) has no pattern for
+          # this branch or its backport branches, so it falls through to the
+          # tag-based fallback and resolves to main's current dev version
+          # instead of this LTS line's own. Pass the real, already-declared
+          # version explicitly to bypass that auto-detection entirely.
+          if [[ "$BASE_REF" == lts/* || "$GITHUB_REF_NAME" == lts/* ]]; then
+            EXPECTED_VERSION=$(grep -ohP "ver:'OWASP_CRS/\K[^']+" rules/*.conf | sort | uniq -c | sort -rn | head -1 | awk '{print $2}')
+            echo "On an LTS branch: passing explicit --version $EXPECTED_VERSION to crs-linter"
+            crs-linter \
+              --output=github \
+              -r crs-setup.conf.example \
+              -r 'rules/*.conf' \
+              -t util/APPROVED_TAGS \
+              -f util/FILENAME_EXCLUSIONS \
+              -T 'tests/regression/tests/' \
+              -E 'tests/TESTS_EXCLUSIONS' \
+              -d "$(pwd)" \
+              --version "$EXPECTED_VERSION"
+          else
+            crs-linter \
+              --output=github \
+              -r crs-setup.conf.example \
+              -r 'rules/*.conf' \
+              -t util/APPROVED_TAGS \
+              -f util/FILENAME_EXCLUSIONS \
+              -T 'tests/regression/tests/' \
+              -E 'tests/TESTS_EXCLUSIONS' \
+              -d "$(pwd)" \
+              --head-ref "$HEAD_REF" \
+              --commit-message "$COMMIT_MESSAGE"
+          fi
 
       - name: "Install crs-toolchain ${{ env.CRS_TOOLCHAIN_VERSION }}"
         env:


### PR DESCRIPTION
## what

The lint workflow's \"Check CRS formatting\" step now passes an explicit \`--version\` to \`crs-linter\` when running against this branch (detected via \`BASE_REF\`/\`GITHUB_REF_NAME\`), instead of letting the tool auto-detect it.

## why

\`crs-linter\`'s own version auto-detection (\`generate_version_string\` in its \`utils.py\`) checks, in order: the commit message, then a \`release/(v\d+\.\d+\.\d+)\` branch-name pattern, then falls back to the latest reachable git tag bumped one minor. Neither \`lts/v4.25.x\` nor its \`lts-backport/<PR#>\` branches match that pattern, so every PR against this branch falls through to the tag-based fallback — which resolves to \`main\`'s current dev version (e.g. \`4.29.0-dev\`) rather than this LTS line's own, producing a wall of unrelated \`ver:\` mismatch errors on every single PR. This has been true since the branch was forked (confirmed identical logic pre-existing here), which is exactly why \`CLAUDE.md\`'s LTS backport notes already say to compare error counts against baseline rather than expect zero — this fix removes the need for that workaround going forward.

The fix reads the version every real (non-comment, non-example) rule already declares — currently \`4.25.1\` — and passes it via \`--version\`, which \`crs-linter\` uses as-is, bypassing auto-detection entirely.

## refs

- observed while backporting #4713 and #4703's real fix to this branch (PRs #4729, #4728) — every lint run showed ~55 false \`ver\` mismatch errors unrelated to either change

## verification

- \`actionlint .github/workflows/lint.yaml\` — clean
- \`zizmor .github/workflows/lint.yaml\` — same single pre-existing finding as the unmodified baseline (missing \`persist-credentials: false\` on the checkout step, unrelated to this change), no new findings
- tested the conditional's bash logic locally against both an LTS-like context (\`BASE_REF=lts/v4.25.x\`) and a non-LTS context (\`BASE_REF=main\`), confirming each takes the correct branch
- this PR's own CI run against \`lts/v4.25.x\` is the live end-to-end test of the fix

## ai disclosure

- **tools used**: Claude (Sonnet 5)
- **assisted with**: tracing the root cause into \`crs-linter\`'s own source (a separate repo) to find exactly where version auto-detection falls back incorrectly, drafting the workflow fix, drafting this PR description
- **review performed**: read \`crs-linter\`'s \`generate_version_string\`/\`parse_version_from_branch_name\`/\`parse_version_from_latest_tag\` source directly rather than guessing at the bug; ran \`actionlint\` and \`zizmor\` and diffed \`zizmor\`'s findings against the unmodified baseline to confirm no new issues; manually tested the added bash conditional against both branches of its logic before pushing