### PR TITLE
feat: Add Mozilla/6.0 used by scanner tools

### DIFF
--- a/rules/scanners-user-agents.data
+++ b/rules/scanners-user-agents.data
@@ -11,7 +11,7 @@
 arachni
 
 # Mozilla/6.0 used by Cobaltstrike GraphStrike server
-# Not legitimate, the legitimate variant is Mozilla/5.0
+# Technically valid user-agent, but only Mozilla/5.0 is used in practice.
 Mozilla/6.0
 
 betabot

--- a/rules/scanners-user-agents.data
+++ b/rules/scanners-user-agents.data
@@ -10,6 +10,10 @@
 # http://www.arachni-scanner.com/
 arachni
 
+# Mozilla/6.0 used by Cobaltstrike GraphStrike server
+# Not legitimate, the legitimate variant is Mozilla/5.0
+Mozilla/6.0
+
 betabot
 
 bewica-security-scan


### PR DESCRIPTION
# What?
Add the Mozilla/6.0 user agent to the scanner list

# Why?
It just used by scanner tools, it have no legitimate use at all, the legitimate one is `Mozilla/5.0`, that presence of a user agent meaning just associated with scanners

# Refs
- https://github.com/mthcht/awesome-lists/blob/main/Lists/suspicious_http_user_agents_list.csv#L1493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Updates**
  * Added `Mozilla/6.0` to the list of recognized security scanner user agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->