### PR TITLE
ci: run the nginx test container with a single worker

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -30,6 +30,11 @@ x-nginx-env: &nginx-env
   ERRORLOG: "/var/log/nginx/error.log"
   LOGLEVEL: "info"
   MODSEC_AUDIT_LOG: "/var/log/nginx/modsec_audit.log"
+  # go-ftw delimits the log lines of a request with markers. Several nginx
+  # workers flush their buffers independently, so lines interleave and tests
+  # fail at random; see https://github.com/coreruleset/go-ftw/issues/473.
+  # Scoped to the test containers - the image still defaults to `auto`.
+  NGINX_WORKER_PROCESSES: "1"
   SERVERNAME: modsec3-nginx
 
 # Coraza uses its own CORAZA_-prefixed env vars instead of MODSEC_-prefixed
@@ -89,7 +94,7 @@ services:
 
   modsec3-nginx: &nginx
     container_name: modsec3-nginx
-    image: owasp/modsecurity-crs:nginx@sha256:d5075e29201de332751b1a691186944ae0af1f4d9dda37275daa342d18117902
+    image: owasp/modsecurity-crs:nginx@sha256:ccec5e3ecd1dcf6b48903268f4fe415fd17914e8bf30fc21263fd05cc7045f29
     # NOTE: The user used to run the container process is explicitly set to
     # 'root'. This fixes issues with permissions on the logging directories used
     # as bind mounts. This is done as *a convenience for running the CRS testing

--- a/tests/regression/nginx-overrides.yaml
+++ b/tests/regression/nginx-overrides.yaml
@@ -8,9 +8,9 @@ meta:
 test_overrides:
   - rule_id: 920100
     test_ids: [4]
-    reason: "Nginx returns a 400 bad request"
+    reason: "Nginx rejects the CONNECT method with a 405"
     output:
-      status: 400
+      status: 405
   - rule_id: 920100
     test_ids: [8]
     reason: |


### PR DESCRIPTION
## what

- run the nginx test container with `NGINX_WORKER_PROCESSES: "1"`
- bump the pinned `owasp/modsecurity-crs:nginx` digest to pick up that variable
- update the 920100-4 nginx override from status 400 to 405

## why

go-ftw delimits the log lines of a request with markers. several nginx workers flush their buffers independently, so lines interleave and tests fail at random — see coreruleset/go-ftw#473. this is the same fix coreruleset/modsecurity-crs-docker#463 applies from the outside with `yq`; doing it here makes that patch redundant.

the digest bump is not cosmetic. `NGINX_WORKER_PROCESSES` landed in coreruleset/modsecurity-crs-docker#456 on 2026-08-05, but the pinned digest is from 2026-04-04 and its `nginx.conf.template` hardcodes `worker_processes auto;` with no substitution — setting the variable alone would have been silently inert. the new digest templates it and still defaults to `auto`, so nothing changes for users of the image.

the newer nginx answers `CONNECT` with `405 Not Allowed` instead of `400 Bad Request`, which is what 920100-4 asserts on this platform, hence the override change. i isolated that to the image rather than the worker setting: old image + `auto` passes, new image + `auto` fails, new image + `1` fails identically before the override is updated.

verified locally:

| check | result |
|---|---|
| `docker compose config` | valid; `modsec3-nginx` and `modsec3-nginx-debug` both resolve `NGINX_WORKER_PROCESSES: "1"`, anchored `LOGLEVEL`/`SERVERNAME` still merge |
| worker count in the container | `worker_processes 1;`, exactly one worker pid under `/proc` |
| full suite on nginx | 5091/5091 pass |
| full suite on apache | 5091/5091 pass |

## refs

- coreruleset/go-ftw#473
- coreruleset/modsecurity-crs-docker#456
- coreruleset/modsecurity-crs-docker#463

## ai disclosure

- **tools used**: Claude (Opus 5)
- **assisted with**: locating the inert-variable problem, isolating the CONNECT status change, drafting the commit message and this description
- **review performed**: inspected `/etc/nginx/templates/nginx.conf.template` inside both the old and new image to confirm the old one hardcodes `worker_processes auto`; confirmed the resolved compose config for both nginx services and counted worker pids in the running container; sent a raw `CONNECT` request and read the 405 off the wire; ran the full go-ftw suite on nginx and on apache (5091 tests each, both green), and ran the old image, new image + `auto`, and new image + `1` separately to attribute the 920100-4 failure to the image rather than the worker count
