### PR TITLE
docs: fix rule-range support claims in exclusion examples

### DIFF
--- a/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example
+++ b/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example
@@ -73,20 +73,21 @@
 # SecRuleUpdateTargetByTag  -> place in RESPONSE-999-EXCLUSION-RULES-AFTER-CRS
 #
 # Rule ID ranges (e.g. 942100-942999) are only expanded by directives/actions
-# that remove a whole rule; they are NOT expanded by directives/actions that
-# modify or remove a rule's target:
+# that remove a whole rule on ModSecurity v2 and v3; they are NOT expanded by
+# directives/actions that modify or remove a rule's target on those engines.
+# Coraza is the exception: it expands ranges correctly everywhere.
 #
-#                            | v2 + Apache | v3 + libModSecurity
-# SecRuleRemoveById          | range OK    | range OK
-# ctl:ruleRemoveById         | range OK    | range OK
-# SecRuleUpdateTargetById    | range OK    | single ID only
-# ctl:ruleRemoveTargetById   | range OK    | single ID only
+#                            | v2 + Apache | v3 + libModSecurity | Coraza
+# SecRuleRemoveById          | range OK    | range OK            | range OK
+# ctl:ruleRemoveById         | range OK    | range OK            | range OK
+# SecRuleUpdateTargetById    | range OK    | single ID only      | range OK
+# ctl:ruleRemoveTargetById   | range OK    | single ID only      | range OK
 #
-# On v3, giving SecRuleUpdateTargetById or ctl:ruleRemoveTargetById a range
-# silently affects only the first rule ID in the range; the rest of the
+# On v2 and v3, giving SecRuleUpdateTargetById or ctl:ruleRemoveTargetById a
+# range silently affects only the first rule ID in the range; the rest of the
 # range's rules are still fully inspected. Use ruleRemoveTargetByTag/ByMsg or
 # SecRuleUpdateTargetByTag/ByMsg instead if you need to affect several rules
-# at once on v3.
+# at once on those engines.
 #
 #
 # What follows are a group of examples that show you how to perform rule

--- a/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example
+++ b/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example
@@ -72,6 +72,22 @@
 # SecRuleUpdateTargetByMsg  -> place in RESPONSE-999-EXCLUSION-RULES-AFTER-CRS
 # SecRuleUpdateTargetByTag  -> place in RESPONSE-999-EXCLUSION-RULES-AFTER-CRS
 #
+# Rule ID ranges (e.g. 942100-942999) are only expanded by directives/actions
+# that remove a whole rule; they are NOT expanded by directives/actions that
+# modify or remove a rule's target:
+#
+#                            | v2 + Apache | v3 + libModSecurity
+# SecRuleRemoveById          | range OK    | range OK
+# ctl:ruleRemoveById         | range OK    | range OK
+# SecRuleUpdateTargetById    | range OK    | single ID only
+# ctl:ruleRemoveTargetById   | range OK    | single ID only
+#
+# On v3, giving SecRuleUpdateTargetById or ctl:ruleRemoveTargetById a range
+# silently affects only the first rule ID in the range; the rest of the
+# range's rules are still fully inspected. Use ruleRemoveTargetByTag/ByMsg or
+# SecRuleUpdateTargetByTag/ByMsg instead if you need to affect several rules
+# at once on v3.
+#
 #
 # What follows are a group of examples that show you how to perform rule
 # exclusions.
@@ -102,6 +118,9 @@
 # This rule shows how to conditionally exclude the "password"
 # parameter for rule 942100 when the REQUEST_URI is /index.php
 # ModSecurity Rule Exclusion: 942100 SQL Injection Detected via libinjection
+#
+# NOTE: ctl:ruleRemoveTargetById does not support rule ranges on ModSecurity
+# v3 (see rule-range support matrix above).
 #
 # SecRule REQUEST_URI "@beginsWith /index.php" \
 #     "id:1001,\
@@ -149,11 +168,9 @@
 #
 # This rule illustrates that we can remove a rule range via a ctl action.
 # This uses the fact, that rules are grouped by topic in rule files covering
-# a certain id range.
-# IMPORTANT: ModSecurity v3, aka libModSecurity, does not currently support the
-# use of rule ranges in a ruleRemoveById ctl action (this feature has been
-# planned for v3.1). Consider using ruleRemoveByTag as a workaround, if
-# appropriate.
+# a certain id range. Unlike ctl:ruleRemoveTargetById, ctl:ruleRemoveById
+# supports rule ranges on both ModSecurity v2 and v3 (see rule-range support
+# matrix above).
 #
 # ModSecurity Rule Exclusion: Disable all SQLi and XSS rules
 # SecRule REQUEST_FILENAME "@beginsWith /admin" \

