### PR TITLE
feat(933100): add a regression test

### DIFF
--- a/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933100.yaml
+++ b/tests/regression/tests/REQUEST-933-APPLICATION-ATTACK-PHP/933100.yaml
@@ -1688,3 +1688,21 @@ tests:
         output:
           log:
             expect_ids: [933100]
+  - test_id: 93
+    desc: |
+      PHP injection in HTTP header - CVE-2026-75650
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: "*/*"
+            Host: "localhost"
+            User-Agent: "OWASP CRS test agent"
+            Store: "<?php phpinfo(); ?>"
+          method: GET
+          port: 80
+          uri: "/graphql"
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [933100]


### PR DESCRIPTION
## Proposed changes

Hi,

This PR adds a unit test for OWASP CRS rule 933100 to verify the detection of PHP code embedded in an HTTP request header value (https://sansec.io/research/stylesmuggler-0day - https://helpx.adobe.com/security/products/magento/apsb26-146.html)

The following payload was tested against the CRS sandbox at Paranoia Level 4:

Store: ss6_457cfa2fb7_<?php echo 1;?>

Using:

curl -H "x-format-output: txt-matched-rules" \
     -H "x-crs-paranoia-level:4" \
     "http://sandbox.coreruleset.org/" \
     -H 'Store: ss6_457cfa2fb7_<?php echo 1;?>'

The sandbox currently reports:

```
920274 PL4 Invalid character in request headers (outside of very strict set)
949110 PL? Inbound Anomaly Score Exceeded (Total Score: 5)
980170 PL? Anomaly Scores: (Inbound Scores: blocking=5, detection=5, per_pl=0-0-0-5, threshold=5) - (Outbound Scores: blocking=0, detection=0, per_pl=0-0-0-0, threshold=4) - (SQLI=0, XSS=0, RFI=0, LFI=0, RCE=0, PHPI=0, HTTP=0, SESS=0, COMBINED_SCORE=5)
```

Rule 933100 is not triggered, despite the PHP opening tag being present in the header value.

This PR adds a dedicated regression/unit test for this case in order to determine whether this represents an actual coverage gap in rule 933100 or simply an anomaly/limitation of the public CRS sandbox environment.

The expected behavior is that rule 933100 detects the PHP injection pattern independently of rule 920274.

<!-- Github Tip: adding the text 'Fixes #<issue>' or 'Closes #<issue>' will automatically close the mentioned issue. -->

## PR Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/coreruleset/coreruleset/blob/v4.0/dev/CONTRIBUTING.md) doc
- [x] I have added positive tests proving my fix/feature works as intended.
- [ ] I have added negative tests that prove my fix/feature considers common cases that might end in false positives
- [ ] In case you changed a regular expression, you are not adding a ReDOS for pcre. You can check this using [regexploit](https://github.com/doyensec/regexploit)
- [ ] My test use the `comment` field to write the expected behavior
- [ ] I have added documentation for the rule or change (when appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... If there are no additional comments, you may remove this section. -->

## AI Disclosure

<!-- Required per our AI-Assisted Contribution Policy (AI-CONTRIBUTIONS.md) -->

<!-- Select exactly one by deleting the option that does not apply. -->
**AI usage for this contribution:** None / Used

**If "Used", complete the details below:**

| Detail | Response |
|--------|----------|
| Tool(s) used | <!-- e.g., GitHub Copilot, Claude 4, ChatGPT-4o --> |
| What was AI-assisted | <!-- e.g., initial regex draft, test scaffolding, docs wording --> |
| Review performed | <!-- e.g., validated against payload corpus, ran test suite, manual review --> |

## For the reviewer

<!-- Don't remove this part. Reviewers will use it as guidance for the review process. -->

- [ ] Positive and negative tests were added
- [ ] Tests cover the intended fix/feature properly
- [ ] No usage of dangerous constructs like `ctl:requestBodyAccess=Off` were used in the rule
- [ ] In case a regular expression was changed, [there is no ReDOS](https://github.com/coreruleset/coreruleset/wiki/Testing-for-Regular-Expresion-DoS)
- [ ] Documentation is clear for the rule/change
- [ ] If a contribution shows signs of unreviewed AI generation (e.g., plausible-but-broken regex, generic boilerplate comments, hallucinated SecLang directives), reviewers should ask about AI usage regardless of what was checked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for detecting PHP injection attempts in the `Store` HTTP header.
  * Verified that the `/graphql` request triggers the expected security rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->