### PR TITLE
chore: drop dangling breaking-change label from release config

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -13,7 +13,6 @@ changelog:
         - release:important
     - title: Breaking Changes 🛠
       labels:
-        - breaking-change
         - release:breaking
     - title: 🆕 New features and detections 🎉
       labels:


### PR DESCRIPTION
## what

- drops `breaking-change` from the Breaking Changes category in `.github/release.yml`, leaving `release:breaking` as the only label for that section

## why

- `breaking-change` is not a label in this repository, so the entry never matched a PR and the category was effectively keyed on `release:breaking` alone
- every other category in the file is keyed on the `release:` prefix; keeping a second, unprefixed alias invites a PR carrying both labels without changing the generated notes
- `release:breaking` now has a description spelling out when it applies (removed or renumbered rule ID, removed or renamed tag, removed `crs-setup.conf.example` key, removed exported symbol or CLI flag in the tooling)

## refs

- `.github/release.yml`

## ai disclosure

- **tools used**: Claude Code (Claude Opus 5)
- **assisted with**: spotting that `.github/release.yml` referenced a label absent from the repository while auditing the release-label taxonomy; the one-line deletion; drafting this PR description
- **review performed**: confirmed via `gh label list --repo coreruleset/coreruleset` that `breaking-change` did not exist in the repository and that `release:breaking` does; confirmed no open PR or issue carried the label; checked that the remaining `release:*` labels each map to exactly one category in `release.yml`; pre-commit `yamllint` and `check yaml` hooks passed on the changed file
