### PR TITLE
fix: Replace in all with in all <b>, instead of commenting it

### DIFF
--- a/rules/php-errors.data
+++ b/rules/php-errors.data
@@ -1587,7 +1587,7 @@ with an empty name
 ::__toString() must return a string value
 ::getCurrentLine(): Return value must be of type string,
 ::offsetSet() instead
-# > in all
+> in all <b>
 > in attribute
 > in attributeGroup
 > in choice

--- a/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
+++ b/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
@@ -124,7 +124,6 @@ tests:
           log:
             no_expect_ids: [953100]
 
-
   - test_id: 7
     desc: "Detect '> in all <b>' true php error"
     stages:
@@ -141,7 +140,7 @@ tests:
           method: "POST"
           version: "HTTP/1.1"
           uri: "/sample-php-error"
-          data: "<b>Fatal error</b>: ... > in all'indirizzo <b>/var/www/index.php</b>"
+          data: "<b>Fatal error</b>: ... > in all <b>/var/www/index.php</b>"
         output:
           log:
             expect_ids: [953100]

--- a/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
+++ b/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
@@ -125,7 +125,7 @@ tests:
             no_expect_ids: [953100]
 
   - test_id: 7
-    desc: "Detect '> in all <b>' true php error"
+    desc: "Detect '> in all <b>' in error response"
     stages:
       - input:
           dest_addr: "127.0.0.1"
@@ -140,7 +140,7 @@ tests:
           method: "POST"
           version: "HTTP/1.1"
           uri: "/reflect"
-          data: "<b>Fatal error</b>: ... > in all <b>/var/www/index.php</b>"
+          data: "Error: Parser error > in all <b>myElement</b> at line 100"
         output:
           log:
             expect_ids: [953100]

--- a/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
+++ b/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "M4tteoP, Esad Cetiner, azurit"
+  author: "M4tteoP, Esad Cetiner, azurit, RelunSec"
 rule_id: 953100
 tests:
   - test_id: 1
@@ -123,3 +123,25 @@ tests:
         output:
           log:
             no_expect_ids: [953100]
+
+
+  - test_id: 7
+    desc: "Detect '> in all <b>' true php error"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          port: 80
+          headers:
+            Host: "localhost"
+            User-Agent: "OWASP CRS test agent"
+            Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+            Accept-Encoding: "gzip,deflate"
+            Accept-Language: "en-us,en;q=0.5"
+            Content-Type: "text/plain"
+          method: "POST"
+          version: "HTTP/1.1"
+          uri: "/sample-php-error"
+          data: "<b>Fatal error</b>: ... > in all'indirizzo <b>/var/www/index.php</b>"
+        output:
+          log:
+            expect_ids: [935100]

--- a/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
+++ b/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
@@ -139,7 +139,7 @@ tests:
             Content-Type: "text/plain"
           method: "POST"
           version: "HTTP/1.1"
-          uri: "/sample-php-error"
+          uri: "/reflect"
           data: "<b>Fatal error</b>: ... > in all <b>/var/www/index.php</b>"
         output:
           log:

--- a/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
+++ b/tests/regression/tests/RESPONSE-953-DATA-LEAKAGES-PHP/953100.yaml
@@ -144,4 +144,4 @@ tests:
           data: "<b>Fatal error</b>: ... > in all'indirizzo <b>/var/www/index.php</b>"
         output:
           log:
-            expect_ids: [935100]
+            expect_ids: [953100]


### PR DESCRIPTION
# What?
Remove the causing fp `< in all` and replace it with `< in all <b>` 

# Why?
The previous approach uncomment entirely `< in all` for fp reason, the pr restores the detection while not introducing the fp