### PR TITLE
feat(934200): detect Velocity and FreeMarker directive syntax

### DIFF
--- a/regex-assembly/934200.ra
+++ b/regex-assembly/934200.ra
@@ -36,3 +36,19 @@
   ##!=>
   [^%]*?%>
 ##!<
+
+##! Velocity directives: #set($c=$x.class.forName(...)), #foreach($i in [$x.exec(...)])
+##! A `$` reference is required after the opening parenthesis so that ordinary
+##! text and C preprocessor lines such as `#if(defined(X))` do not match.
+##!> assemble
+  #\w+\s*\(\s*\$[^)]*?
+  ##!=>
+  {{exec-indicators}}
+##!<
+
+##! FreeMarker directives: <#assign ex=("..."+"...")?new()>, <@ex("id")>
+##!> assemble
+  <[#@]\w+[^>]*?
+  ##!=>
+  {{exec-indicators}}
+##!<

--- a/regex-assembly/934200.ra
+++ b/regex-assembly/934200.ra
@@ -44,6 +44,8 @@
   #\w+\s*\(\s*\$[^)]*?
   ##!=>
   {{exec-indicators}}
+  ##!=>
+  [^)]*?\)
 ##!<
 
 ##! FreeMarker directives: <#assign ex=("..."+"...")?new()>, <@ex("id")>
