### PR TITLE
fix(956100): FP with keyword 'EOFError' inside RESPONSE_BODY

### DIFF
--- a/rules/ruby-errors.data
+++ b/rules/ruby-errors.data
@@ -86,7 +86,7 @@ Oj::GeneratorError
 
 #### Network & HTTP Client Errors
 SocketError
-EOFError
+#EOFError
 OpenSSL::SSL::SSLError
 Timeout::Error
 Net::ReadTimeout

--- a/tests/regression/tests/RESPONSE-956-DATA-LEAKAGES-RUBY/956100.yaml
+++ b/tests/regression/tests/RESPONSE-956-DATA-LEAKAGES-RUBY/956100.yaml
@@ -234,3 +234,23 @@ tests:
         output:
           log:
             no_expect_ids: [956100]
+  - test_id: 12
+    desc: "False Positive with keyword 'EOFError' inside JavaScript"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          port: 80
+          headers:
+            Host: "localhost"
+            User-Agent: "OWASP CRS test agent"
+            Accept: "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+            Accept-Encoding: "gzip,deflate"
+            Accept-Language: "en-us,en;q=0.5"
+            Content-Type: "text/html"
+          method: "POST"
+          version: "HTTP/1.1"
+          uri: "/reflect"
+          data: "ajaxRequest.useCallbackInCaseOfError()"
+        output:
+          log:
+            no_expect_ids: [956100]


### PR DESCRIPTION
## Proposed changes


<!-- Github Tip: adding the text 'Fixes #<issue>' or 'Closes #<issue>' will automatically close the mentioned issue. -->

## PR Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/CONTRIBUTING.md) doc
- [ ] I have added positive tests proving my fix/feature works as intended.
- [x] I have added negative tests that prove my fix/feature considers common cases that might end in false positives
- [ ] In case you changed a regular expression, you are not adding a ReDOS for pcre. You can check this using [regexploit](https://github.com/doyensec/regexploit)
- [ ] My test use the `comment` field to write the expected behavior
- [ ] I have added documentation for the rule or change (when appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... If there are no additional comments, you may remove this section. -->

## AI Disclosure

<!-- Required per our AI-Assisted Contribution Policy (AI-CONTRIBUTIONS.md) -->

<!-- Select exactly one by deleting the option that does not apply. -->
**AI usage for this contribution:** None

**If "Used", complete the details below:**

| Detail | Response |
|--------|----------|
| Tool(s) used | <!-- e.g., GitHub Copilot, Claude 4, ChatGPT-4o --> |
| What was AI-assisted | <!-- e.g., initial regex draft, test scaffolding, docs wording --> |
| Review performed | <!-- e.g., validated against payload corpus, ran test suite, manual review --> |

## For the reviewer

<!-- Don't remove this part. Reviewers will use it as guidance for the review process. -->

- [ ] Positive and negative tests were added
- [ ] Tests cover the intended fix/feature properly
- [ ] No usage of dangerous constructs like `ctl:requestBodyAccess=Off` were used in the rule
- [ ] In case a regular expression was changed, [there is no ReDOS](https://github.com/coreruleset/coreruleset/wiki/Testing-for-Regular-Expresion-DoS)
- [ ] Documentation is clear for the rule/change
- [ ] If a contribution shows signs of unreviewed AI generation (e.g., plausible-but-broken regex, generic boilerplate comments, hallucinated SecLang directives), reviewers should ask about AI usage regardless of what was checked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Ruby error detection for `EOFError` messages, ensuring valid error text is recognized consistently.
  - Prevented unrelated JavaScript callback text from being incorrectly flagged as a Ruby data-leakage issue.

- **Tests**
  - Added regression coverage for both valid `EOFError` messages and similar-looking non-Ruby content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->