### PR TITLE
chore(tests): adds Unicode best-fit guarding urlDecodeUni on 941100/942100

### DIFF
--- a/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941100.yaml
+++ b/tests/regression/tests/REQUEST-941-APPLICATION-ATTACK-XSS/941100.yaml
@@ -119,3 +119,35 @@ tests:
         output:
           log:
             expect_ids: [941100]
+  - test_id: 8
+    desc: 'Unicode best-fit %uXXXX XSS: U+00AB/U+00BB guillemets fold to angle brackets'
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            User-Agent: 'OWASP CRS test agent'
+            Host: localhost
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: GET
+          port: 80
+          uri: '/?id=%u00abscript%u00bballert(1)%u00ab/script%u00bb'
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [941100]
+  - test_id: 9
+    desc: 'Unicode best-fit %uXXXX XSS: U+2039/U+203A single guillemets fold to angle brackets'
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            User-Agent: 'OWASP CRS test agent'
+            Host: localhost
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: GET
+          port: 80
+          uri: '/?id=%u2039script%u203aalert(1)%u2039/script%u203a'
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [941100]

--- a/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942100.yaml
+++ b/tests/regression/tests/REQUEST-942-APPLICATION-ATTACK-SQLI/942100.yaml
@@ -259,3 +259,35 @@ tests:
         output:
           log:
             expect_ids: [942100]
+  - test_id: 16
+    desc: 'Unicode best-fit %uXXXX SQLi: curly apostrophe U+2019 folds to single quote'
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            User-Agent: 'OWASP CRS test agent'
+            Host: localhost
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: GET
+          port: 80
+          uri: '/?id=%u2019%20OR%201%3D1--%20-'
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [942100]
+  - test_id: 17
+    desc: "Unicode best-fit %uXXXX SQLi: ' or 'a'='a with every quote as U+2019"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            User-Agent: 'OWASP CRS test agent'
+            Host: localhost
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          method: GET
+          port: 80
+          uri: '/?id=%u2019%20or%20%u2019a%u2019%3d%u2019a'
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [942100]


### PR DESCRIPTION
Proposes to add tests for Unicode best-fit (%uXXXX) evasion of 941100/942100. CRS rules decode %uXXXX via t:urlDecodeUni, whose best-fit mapping is expected to fold codepoints like U+2019 (') and U+00AB/U+2039 (<) to ASCII.
No existing test exercises that fold. These tests guard the transformation chain against regression and pin the expected cross-engine behavior.

For full context see https://github.com/corazawaf/libinjection-go/issues/118, https://github.com/coreruleset/go-ftw/issues/392 and https://github.com/corazawaf/coraza/pull/1649.


- [x] Positive and negative tests were added (does not apply, it is just extending positives tests, negatives are already available)
- [x] Tests cover the intended fix/feature properly 
- [x] No usage of dangerous constructs like `ctl:requestBodyAccess=Off` were used in the rule (does not apply)
- [x] In case a regular expression was changed, [there is no ReDOS](https://github.com/coreruleset/coreruleset/wiki/Testing-for-Regular-Expresion-DoS) (does not apply)
- [x] Documentation is clear for the rule/change
- [x] If a contribution shows signs of unreviewed AI generation (e.g., plausible-but-broken regex, generic boilerplate comments, hallucinated SecLang directives), reviewers should ask about AI usage regardless of what was checked.