@@ -51,4 +53,6 @@
   <[#@]\w+[^>]*?
   ##!=>
   {{exec-indicators}}
+  ##!=>
+  [^>]*?>
 ##!<

--- a/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
+++ b/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
@@ -284,7 +284,7 @@ SecRule REQUEST_FILENAME|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|X
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 934200
 #
-SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/*|XML://@* "@rx \{\{[^\}]*?(?:[\(\*]|__)[^\}]*?\}\}|#(?:\{[^\}]*?(?:[\(\*]|__)[^\}]*?\}|[0-9A-Z_a-z]+[\s\x0b]*\([\s\x0b]*\$[^\)]*?(?:[\(\*]|__))|<(?:%=?[\s\x0b]*[^%]*?(?:[\(\*]|__)[^%]*?%>|[#@][0-9A-Z_a-z]+[^>]*?(?:[\(\*]|__))" \
+SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/*|XML://@* "@rx \{\{[^\}]*?(?:[\(\*]|__)[^\}]*?\}\}|#(?:\{[^\}]*?(?:[\(\*]|__)[^\}]*?\}|[0-9A-Z_a-z]+[\s\x0b]*\([\s\x0b]*\$[^\)]*?(?:[\(\*]|__)[^\)]*?\))|<(?:%=?[\s\x0b]*[^%]*?(?:[\(\*]|__)[^%]*?%|[#@][0-9A-Z_a-z]+[^>]*?(?:[\(\*]|__)[^>]*?)>" \
     "id:934200,\
     phase:2,\
     block,\

--- a/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
+++ b/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
@@ -284,7 +284,7 @@ SecRule REQUEST_FILENAME|REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|X
 # (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
 #   crs-toolchain regex update 934200
 #
-SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/*|XML://@* "@rx (?:\{\{[^\}]*?(?:[\(\*]|__)[^\}]*?\}|#\{[^\}]*?(?:[\(\*]|__)[^\}]*?)\}|<%=?[\s\x0b]*[^%]*?(?:[\(\*]|__)[^%]*?%>" \
+SecRule REQUEST_COOKIES|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/*|XML://@* "@rx \{\{[^\}]*?(?:[\(\*]|__)[^\}]*?\}\}|#(?:\{[^\}]*?(?:[\(\*]|__)[^\}]*?\}|[0-9A-Z_a-z]+[\s\x0b]*\([\s\x0b]*\$[^\)]*?(?:[\(\*]|__))|<(?:%=?[\s\x0b]*[^%]*?(?:[\(\*]|__)[^%]*?%>|[#@][0-9A-Z_a-z]+[^>]*?(?:[\(\*]|__))" \
     "id:934200,\
     phase:2,\
     block,\

--- a/tests/regression/tests/REQUEST-934-APPLICATION-ATTACK-GENERIC/934200.yaml
+++ b/tests/regression/tests/REQUEST-934-APPLICATION-ATTACK-GENERIC/934200.yaml
@@ -166,3 +166,164 @@ tests:
         output:
           log:
             expect_ids: [934200]
+
+  - test_id: 11
+    desc: "Velocity SSTI - #set directive with reflective call"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/get?x=%23set%28%24x%3D%27%27%29%23set%28%24c%3D%24x.class.forName%28%27java.lang.Runt%27%2B%27ime%27%29%29%23set%28%24z%3D%24c.getMethod%28%27ex%27%2B%27ec%27%29%29"
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [934200]
+  - test_id: 12
+    desc: "Velocity SSTI - #foreach directive with method call"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/get?x=%23foreach%28%24i%20in%20%5B%24m.invoke%28%24r%2C%27id%27%29%5D%29%23end"
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [934200]
+  - test_id: 13
+    desc: "Velocity SSTI - #if directive with method call"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/get?x=%23if%28%24m.invoke%28%24r%2C%27id%27%29%29%23end"
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [934200]
+  - test_id: 14
+    desc: "FreeMarker SSTI - <#assign> instantiating a class"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/get?x=%3C%23assign%20ex%3D%28%22freemarker.temp%22%2B%22late.utility.Execute%22%29%3Fnew%28%29%3E"
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [934200]
+  - test_id: 15
+    desc: "FreeMarker SSTI - <#list> directive with method call"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/get?x=%3C%23list%20%5Bex%28%22id%22%29%5D%20as%20i%3E%3C%2F%23list%3E"
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [934200]
+  - test_id: 16
+    desc: "FreeMarker SSTI - <@macro> call"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/get?x=%3C%40ex%28%22id%22%29%3E"
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [934200]
+  - test_id: 17
+    desc: "C preprocessor directive must not match (no $ reference)"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/get?x=%23if%28defined%28FOO%29%29"
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids: [934200]
+  - test_id: 18
+    desc: "Markdown heading with parentheses must not match"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/get?x=%23%20Title%20%28version%202%29"
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids: [934200]
+  - test_id: 19
+    desc: "HTML markup must not match"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/get?x=%3Ca%20href%3D%22%2Fx%3Fy%3D1%2A2%22%3Elink%3C%2Fa%3E"
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids: [934200]
+  - test_id: 20
+    desc: "Chat-style mention must not match"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/get?x=%3C%40U012345%3E%20please%20take%20a%20look"
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids: [934200]

--- a/tests/regression/tests/REQUEST-934-APPLICATION-ATTACK-GENERIC/934200.yaml
+++ b/tests/regression/tests/REQUEST-934-APPLICATION-ATTACK-GENERIC/934200.yaml
@@ -248,7 +248,7 @@ tests:
           log:
             expect_ids: [934200]
   - test_id: 16
-    desc: "FreeMarker SSTI - <@macro> call"
+    desc: "FreeMarker SSTI - <@...> user-directive call invoking a method"
     stages:
       - input:
           dest_addr: 127.0.0.1
@@ -327,3 +327,19 @@ tests:
         output:
           log:
             no_expect_ids: [934200]
+  - test_id: 21
+    desc: "Velocity SSTI - arithmetic execution indicator in a #set directive"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+          method: GET
+          port: 80
+          uri: "/get?x=%23set%28%24x%3D7%2A7%29"
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [934200]


### PR DESCRIPTION
Addresses the gap reported in #4773.

934200 matches `{{...}}`, `#{...}` and `<%...%>`, but has no alternative for the directive syntax used by Apache Velocity (`#set`, `#foreach`, `#if`) or FreeMarker (`<#assign>`, `<#list>`, `<@macro>`). Payloads in either engine reach PL1 undetected unless they happen to spell a class name listed in `java-classes.data` — and since `@pmFromFile` matches literals, splitting the literal defeats it.

In #4773 I posted working RCE chains for both engines that are `http=200` with no rule matched at PL1, verified as executing under Velocity 2.3 and FreeMarker 2.3.32.

### What this changes

Two assembly blocks added to `regex-assembly/934200.ra`, reusing the existing `exec-indicators` define, so a directive only matches when it contains a call, arithmetic, or dunder access — the same design the file already uses for the other three syntaxes.

The Velocity alternative additionally requires a `$` reference after the opening parenthesis. That is what keeps C preprocessor lines such as `#if(defined(FOO))` out, which I think is the main false-positive risk at PL1 for a `#directive(` pattern.

### Tests

Ten tests added to `934200.yaml` — six positive covering all three directive forms in each engine, four negative:

- `#if(defined(FOO))` — C preprocessor
- `# Title (version 2)` — Markdown heading
- `<a href="/x?y=1*2">link</a>` — HTML
- `<@U012345> please take a look` — chat-style mention

The four pre-existing positive cases still match, so the other three syntaxes are unaffected.

### Checks run locally

- `crs-toolchain regex format -aco github` — clean
- `crs-toolchain regex compare -ao github` — `Regex of 934200 has not changed`
- `crs-toolchain util renumber-tests -cao github` — clean
- crs-toolchain 2.6.0, matching `CRS_TOOLCHAIN_VERSION` in `lint.yaml`. Before making any change I regenerated 934200 from the unmodified `.ra` and confirmed it reproduced the committed regex byte-for-byte, so the diff here is only my addition.

### On placement

I put this in 934200 because it is already the PL1 SSTI rule and the design fits, but the paranoia level is your call rather than mine. If `#\w+\s*\(\s*\$` is more false-positive risk than you want at PL1, I am happy to move the Velocity alternative to a stricter sibling at PL2 and leave only the FreeMarker one at PL1 — `<#` is considerably more distinctive. Say which you prefer and I will rework it.
