### PR TITLE
feat(913100): block user-agent header containing a literal `useragent` value

### DIFF
--- a/rules/scanners-user-agents.data
+++ b/rules/scanners-user-agents.data
@@ -6,6 +6,11 @@
 # cases where certain scanners / bots are welcome in certain
 # situations. We consider this a baseline of unwanted scanners.
 
+# User-agent header containing an literal `user-agent`.
+# This behavior was observed in Subgraph's Vega scanner, but
+# it's possible this occurs in other security scanners.
+useragent
+user-agent
 
 # http://www.arachni-scanner.com/
 arachni

--- a/tests/regression/tests/REQUEST-913-SCANNER-DETECTION/913100.yaml
+++ b/tests/regression/tests/REQUEST-913-SCANNER-DETECTION/913100.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  author: "csanders-git, azurit"
+  author: "csanders-git, azurit, Esad Cetiner"
 rule_id: 913100
 tests:
   - test_id: 1
@@ -127,3 +127,35 @@ tests:
         output:
           log:
             no_expect_ids: [913100]
+  - test_id: 8
+    desc: "Block User-Agent header containing literal `UserAgent`"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          method: "GET"
+          port: 80
+          headers:
+            User-Agent: "UserAgent"
+            Host: "localhost"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          uri: "/get"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [913100]
+  - test_id: 9
+    desc: "Block User-Agent header containing literal `User-Agent`"
+    stages:
+      - input:
+          dest_addr: "127.0.0.1"
+          method: "GET"
+          port: 80
+          headers:
+            User-Agent: "User-Agent"
+            Host: "localhost"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          uri: "/get"
+          version: "HTTP/1.1"
+        output:
+          log:
+            expect_ids: [913100]


### PR DESCRIPTION
## Proposed changes

I noticed while working on issue https://github.com/coreruleset/coreruleset/issues/4776 that the vega security scanner doesn't set it's user-agent properly and sets the user-agent header to literally `UserAgent`. The version I installed is probably bugged, but something similar may also happen with other security scanners, so I think it's worth blocking.

## PR Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/CONTRIBUTING.md) doc
- [x] I have added positive tests proving my fix/feature works as intended.
- [ ] I have added negative tests that prove my fix/feature considers common cases that might end in false positives
- [ ] In case you changed a regular expression, you are not adding a ReDOS for pcre. You can check this using [regexploit](https://github.com/doyensec/regexploit)
- [x] My test use the `comment` field to write the expected behavior
- [ ] I have added documentation for the rule or change (when appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... If there are no additional comments, you may remove this section. -->

## AI Disclosure

Not Used

## For the reviewer

<!-- Don't remove this part. Reviewers will use it as guidance for the review process. -->

- [ ] Positive and negative tests were added
- [ ] Tests cover the intended fix/feature properly
- [ ] No usage of dangerous constructs like `ctl:requestBodyAccess=Off` were used in the rule
- [ ] In case a regular expression was changed, [there is no ReDOS](https://github.com/coreruleset/coreruleset/wiki/Testing-for-Regular-Expresion-DoS)
- [ ] Documentation is clear for the rule/change
- [ ] If a contribution shows signs of unreviewed AI generation (e.g., plausible-but-broken regex, generic boilerplate comments, hallucinated SecLang directives), reviewers should ask about AI usage regardless of what was checked.