--- a/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf.example
+++ b/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf.example
@@ -36,6 +36,13 @@
 # ModSecurity Rule Exclusion: disable sqli rules for parameter foo.
 # SecRuleUpdateTargetByTag "attack-sqli" "!ARGS:foo"
 
+# NOTE: on ModSecurity v3 (libModSecurity), SecRuleUpdateTargetById does not
+# support rule ranges (e.g. 942100-942999) -- only a single rule ID is
+# honored, the rest of the range stays fully inspected. Use
+# SecRuleUpdateTargetByTag/ByMsg (as above) instead if you need to affect
+# several rules at once on v3. See the rule-range support matrix in
+# REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example.
+
 
 # -- [[ Changing the Disruptive Action for Anomaly Mode ]] --
 #


### PR DESCRIPTION
## what

corrects the rule-range support claims in the two exclusion example files (`REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf.example`, `RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf.example`):

- removes the note from #3303 claiming `ctl:ruleRemoveById` lacks rule-range support on ModSecurity v3 -- it works fine.
- adds a compact support matrix (v2, v3, Coraza) for the four range-relevant directives/actions right after the directive-placement table.
- adds notes at the actual gap: on v2 and v3, `ctl:ruleRemoveTargetById` and `SecRuleUpdateTargetById` silently only honor the first rule ID in a range, leaving the rest of the range fully inspected. Coraza does not share this gap -- it expands ranges correctly for all four.

## why

issue #3324 reports the exclusion examples are "incorrect in a couple of places". the note added by #3303 (Sept 2023) was wrong: `ctl:ruleRemoveById` supports ranges on v3; the real gap is with the target-modifying actions (`ctl:ruleRemoveTargetById`, `SecRuleUpdateTargetById`), which silently honor only the first ID in a range. Coraza does not share this gap: it expands ranges correctly for all four directives (`SecRuleRemoveById`, `ctl:ruleRemoveById`, `ctl:ruleRemoveTargetById`, `SecRuleUpdateTargetById`) -- range support for `ctl:ruleRemoveTargetById` is tracked upstream as corazawaf/coraza#119, and for `SecRuleUpdateTargetById` as corazawaf/coraza#1020.

the `coraza-crs:caddy-alpine` image pinned in this repo's `tests/docker-compose.yml` predates corazawaf/coraza#1020 and does not reflect this behavior; verification used a current pull of that image instead. the pinned digest should be bumped separately from this PR.

## refs

- refs #3324 (leaves this open -- the issue's second TODO, updating the HTML documentation, lives in a different repo and isn't addressed by this PR)
- corazawaf/coraza#119 (Coraza's range support for `ctl:ruleRemoveTargetById`)
- corazawaf/coraza#1020 (Coraza's range support for `SecRuleUpdateTargetById`, plus `SecRuleUpdateTargetByTag`)
- owasp-modsecurity/ModSecurity#2110, owasp-modsecurity/ModSecurity#2355 (the still-open v2/v3 range gap for target-modifying actions)

## ai disclosure

- **tools used**: Claude (Sonnet 5)
- **assisted with**: drafting the corrected wording and the v2/v3/Coraza support matrix in both example files, designing and running the empirical verification requests, reading the Coraza source
- **review performed**: ran `SecRuleRemoveById`, `ctl:ruleRemoveById`, `ctl:ruleRemoveTargetById`, and `SecRuleUpdateTargetById` over the range `942100-942999` (and each as a single ID, for comparison) against `modsec3-nginx` and a current `coraza-crs:caddy-alpine` pull, confirming via each engine's log which rule IDs in the range stayed inspected vs. excluded; read Coraza's range-handling source (`internal/seclang/directives.go`); ran `crs-linter` (pinned CI version) against the full rule set, zero new errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified rule-range support across ModSecurity v2, ModSecurity v3, and Coraza for exclusion directives and whole-rule removal.
  * Documented that ModSecurity v3 target-modifying directives support only single rule IDs, with ranges not fully applied.
  * Recommended tag- or message-based alternatives for affecting multiple rules on ModSecurity v3.
  * Updated example comments and references to help configure exclusions consistently across supported engines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

