### PR TITLE
chore: bump pinned coraza-crs caddy-alpine image digest

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -124,7 +124,7 @@ services:
 
   coraza-caddy: &coraza
     container_name: coraza-caddy
-    image: ghcr.io/coreruleset/coraza-crs:caddy-alpine@sha256:d607eb5ebe110dceb88367ab4d0366536ba84b881d26d6772005ba3db1cbe163
+    image: ghcr.io/coreruleset/coraza-crs:caddy-alpine@sha256:0793c03366a1b5e71b3b160abaf5e85712a866859657c1aa4ea128b0488f36e0
     environment:
       <<: *coraza-env
       CORAZA_AUDIT_LOG: "/var/log/coraza/audit.log"


### PR DESCRIPTION
## what

bumps the pinned `ghcr.io/coreruleset/coraza-crs:caddy-alpine` digest in `tests/docker-compose.yml` from `sha256:d607eb5e...` (built 2026-07-18) to `sha256:0793c033...` (built 2026-09-02).

## why

the currently pinned digest predates `coreruleset/coraza-crs-docker#b958375` ("build against coraza-caddy v2, the pinned version is ignored"), merged 2026-08-18. before that fix, the image build silently resolved `coraza-caddy v1.2.2` (Jan 2023) regardless of the intended version, so the pinned digest has been running a years-old Coraza build rather than a current one. this surfaced during PR #4796: `SecRuleUpdateTargetById` with a rule-id range crashes the container outright on the pinned digest (`strconv.Atoi: parsing "942100-942999": invalid syntax`, matching pre-`corazawaf/coraza#1020` behavior), and `SecRuleRemoveById`/`ctl:ruleRemoveById` ranges silently no-op instead of removing rules.

full `go-ftw` regression run against the new digest (`tests/regression/tests`, `coraza-overrides.yaml`) shows the same failures as against the current pinned digest, with one addition: `980170-1`/`980170-2` (`RESPONSE-980-CORRELATION`, phase-5 anomaly-score reporting) pass on the old, accidentally-ancient digest but fail on any digest built after the b958375 fix -- tested directly against the first post-fix build (`4-caddy-alpine-202608260408`, 2026-08-26) and the new pinned digest; both fail identically. so this isn't a regression from picking this specific digest, it's the v1.2.2-era Coraza masking a gap that any current Coraza build has. traced as far as: rule 980099 (phase 5, unconditional, sets `tx.detection_anomaly_score` from the inbound/outbound components) appears not to produce the expected downstream effect, since `949110` (anomaly score exceeded) fires normally but `980170` never does; did not go further into Coraza's phase-5/`SecMarker` internals, since Coraza is not part of this repo's CI regression gate (`.github/workflows/test.yml` only runs `modsec2-apache`/`modsec3-nginx`).

everything else observed against the new digest matches the pre-existing (pinned-digest) failure list -- no other new failures.

## refs

- coreruleset/coraza-crs-docker@b958375
- corazawaf/coraza#1020
- refs #4796

## ai disclosure

- **tools used**: Claude (Sonnet 5)
- **assisted with**: identifying the stale digest during PR #4796's verification, drafting this bump and its PR description
- **review performed**: ran the full `go-ftw` regression suite (`tests/regression/tests`, `coraza-overrides.yaml`) against both the old and new pinned digests and diffed the failure lists; reproduced the `980170` gap against the new digest, the first post-b958375-fix build, and confirmed its absence against the old (pre-fix) digest; traced `coreruleset/coraza-crs-docker` commit history to identify b958375 as the boundary; smoke-tested the new digest via `docker compose` (container starts, CRS rules load, SQLi detection fires as expected)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the test environment’s container image to a newer verified build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->