### PR TITLE
chore: attest release artifacts with build provenance

### DIFF
--- a/.github/workflows/attest-release.yaml
+++ b/.github/workflows/attest-release.yaml
@@ -1,0 +1,57 @@
+name: Attest release artifacts
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  attestations: write
+  id-token: write
+
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Set version
+        id: version
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Download full source archives
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          gh release download "$TAG" -R "${{ github.repository }}" -A zip
+          gh release download "$TAG" -R "${{ github.repository }}" -A tar.gz
+
+      - name: Build minimal archives
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          tar zxf "coreruleset-${VERSION}.tar.gz"
+          rm -rf "coreruleset-${VERSION}"/{util,regex-assembly,tests} \
+            "coreruleset-${VERSION}/renovate.json" "coreruleset-${VERSION}"/.[a-z]*
+          mv "coreruleset-${VERSION}"/*.md "coreruleset-${VERSION}/docs"
+          tar czf "coreruleset-${VERSION}-minimal.tar.gz" "coreruleset-${VERSION}"
+          zip -r "coreruleset-${VERSION}-minimal.zip" "coreruleset-${VERSION}"
+
+      - name: Upload minimal archives to release
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh release upload "$TAG" -R "${{ github.repository }}" \
+            "coreruleset-${VERSION}-minimal.tar.gz" "coreruleset-${VERSION}-minimal.zip"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            coreruleset-${{ steps.version.outputs.version }}.zip
+            coreruleset-${{ steps.version.outputs.version }}.tar.gz
+            coreruleset-${{ steps.version.outputs.version }}-minimal.zip
+            coreruleset-${{ steps.version.outputs.version }}-minimal.tar.gz


### PR DESCRIPTION
## what

adds a workflow, triggered when a release is published, that:
- downloads the full source zip/tar.gz that github auto-attaches to the release
- rebuilds the `-minimal` zip/tar.gz variants (same strip recipe as the existing local signing script) and uploads them as release assets
- runs `actions/attest-build-provenance` against all four archives

## why

`gh attestation verify` currently 404s for every crs release artifact because no workflow generates build provenance attestations. gpg signing (via a local, maintainer-run script) stays as the primary integrity mechanism, but it depends on a manually-guarded private key and isn't independently checkable through `gh attestation verify`. this adds sigstore-based provenance as an additional, keyless verification path for anyone downloading a release asset.

the minimal archives have to be built and uploaded by this same workflow, not reproduced separately, because zip/tar archives embed filesystem metadata (mtimes, permissions) that differs between a local machine and a ci runner — attesting an independently rebuilt copy would not match the hash of the file actually downloaded from the release page.

the release-signing script (maintained outside this repo) will need a small update to download the ci-built `-minimal` assets instead of building them locally.

## refs

n/a

## ai disclosure

- **tools used**: claude (sonnet 5)
- **assisted with**: drafting the workflow yaml, identifying the byte-identity issue with independently rebuilding minimal archives, looking up the current `actions/attest-build-provenance` release/sha to pin, drafting this pr description
- **review performed**: ran `actionlint` and `zizmor` against the new workflow file (both clean); manually traced the existing `sign-crs-release.sh` script and github's release-asset naming to confirm the workflow's file-naming assumptions match; empirically confirmed via `gh attestation verify` that no attestations currently exist for crs releases (motivating issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release publications now automatically include minimal source archive variants alongside the full source archives.
  * Build provenance attestations are generated for all published source archives, helping verify their origin and integrity.
  * Re-running the release process updates existing archive assets instead of creating duplicate files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->